### PR TITLE
Merge fix/chef-provisioning into the develop branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ protected/runtime/*
 protected/data/*.db
 themes/classic/views/
 
+# Vagrant
+*.vagrant
+
 # PhpStorm
 *.iml
 *.iws


### PR DESCRIPTION
The badly broken Vagrant and Chef-Solo build has now been fixed and can be merged back to the develop branch.