### PR TITLE
Fixes for running GitLab CI/CD pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -241,7 +241,7 @@ with_new_cert_deploy:
     # Run database migrations if any
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.staging.yml run --rm  application ./protected/yiic migrate --interactive=0
     # Generate the web certificate for TLS termination on web container.
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.staging.yml run --rm certbot certonly -d gigadb-staging.pommetab.com
+    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.staging.yml run --rm certbot certonly -d $STAGING_HOME_URL
     # symlink the https configuration for web container and reload nginx (cannot be done earlier as nginx will crash if it cannot see valid web certificates)
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.staging.yml exec -T web ln -s /etc/nginx/sites-available/gigadb.staging.https.conf /etc/nginx/sites-enabled/https.server.conf
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.staging.yml kill -s HUP web

--- a/docs/SETUP_CI_CD_PIPELINE.md
+++ b/docs/SETUP_CI_CD_PIPELINE.md
@@ -1,30 +1,38 @@
 # How to set up CI/CD pipelines on gitlab.com
 
-Modern software application development may involve implementing small code 
-changes which are frequently checked into version control. Continuous 
-Integration (CI) provides a consistent and automated way to build, package and 
-test the application under development. Furthermore, Continuous Delivery (CD) 
-automates the deployment of applications to specific infrastructure environments 
-such as staging and production servers.
+Application development may involve implementing small code changes which are 
+frequently checked into version control. Continuous Integration (CI) provides a 
+consistent and automated way to build, package and test the application under 
+development. Furthermore, Continuous Delivery (CD) automates the deployment of 
+applications to specific infrastructure environments such as staging and 
+production servers.
 
 ## Use of GitLab for Continuous Integration
 
-GitLab provides a CI service used by GigaDB based on the 
-[`.gitlab-ci.yml`](https://github.com/gigascience/gigadb-website/blob/develop/.gitlab-ci.yml)
-file located at the root of the repository. A Runner in GitLab is configured to 
-trigger the CI pipeline every time there is a code commit or push. GitLab.com
-allows you to use Shared Runners provided by GitLab Inc which are virtual 
-machines running on GitLab's infrastructure to build any project.
+GitLab provides a CI service used by GigaDB. The CI/CD pipeline is described in 
+the [`.gitlab-ci.yml`](https://github.com/gigascience/gigadb-website/blob/develop/.gitlab-ci.yml)
+file located at the root of the repository. A Runner in GitLab triggers the CI 
+pipeline every time there is a code commit or push. GitLab.com allows you to use 
+Shared Runners provided by GitLab Inc which are virtual machines running on 
+GitLab's infrastructure to build any project.
 
-The GigaDB `.gitlab-ci.yml` file tells the GitLab Runner to run a pipeline job 
-with these stages: build, test, security, conformance, staging and live. The 
-status of every pipeline is displayed in the Pipelines page.
+The GigaDB `gitlab-ci.yml` file tells the GitLab Runner to run a pipeline job 
+with these stages:
+* build
+* test
+* security
+* conformance
+* staging
+* live
+
+The above steps support testing and deployment of GigaDB, but assumes that the 
+set up of the Docker server is already done separately.
 
 ### Mirroring your forked gigadb-website repository from GitHub
 
-To begin, we need to mirror your forked GitHub gigadb-website repository in a 
-GitLab project. This is done by adding your GitHub gigadb-website repository to 
-the GitLab Gigascience Forks organisation. To do this:
+To begin, mirror your forked GitHub gigadb-website repository as a GitLab 
+project. This is done by adding your GitHub gigadb-website repository to the 
+GitLab Gigascience Forks organisation. To do this:
 
 * Log into GitLab and go to the 
 [gigascience/Forks page](https://gitlab.com/gigascience/forks).
@@ -38,8 +46,8 @@ the GitLab Gigascience Forks organisation. To do this:
 
 * Under the *To GitLab* column, select *gigascience/forks* to connect your repo 
 to this GitLab group. Also, provide a name for the repo, *e.g.* 
-pli888-gigadb-website so that you can differentiate this repository from others 
-in the Forks group.
+`pli888-gigadb-website` so that you can differentiate your repository from 
+others in the Forks group.
 
 * Click the *Connect* button to create the mirror of the GitHub repository on
 GitLab.
@@ -109,6 +117,10 @@ staging_tlsauth_ca | 0
 staging_tlsauth_cert | 0
 staging_tlsauth_key | 0
 
+> The value of the `STAGING_HOME_URL` variable is the domain name you will use for
+the server on which you will deploy a staging or production GigaDB application.
+The domain name can be created using your domain registration service.
+
 ### Executing a Continuous Integration run
  
 Your CI/CD pipeline can now be executed:
@@ -121,74 +133,65 @@ Then click on the *Create pipeline* button.
 
 * Refresh the pipelines page, you should see the CI/CD pipeline running. If the 
 set up of your pipeline is successful, you will see it run the build, test, 
-security and conformance stages.
-
-### Triggering CI runs with new code commits
-
-Since our repository includes a .gitlab-ci.yml file, any new commits will 
-trigger a new CI run. To see an example of this happening, edit the 
-`~/.gitlab-ci.yml` file by changing two variables. Firstly, change 
-`GITLAB_UPSTREAM_PROJECT_ID` is updated to its correct value which you can find 
-in the `General project` section in Settings page for your GitLab project. 
-Secondly, edit `MAIN_BRANCH` so that its value is set to the repository branch
-under CI/CD pipeline processing.
-```
-MAIN_BRANCH: "remove-chef-vagrant"
-GITLAB_UPSTREAM_PROJECT_ID: "10678502"
-```  
- 
-Commit and push these changes to your GitHub repository. If you now go to the 
-CI/CD > Pipelines page, you should see a new pipeline with a `running` status 
-which was triggered by the above code commit which is mirrored in the GitLab
-project repository.
+security and conformance stages defined in the `gitlab-ci.yml` file.
  
 ## Continuous Deployment in the CI/CD pipeline
 
-The deployment of gigadb-website code onto a staging or production server to 
+The deployment of `gigadb-website` code onto a staging or production server to 
 provide a running GigaDB application is not automatically performed by the 
-CI/CD pipeline since it is set to run manually in the `.gitlab-ci.yml` file. 
-Therefore, this part of the CI/CD process has to be explicitly executed from the 
-[GitLab pipelines](https://gitlab.com/gigascience/forks/pli888-gigadb-website/pipelines)
-page. Prior to this, a server has to be instantiated with an installation of the
-Docker daemon to manage containers and images, and this can be done using 
-Terraform and Ansible to create a Docker server on AWS.
+CI/CD pipeline since it is set to run manually in the `gitlab-ci.yml` file. 
+This part of the CI/CD process has to be explicitly executed from the GitLab 
+pipelines page.
+
+Prior to this, a host machine has to be instantiated with a 
+secure Docker daemon on which the GigaDB application will be deployed. This 
+machine can be used for a specific environment, most likely staging or 
+production. Two tools are used to set a Docker server on the AWS cloud: 
+Terraform and Ansible.
 
 ### Terraform
 
 [Terraform](https://www.terraform.io) is a tool which allows you to describe and
-instantiate infrastructure as code. Terraform can be installed by downloading
-the installer from the [Terraform](https://www.terraform.io) web site or it can 
-be installed using a package manager for your operating system. For example, 
-MacOSX users can use [Macports](https://www.macports.org).
+instantiate infrastructure as code.
 
-The following environment variables with the required values need to be created 
-which Terraform will use to access AWS:
+Install Terraform by downloading the installer from the 
+[Terraform](https://www.terraform.io) web site or it can be installed using a 
+package manager for your operating system. For example, MacOSX users can use 
+[Macports](https://www.macports.org).
+
+Create the following environment variables with the required values which 
+Terraform will use to access AWS:
 ```
-$ cd ops/infrastructure
 $ export TF_VAR_deployment_target=staging
 $ export TF_VAR_aws_vpc_id=<AWS VPC id>
 $ export TF_VAR_aws_access_key=<AWS Access key>
 $ export TF_VAR_aws_secret_key=<AWS Secret key>
 ```
 
-You could also persist the above variables in your `~/.bash_profile` file.
+>You could also add the above lines into your `~/.bash_profile` file to save 
+having to repeatedly execute the `export` commands.
 
 Terraform describes infrastructure as code in text files ending in *.tf*. There 
-is a such a file in`ops/infrastructure/aws-ec2.tf` and this is used to create a 
+is such a file in`ops/infrastructure/aws-ec2.tf` and this is used to create a 
 t2.micro instance on AWS with the security privileges that allow communication 
-with a Docker daemon. Note that this `tf` file specifies an AWS resource which 
-you will log in with a key pair named `aws-centos7-keys` so this needs to be 
-created. The private key file which you will have downloaded from AWS should be 
-placed in your `~/.ssh` directory so its path will be 
-`~/.ssh/aws-centos7-keys.pem`.
+with a Docker daemon. An AWS resource is specified which you will log in with a 
+key pair named `aws-centos7-keys`. Create this key pair using your AWS console
+web page.
 
-* Create an elastic IP (EIP) address for your staging server hosting GigaDB
+Download the private key file from AWS and place it in your `~/.ssh` directory 
+so that its path will be `~/.ssh/aws-centos7-keys.pem`.
+
+Create an elastic IP (EIP) address for your staging server hosting GigaDB
 with the name `eip-staging-gigadb`. The `aws-ec2.tf` file will instruct 
-Terraform to look for this EIP and associate it with the EC2 instance. If an EIP
-called `eip-staging-gigadb` does not exist then Terraform will generate a
-`no matching Elastic IP found` error message.
+Terraform to look for this EIP and automatically associate it with the EC2 
+instance. If there is no EIP called `eip-staging-gigadb` then Terraform will 
+generate a `no matching Elastic IP found` error message.
 
-* Use Terraform to instantiate the t2.micro instance on AWS cloud:
+> Using your domain name service, map the EIP to the domain name you will use 
+for your staging or production server.
+
+Use Terraform to instantiate the t2.micro instance on AWS cloud with the 
+following commands:
 ```
 $ terraform init
 $ terraform plan
@@ -197,24 +200,28 @@ $ terraform apply
 
 *N.B.* Use `terraform destroy` to terminate the EC2 instance.
 
-Check that your new EC2 instance exists using your AWS Web console.
+Check that your new EC2 instance exists on your AWS Web console. It will have 
+the name `ec2-as1-staging-gigadb`.
 
-Reconcile terraform state file with actual AWS infrastructure to update public 
-IP address of the staging_dockerhost instance with elastic IP address 
-otherwise Ansible will try to use the original EC2 instance IP address and you
-will get a server not found error:
+Reconcile the Terraform state file with the actual AWS infrastructure to update 
+public IP address of the staging_dockerhost instance with the elastic IP 
+address:
 ```
 $ terraform refresh
 ```
 
+If this is not done then Ansible will try to use the original IP address of 
+your EC2 instance and you will get a server not found error since the server
+will have your elastic IP address.
+
 ### Ansible
 
-[Ansible](https://www.ansible.com) is now used to install the EC2 instance 
+[Ansible](https://www.ansible.com) is used to install the EC2 instance 
 with a Docker daemon. The Ansible software is a tool for provisioning, managing
 configuration and deploying applications using its own declarative language. SSH
 is used to connect to remote servers to perform its provisioning tasks.
 
-### Ansible setup and configuration
+#### Ansible setup and configuration
 
 The machines controlled by Ansible are usually defined in a [`hosts`](https://github.com/gigascience/gigadb-website/blob/develop/ops/infrastructure/inventories/hosts)
 file which lists the host machines and how they are grouped together. Our 
@@ -258,10 +265,10 @@ gigadb_environment = production
 gitlab_url = {{ vault_gitlab_url }}
 ```
 
-Our `hosts` file does not list any machines. Instead, we use a tool called 
-[`terraform-inventory`](https://github.com/adammck/terraform-inventory) which 
+Our `hosts` file does not list any machines. Instead, a tool called 
+[`terraform-inventory`](https://github.com/adammck/terraform-inventory)  
 generates a dynamic Ansible inventory from a Terraform state file. Nonetheless, 
-we still use the `hosts` file to reference variables for hosts.
+the `hosts` file is still used to reference variables for hosts.
 
 * One particular variable to note is `gitlab_private_token`. The value of `gitlab_private_token`
 is the contents of a file located at `~/.gitlab_private_token`.  Create this 
@@ -274,14 +281,21 @@ this reason, the actual values are encrypted within an Ansible vault file which
 needs to be located at `ops/infrastructure/group_vars/all/vault`. This vault 
 file should NOT be version controlled as defined in the `.gitignore` file.
 
-To create the `vault` file:
+Create the `vault` file in the ops/infrastructure/group_vars/all directory:
 ```
+$ pwd
+~/gigadb-website
+# Make a directory for group variables
+$ mkdir ops/infrastructure/group_vars 
+# Make a directory for all
+$ mkdir ops/infrastructure/group_vars/all
+# Create vault file
 $ ansible-vault create ops/infrastructure/group_vars/all/vault
 ```
 
-You will be prompted to enter a password, which you will share with others 
-needing access to the vault. The variables below with appropriate values need to
-be placed in the `vault` file:
+You will be prompted to enter a password, which you will need to share with 
+others needing access to the vault. The variables below with appropriate values 
+need to be placed in the `vault` file:
 ```
 vault_staging_pg_user: somevalue
 vault_staging_pg_password: somevalue
@@ -304,8 +318,8 @@ An example of what the `vault_gitlab_url` should look like is:
 vault_gitlab_url: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2Fjbloggs-gigadb-website"
 ```
 
-Save the `vault` file when you are done. Since the `vault` file is encrypted, you will see something like this if you
-try to edit the file in a text editor:
+Save the `vault` file when you are done. Since the `vault` file is encrypted, 
+you will see something like this if you try to edit the file in a text editor:
 ```
 $ANSIBLE_VAULT;1.2;AES256;dev
 37636561366636643464376336303466613062633537323632306566653533383833366462366662
@@ -315,28 +329,31 @@ $ANSIBLE_VAULT;1.2;AES256;dev
 3161
 ```
 
-To open the encrypted `vault` file for editing, use the command below. N.B. you 
-will be prompted for a password.
+To open the encrypted `vault` file for editing, use the command below and input
+the password when prompted.
 ```
 $ ansible-vault edit ops/infrastructure/group_vars/all/vault
 ```
 
-* Provide Ansible with the password to access the vault file during the 
-execution of playbooks by storing the password in a `~/.vault_pass.txt` file. 
+Provide Ansible with the password to access the vault file during the 
+execution of playbooks by storing the password to the vault file in a 
+`~/.vault_pass.txt` file. 
 
 Roles are used in Ansible to perform tasks on machines such as installing a  
 software package. An Ansible role consists of a group of variables, tasks, files 
 and handlers stored in a standardised file structure. There are a number of 
 roles in `ops/infrastructure/roles` for installing Docker, PostgreSQL and 
 security tools on hosts. Other roles are required which are available from 
-public repositories and these should be downloaded as follows:
+public repositories.
+
+Download these roles:
 ```
 $ ansible-galaxy install -r requirements.yml
 ```
 
-### Ansible playbook execution
+#### Ansible playbook execution
 
-To provision the EC2 instance using Ansible:
+Provision the EC2 instance using Ansible:
 ```
 $ ansible-playbook -vvv -i inventories staging-playbook.yml --vault-password-file ~/.vault_pass.txt
 ```
@@ -345,11 +362,9 @@ $ ansible-playbook -vvv -i inventories staging-playbook.yml --vault-password-fil
 in the `~/.ssh/known_hosts` file associated with the elastic IP address if this
 is not the first time you have performed this provisioning step. 
 
-Ansible will update values for specific project environment variables in 
+Ansible will update values for the project environment variables below in 
 GitLab. Check them on the project environment variables page after the Ansible
-provisioning has completed. This is done by the docker-postinstall role. N.B.
-make sure that the correct gitlab project url is being used here in this 
-`main.yml` file.
+provisioning has completed. This is done by the `docker-postinstall` role.
 
 * staging_tlsauth_ca - certificate authority for staging server - this is 
 provided by staging server during Ansible provisioning
@@ -367,31 +382,51 @@ can use the Docker engine. This is the 2-way certificate-based authentication.
 ### Further configuration steps
 
 The new gigadb-website code contains functionality for running GigaDB over 
-[HTTPS](https://en.wikipedia.org/wiki/HTTPS). The 
-[Let's Encrypt](https://letsencrypt.org) certificate authority is used as a 
-trusted authority to sign a certificate provided by GigaDB which is trusted by 
-users.
+[HTTPS](https://en.wikipedia.org/wiki/HTTPS). 
+[Let's Encrypt](https://letsencrypt.org) is used as a trusted certificate 
+authority to sign a certificate provided by GigaDB which is trusted by users.
 
-* For Let's Encrypt to do this, the server used for deployment requires a domain 
-name. The EC2 domain names provided by AWS cannot be used because they are 
-ephemeral and so are blacklisted by Let's Encrypt and your own domain name must 
-be used instead, *e.g.* [http://gigadb-staging.gigatools.net]. Let's Encrypt 
-verifies that this domain name is under our control.
+For Let's Encrypt to do this, the server used for staging GigaDB requires a 
+domain name as mentioned above. The EC2 domain names provided by AWS cannot be 
+used because they are ephemeral and so are blacklisted by Let's Encrypt. Your 
+own domain name must be used instead, *e.g.* [http://gigadb-staging.gigatools.net] 
+which Let's Encrypt will verify as a domain name under your control.
 
-* The .gitlab-ci.yml file needs to be edited to use your domain name by changing
-`gigadb-staging.pommetab.com` to, for example, `gigadb-staging.gigatools.net`, 
-the domain name for your server where GigaDB will be located.
+Currently, an EC2 instance is used to host a GigaDB staging server. This EC2 
+instance has been allocated an elastic IP address which should be mapped onto 
+the domain name (*e.g.* [http://gigadb-staging.gigatools.net]) using your domain 
+name registry service. This domain name is provided with an SSL certificate by 
+Let's Encrypt.
 
-> Actually, all mention of `gigadb-staging.pommetab.com` in files need to be 
-changed to, for example, `gigadb-staging.gigatools.net`. Check out:
-* ops/configuration/nginx-conf/sites/gigadb.staging.http.conf
-* ops/configuration/nginx-conf/sites/gigadb.staging.https.conf
+Deployment of GigaDB on the EC2 staging server in the CI/CD process is 
+described in the [gitlab-ci.yml](https://github.com/gigascience/gigadb-website/blob/develop/.gitlab-ci.yml) 
+file. The CI/CD process has a stage called `with_new_cert_deploy` which includes
+a step to generate a web certificate for TLS termination on the web container 
+for GigaDB. As mentioned above, the value of the $STAGING_HOME_URL CI/CD
+environment variable in this file will be your domain name which ensures that 
+the certificate is created for your domain name. $STAGING_HOME_URL is a GitLab 
+CI/CD environment variable so its value must be provided on the GitLab.com web 
+site.
+
+#### NGINX configuration
+
+In addition, NGINX conf files need to be configured with the domain name of the 
+staging server. Edit the following two NGINX conf files so that any mention of 
+`gigadb-staging.gigatools.net` is replaced with the domain name you are using to 
+stage GigaDB.
+
+* `ops/configuration/nginx-conf/sites/gigadb.staging.http.conf`
+* `ops/configuration/nginx-conf/sites/gigadb.staging.https.conf`
+
+Commit these two NGINX conf files into your repository. You should see a new 
+CI/CD pipeline process start and end with a successful build. 
 
 ### Executing the CD pipeline for deployment
 
-Deployment to the staging server is manually performed by clicking a button on 
-the GitLab Pipeline page. If it is the first time doing this on the server, 
-select the *with_new_cert_deploy* process. Otherwise, use *deploy_app*. 
+Actual deployment of GigaDB to the staging server is manually performed by 
+clicking a button on the GitLab pipelines page for your GitLab GigaDB project. 
+If it is the first time doing this on the server, select the 
+*with_new_cert_deploy* process, otherwise, use *deploy_app*. 
 
-Also note that the HTTPS certificates last 3 months, so you need to do at least 
+Also, note that the HTTPS certificates last 3 months, so you need to do at least 
 one deploy every 3 month (a NO-OP deploy will work).

--- a/docs/SETUP_CI_CD_PIPELINE.md
+++ b/docs/SETUP_CI_CD_PIPELINE.md
@@ -65,29 +65,42 @@ the *General pipelines* section, ensure that the *Public pipelines* checkbox is
 ` \ \ Lines:\s*(\d+.\d+\%)`. Click on the *Save changes* green button.
  
 * The variables below need to be created for your project in the `Environment variables` 
-section in the CI/CD Settings page. Any values below listed as **?** should be 
-replaced with proper values - please contact the GigaScience tech support team 
-for these. These environment variables together with those in the Forks group 
-are exported to the `.secrets` file and are listed 
-[here](https://github.com/gigascience/gigadb-website/blob/develop/ops/configuration/variables/secrets-sample).
-                             
+section in the CI/CD Settings page. Any values below listed as `somevalue` 
+should be replaced with proper values - please contact the GigaScience tech 
+support team for help with setting these.
+
+* The value of the STAGING_HOME_URL variable should be the domain name of the
+machine you will use as the GigaDB staging server.
+
+* The STAGING_IP_ADDRESS variable should be given the IP address of your staging 
+server as its value. 
+
+* Variables whose names begin with `staging_*` and have `0` values will be 
+automatically updated with their proper values during Ansible provisioning of 
+your staging server. 
+
+These environment variables together with those in the Forks group are exported 
+to the `.secrets` file and are listed 
+[here](https://github.com/gigascience/gigadb-website/blob/develop/ops/configuration/variables/secrets-sample). 
+All these GitLab CI/CD environment variables are referred to in the 
+`gitlab-ci.yml` file or used in the CI/CD pipeline.
 
 Variable Name | Value
 ------------- | -----
-ANALYTICS_CLIENT_EMAIL | **?**
-ANALYTICS_CLIENT_ID | **?**
-ANALYTICS_PRIVATE_KEY | **?**
-COVERALLS_REPO_TOKEN | **?**
-FORK | **?**
-MAILCHIMP_API_KEY | **?**
-MAILCHIMP_LIST_ID | **?**
-MAILCHIMP_TEST_EMAIL | **?**
+ANALYTICS_CLIENT_EMAIL | somevalue
+ANALYTICS_CLIENT_ID | somevalue
+ANALYTICS_PRIVATE_KEY | somevalue
+COVERALLS_REPO_TOKEN | somevalue
+FORK | somevalue
+MAILCHIMP_API_KEY | somevalue
+MAILCHIMP_LIST_ID | somevalue
+MAILCHIMP_TEST_EMAIL | somevalue
 STAGING_GIGADB_DB | gigadb
 STAGING_GIGADB_HOST | dockerhost
 STAGING_GIGADB_PASSWORD | vagrant
 STAGING_GIGADB_USER | gigadb
-STAGING_HOME_URL | 0
-STAGING_IP_ADDRESS | 0
+STAGING_HOME_URL | somevalue
+STAGING_IP_ADDRESS | somevalue
 STAGING_PUBLIC_HTTPS_PORT | 433
 STAGING_PUBLIC_HTTP_PORT | 80
 staging_private_ip | 0

--- a/docs/SETUP_CI_CD_PIPELINE.md
+++ b/docs/SETUP_CI_CD_PIPELINE.md
@@ -1,0 +1,311 @@
+# How to set up CI/CD pipelines on gitlab.com
+
+Modern software application development may involve implementing small code 
+changes which are frequently checked into version control. Continuous 
+Integration (CI) provides a consistent and automated way to build, package and 
+test the application under development. Furthermore, Continuous Delivery (CD) 
+automates the deployment of applications to specific infrastructure environments 
+such as staging and production servers.
+
+## Use of GitLab for Continuous Integration
+
+GitLab provides a CI service used by GigaDB based on the 
+[`.gitlab-ci.yml`](https://github.com/gigascience/gigadb-website/blob/develop/.gitlab-ci.yml)
+file located at the root of the repository. A Runner in GitLab is configured to 
+trigger the CI pipeline every time there is a code commit or push. GitLab.com
+allows you to use Shared Runners provided by GitLab Inc which are virtual 
+machines running on GitLab's infrastructure to build any project.
+
+The GigaDB `.gitlab-ci.yml` file tells the GitLab Runner to run a pipeline job 
+with these stages: build, test, security, conformance, staging and live. The 
+status of every pipeline is displayed in the Pipelines page.
+
+### Mirroring your forked gigadb-website repository from GitHub
+
+To begin, we need to mirror your forked GitHub gigadb-website repository in a 
+GitLab project. This is done by adding your GitHub gigadb-website repository to 
+the GitLab Gigascience Forks organisation. To do this:
+
+* Log into GitLab and go to the 
+[gigascience/Forks page](https://gitlab.com/gigascience/forks).
+ 
+* Click on *New Project* followed by *CI/CD for external repo* and then 
+*GitHub*. 
+
+* On the *Connect repositories from GitHub page*, click on the 
+*List your GitHub repositories* green button. Find the repository fork of 
+`gigadb-website` that you want to perform CI/CD on.
+
+* Under the *To GitLab* column, select *gigascience/forks* to connect your repo 
+to this GitLab group. Also, provide a name for the repo, *e.g.* 
+pli888-gigadb-website so that you can differentiate this repository from others 
+in the Forks group.
+
+* Click the *Connect* button to create the mirror of the GitHub repository on
+GitLab.
+
+### Configuring your GitLab gigadb-website project
+
+Your new GitLab `gigadb-website` project requires configuration:
+
+* The default branch needs to be selected for your project to allow you to 
+perform CI/CD on this branch. Go to the Repository settings for your project, 
+*e.g.*
+[https://gitlab.com/gigascience/forks/pli888-gigadb-website/settings/repository],
+ click on the *Expand* button for the `Default Branch` settings. Use the 
+drop-down menu to select the default branch and click the *Save changes* green 
+button. Whatever branch you select requires a .gitlab-ci.yml file at the root of 
+the repository project for CI/CD to work.
+
+* Go to the CI/CD Settings for your project, *e.g.*
+[https://gitlab.com/gigascience/forks/pli888-gigadb-website/settings/ci_cd]. In 
+the *General pipelines* section, ensure that the *Public pipelines* checkbox is 
+**NOT** ticked, otherwise variables will leak into the logs. The 
+*Test coverage parsing* text field should also contain: 
+` \ \ Lines:\s*(\d+.\d+\%)`. Click on the *Save changes* green button.
+ 
+* The variables below need to be created for your project in the `Environment variables` 
+section in the CI/CD Settings page. Any values below listed as **?** should be 
+replaced with proper values - please contact the GigaScience tech support team 
+for these. These environment variables together with those in the Forks group 
+are exported to the `.secrets` file and are listed 
+[here](https://github.com/gigascience/gigadb-website/blob/develop/ops/configuration/variables/secrets-sample).
+                             
+
+Variable Name | Value
+------------- | -----
+ANALYTICS_CLIENT_EMAIL | **?**
+ANALYTICS_CLIENT_ID | **?**
+ANALYTICS_PRIVATE_KEY | **?**
+COVERALLS_REPO_TOKEN | **?**
+FORK | **?**
+MAILCHIMP_API_KEY | **?**
+MAILCHIMP_LIST_ID | **?**
+MAILCHIMP_TEST_EMAIL | **?**
+STAGING_GIGADB_DB | gigadb
+STAGING_GIGADB_HOST | dockerhost
+STAGING_GIGADB_PASSWORD | vagrant
+STAGING_GIGADB_USER | gigadb
+STAGING_HOME_URL | 0
+STAGING_IP_ADDRESS | 0
+STAGING_PUBLIC_HTTPS_PORT | 433
+STAGING_PUBLIC_HTTP_PORT | 80
+staging_private_ip | 0
+staging_public_ip | 0
+staging_tlsauth_ca | 0
+staging_tlsauth_cert | 0
+staging_tlsauth_key | 0
+
+### Executing a Continuous Integration run
+ 
+Your CI/CD pipeline can now be executed:
+
+* Go to your pipelines page and click on *Run Pipeline*.
+
+* In the *Create for* text field, confirm the name of the branch you want to run 
+the CI/CD pipeline. The default branch should already be pre-selected for you. 
+Then click on the *Create pipeline* button. 
+
+* Refresh the pipelines page, you should see the CI/CD pipeline running. If the 
+set up of your pipeline is successful, you will see it run the build, test, 
+security and conformance stages.
+
+### Triggering CI runs with new code commits
+
+Since our repository includes a .gitlab-ci.yml file, any new commits will 
+trigger a new CI run. To see an example of this happening, edit the 
+`~/.gitlab-ci.yml` file by changing two variables. Firstly, change 
+`GITLAB_UPSTREAM_PROJECT_ID` is updated to its correct value which you can find 
+in the `General project` section in Settings page for your GitLab project. 
+Secondly, edit `MAIN_BRANCH` so that its value is set to the repository branch
+under CI/CD pipeline processing.
+```
+MAIN_BRANCH: "remove-chef-vagrant"
+GITLAB_UPSTREAM_PROJECT_ID: "10678502"
+```  
+ 
+Commit and push these changes to your GitHub repository. If you now go to the 
+CI/CD > Pipelines page, you should see a new pipeline with a `running` status 
+which was triggered by the above code commit which is mirrored in the GitLab
+project repository.
+ 
+## Continuous Deployment in the CI/CD pipeline
+
+The deployment of gigadb-website code onto a staging or production server to 
+provide a running GigaDB application is not automatically performed by the 
+CI/CD pipeline since it is set to run manually in the `.gitlab-ci.yml` file. 
+Therefore, this part of the CI/CD process has to be explicitly executed from the 
+[GitLab pipelines](https://gitlab.com/gigascience/forks/pli888-gigadb-website/pipelines)
+page. Prior to this, a server has to be instantiated with an installation of the
+Docker daemon to manage containers and images, and this can be done using 
+Terraform and Ansible to create a Docker server on AWS.
+
+### Terraform
+
+[Terraform](https://www.terraform.io) is a tool which allows you to describe and
+instantiate infrastructure as code. Terraform can be installed by downloading
+the installer from the [Terraform](https://www.terraform.io) web site or it can 
+be installed using a package manager for your operating system. For example, 
+MacOSX users can use [Macports](https://www.macports.org).
+
+The following environment variables with the required values need to be created 
+which Terraform will use to access AWS:
+```
+$ cd ops/infrastructure
+$ export TF_VAR_deployment_target=staging
+$ export TF_VAR_aws_vpc_id=<AWS VPC id>
+$ export TF_VAR_aws_access_key=<AWS Access key>
+$ export TF_VAR_aws_secret_key=<AWS Secret key>
+```
+
+You could also persist the above variables in your `~/.bash_profile` file.
+
+Terraform describes infrastructure as code in text files ending in *.tf*. There 
+is a such a file in`ops/infrastructure/aws-ec2.tf` and this is used to create a 
+t2.micro instance on AWS with the security privileges that allow communication 
+with a Docker daemon. Note that this `tf` file specifies an AWS resource which 
+you will log in with a key pair named `aws-centos7-keys` so this needs to be 
+created. The private key file which you will have downloaded from AWS should be 
+placed in your `~/.ssh` directory so its path will be 
+`~/.ssh/aws-centos7-keys.pem`.
+
+* Create an elastic IP (EIP) address for your staging server hosting GigaDB
+with the name `eip-staging-gigadb`. The `aws-ec2.tf` file will instruct 
+Terraform to look for this EIP and associate it with the EC2 instance. If an EIP
+called `eip-staging-gigadb` does not exist then Terraform will generate a
+`no matching Elastic IP found` error message.
+
+* Use Terraform to instantiate the t2.micro instance on AWS cloud:
+```
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+*N.B.* Use `terraform destroy` to terminate the EC2 instance.
+
+Check that your new EC2 instance exists using your AWS Web console.
+
+Reconcile terraform state file with actual AWS infrastructure to update public 
+IP address of the staging_dockerhost instance with elastic IP address 
+otherwise Ansible will try to use the original EC2 instance IP address and you
+will get a server not found error:
+```
+$ terraform refresh
+```
+
+### Ansible
+
+[Ansible](https://www.ansible.com) is now used to install the EC2 instance 
+with a Docker daemon. The Ansible software is a tool for provisioning, managing
+configuration and deploying applications using its own declarative language. SSH
+is used to connect to remote servers to perform its provisioning tasks.
+
+### Ansible setup and configuration
+
+The machines controlled by Ansible are defined in a `hosts` file which lists 
+host groups and the hosts within these groups. The `hosts` file for the 
+gigadb-website project is at `ops/infrastructure/inventories/hosts`.
+
+* Check this file so that the `ansible_ssh_private_key_file` variable contains 
+the correct path to your AWS pem file.
+* If not present, create a [`~/.gitlab_private_token`](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) 
+file since this is referenced in the `hosts` file and provides access to the 
+GitLab API. The `read_user` and `read_registry` scopes are not required when
+creating the private token.
+
+Roles are used in Ansible to perform tasks such as installing a piece of 
+software. An Ansible role consists of a group of variables, tasks, files and 
+handlers stored in a standardised file structure. There are a number of roles in
+`ops/infrastructure/roles` for installing Docker, PostgreSQL and security 
+tools on hosts.
+
+Other roles are required which are available from public repositories and these
+should be downloaded as follows:
+```
+$ ansible-galaxy install -r requirements.yml
+```
+
+Database security credentials are placed in an encrypted file which is created 
+using Ansible Vault. Place the vault file in 
+`ops/infrastructure/group_vars/all/vault`. This vault file should NOT be version 
+controlled as defined in the `.gitignore` file.
+
+Opening the encrypted file for editing to adjust the database credentials can be 
+done using the command below. N.B. you will be prompted for a password.
+```
+$ ansible-vault edit ops/infrastructure/group_vars/all/vault
+``` 
+
+Provide Ansible with the password so it can access the vault file during the 
+execution of playbooks by storing the password in a `~/.vault_pass.txt` file. 
+
+>The docker-postinstall role needs to be updated because the name of the GitLab
+project whose environmental variables are edited by this role is hard-coded into
+the `ops/infrastructure/roles/docker-postinstall/tasks/main.yml` file so the 
+specific name of your GitLab project needs to be edited accordingly here.
+
+> A possible fix for this is to do env variable lookups from the .env file which 
+contains the gitlab project url we need in the main.yml file.
+ 
+
+### Ansible playbook execution
+
+To provision the EC2 instance using Ansible:
+```
+$ ansible-playbook -vvv -i inventories staging-playbook.yml --vault-password-file ~/.vault_pass.txt
+```
+
+> Since an elastic IP address is being used, you might need to delete the entry
+in the `~/.ssh/known_hosts` file associated with the elastic IP address.
+
+Ansible will update values for specific project environment variables in 
+GitLab. Check them on the project environment variables page after the Ansible
+provisioning has completed. This is done by the docker-postinstall role. N.B.
+make sure that the correct gitlab project url is being used here in this 
+`main.yml` file.
+
+* staging_tlsauth_ca - certificate authority for staging server - this is 
+provided by staging server during Ansible provisioning
+* staging_tlsauth_cert - public certificate for staging server - this is 
+provided by staging server during Ansible provisioning
+* staging_tlsauth_key - the server key for the above CA - this is provided by 
+staging server during Ansible provisioning
+ 
+This is for running a secure Docker engine on the production CNGB virtual server
+so that the Docker API is secured over TCP and we know we are communicating 
+with the correct server and not a malicious impersonation. We also need to 
+authenticate the client with TLS so only clients using the client certificates 
+can use the Docker engine. This is the 2-way certificate-based authentication.
+
+### Further configuration steps
+
+The new gigadb-website code contains functionality for running GigaDB over 
+[HTTPS](https://en.wikipedia.org/wiki/HTTPS). The 
+[Let's Encrypt](https://letsencrypt.org) certificate authority is used as a 
+trusted authority to sign a certificate provided by GigaDB which is trusted by 
+users.
+
+* For Let's Encrypt to do this, the server used for deployment requires a domain 
+name. The EC2 domain names provided by AWS cannot be used because they are 
+ephemeral and so are blacklisted by Let's Encrypt and your own domain name must 
+be used instead, *e.g.* [http://gigadb-staging.gigatools.net]. Let's Encrypt 
+verifies that this domain name is under our control.
+
+* The .gitlab-ci.yml file needs to be edited to use your domain name by changing
+`gigadb-staging.pommetab.com` to, for example, `gigadb-staging.gigatools.net`, 
+the domain name for your server where GigaDB will be located.
+
+> Actually, all mention of `gigadb-staging.pommetab.com` in files need to be 
+changed to, for example, `gigadb-staging.gigatools.net`. Check out:
+* ops/configuration/nginx-conf/sites/gigadb.staging.http.conf
+* ops/configuration/nginx-conf/sites/gigadb.staging.https.conf
+
+### Executing the CD pipeline for deployment
+
+Deployment to the staging server is manually performed by clicking a button on 
+the GitLab Pipeline page. If it is the first time doing this on the server, 
+select the *with_new_cert_deploy* process. Otherwise, use *deploy_app*. 
+
+Also note that the HTTPS certificates last 3 months, so you need to do at least 
+one deploy every 3 month (a NO-OP deploy will work).

--- a/ops/configuration/nginx-conf/sites/gigadb.staging.http.conf
+++ b/ops/configuration/nginx-conf/sites/gigadb.staging.http.conf
@@ -3,7 +3,7 @@ server {
     listen 80;
     listen [::]:80;
 
-    server_name gigadb-staging.pommetab.com web gigadb.dev;
+    server_name gigadb-staging.gigatools.net web gigadb.dev;
     root /var/www;
     index index.php index.html index.htm;
 

--- a/ops/configuration/nginx-conf/sites/gigadb.staging.https.conf
+++ b/ops/configuration/nginx-conf/sites/gigadb.staging.https.conf
@@ -47,8 +47,8 @@ location /search {
 
 
     # certs sent to the client in SERVER HELLO are concatenated in ssl_certificate
-    ssl_certificate /etc/letsencrypt/live/gigadb-staging.pommetab.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/gigadb-staging.pommetab.com/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/gigadb-staging.gigatools.net/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/gigadb-staging.gigatools.net/privkey.pem;
     ssl_session_timeout 1d;
     ssl_session_cache shared:SSL:50m;
     ssl_session_tickets off;
@@ -70,7 +70,7 @@ location /search {
     ssl_stapling_verify on;
 
     ## verify chain of trust of OCSP response using Root CA and Intermediate certs
-    ssl_trusted_certificate /etc/letsencrypt/live/gigadb-staging.pommetab.com/chain.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/gigadb-staging.gigatools.net/chain.pem;
 
     add_header Content-Security-Policy "child-src 'self' http://penguin.genomics.cn;";
 }

--- a/ops/configuration/nginx-conf/sites/gigadb.staging.https.conf
+++ b/ops/configuration/nginx-conf/sites/gigadb.staging.https.conf
@@ -2,7 +2,7 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
 
-    server_name gigadb-staging.pommetab.com web gigadb.dev;
+    server_name gigadb-staging.gigatools.net web gigadb.dev;
 
 
     root /var/www;

--- a/ops/infrastructure/aws-ec2.tf
+++ b/ops/infrastructure/aws-ec2.tf
@@ -56,3 +56,15 @@ resource "aws_instance" "staging_dockerhost" {
   vpc_security_group_ids = ["${aws_security_group.docker_host_sg.id}"]
   key_name = "aws-centos7-keys"
 }
+
+data "aws_eip" "staging_eip" {
+  filter {
+    name   = "tag:Name"
+    values = ["eip-staging-gigadb"]
+  }
+}
+
+resource "aws_eip_association" "staging_eip" {
+  instance_id   = "${aws_instance.staging_dockerhost.id}"
+  allocation_id = "${data.aws_eip.staging_eip.id}"
+}

--- a/ops/infrastructure/aws-ec2.tf
+++ b/ops/infrastructure/aws-ec2.tf
@@ -55,6 +55,9 @@ resource "aws_instance" "staging_dockerhost" {
   instance_type = "t2.micro"
   vpc_security_group_ids = ["${aws_security_group.docker_host_sg.id}"]
   key_name = "aws-centos7-keys"
+  tags                   = {
+    Name = "ec2-as1-staging-gigadb"
+  }
 }
 
 data "aws_eip" "staging_eip" {

--- a/ops/infrastructure/aws-ec2.tf
+++ b/ops/infrastructure/aws-ec2.tf
@@ -4,8 +4,6 @@ provider "aws" {
 	region     = "ap-southeast-1"
 }
 
-
-
 resource "aws_security_group" "docker_host_sg" {
   name        = "docker_host_sg"
   description = "Allow connection to docker host"
@@ -45,18 +43,20 @@ resource "aws_security_group" "docker_host_sg" {
 	protocol    = "-1"
 	cidr_blocks = ["0.0.0.0/0"]
   }
-
-
 }
 
 
 resource "aws_instance" "staging_dockerhost" {
-  ami           = "ami-8e0205f2"
+  ami = "ami-8e0205f2"
   instance_type = "t2.micro"
   vpc_security_group_ids = ["${aws_security_group.docker_host_sg.id}"]
   key_name = "aws-centos7-keys"
-  tags                   = {
+  tags = {
     Name = "ec2-as1-staging-gigadb"
+  }
+
+  root_block_device = {
+    delete_on_termination = "true"
   }
 }
 

--- a/ops/infrastructure/inventories/hosts
+++ b/ops/infrastructure/inventories/hosts
@@ -4,7 +4,7 @@
 
 [staging_dockerhost:vars]
 
-ansible_ssh_private_key_file="/Users/rija/.ssh/aws-centos7-keys.pem"
+ansible_ssh_private_key_file= {{ vault_staging_private_key_file_location }}
 ansible_user="centos"
 ansible_become="true"
 database_bootstrap="../../sql/production_like.pgdmp"
@@ -20,7 +20,7 @@ gigadb_environment = staging
 
 [production_dockerhost:vars]
 
-ansible_ssh_private_key_file=""
+ansible_ssh_private_key_file= {{ vault_production_private_key_file_location }}
 ansible_user="centos"
 ansible_become="true"
 database_bootstrap="../../sql/production_like.pgdmp"
@@ -30,3 +30,6 @@ pg_database = {{ vault_production_pg_database }}
 gitlab_private_token = {{ lookup('file','~/.gitlab_private_token') }}
 gigadb_environment = production
 
+[all:vars]
+
+gitlab_url = {{ vault_gitlab_url }}

--- a/ops/infrastructure/roles/docker-postinstall/tasks/main.yml
+++ b/ops/infrastructure/roles/docker-postinstall/tasks/main.yml
@@ -58,7 +58,7 @@
 
 - name: Copy the CA pem to GITLAB CI environment variable (first time)
   uri:
-    url: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2Frija-gigadb-website/variables"
+    url: "{{ gitlab_url }}/variables"
     method: POST
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
@@ -73,7 +73,7 @@
 
 - name: Copy the CA pem to GITLAB CI environment variable (subsequently)
   uri:
-    url: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2Frija-gigadb-website/variables/{{ gigadb_environment }}_tlsauth_ca"
+    url: "{{ gitlab_url }}/variables/{{ gigadb_environment }}_tlsauth_ca"
     method: PUT
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
@@ -86,7 +86,7 @@
 
 - name: Copy the cert pem to GITLAB CI environment variable
   uri:
-    url: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2Frija-gigadb-website/variables"
+    url: "{{ gitlab_url }}/variables"
     method: POST
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
@@ -102,7 +102,7 @@
 
 - name: Copy the cert pem to GITLAB CI environment variable (subsequently)
   uri:
-    url: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2Frija-gigadb-website/variables/{{ gigadb_environment }}_tlsauth_cert"
+    url: "{{ gitlab_url }}/variables/{{ gigadb_environment }}_tlsauth_cert"
     method: PUT
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
@@ -115,7 +115,7 @@
 
 - name: Copy the key pem to GITLAB CI environment variable
   uri:
-    url: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2Frija-gigadb-website/variables"
+    url: "{{ gitlab_url }}/variables"
     method: POST
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
@@ -131,7 +131,7 @@
 
 - name: Copy the key pem to GITLAB CI environment variable (subsequently)
   uri:
-    url: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2Frija-gigadb-website/variables/{{ gigadb_environment }}_tlsauth_key"
+    url: "{{ gitlab_url }}/variables/{{ gigadb_environment }}_tlsauth_key"
     method: PUT
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
@@ -144,7 +144,7 @@
 
 - name: copy the private ip address to GITLAB CI environment variable (first time)
   uri:
-    url: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2Frija-gigadb-website/variables"
+    url: "{{ gitlab_url }}/variables"
     method: POST
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
@@ -160,7 +160,7 @@
 
 - name: copy the private ip address to GITLAB CI environment variable (subsequently)
   uri:
-    url: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2Frija-gigadb-website/variables/{{ gigadb_environment }}_private_ip"
+    url: "{{ gitlab_url }}/variables/{{ gigadb_environment }}_private_ip"
     method: PUT
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
@@ -173,7 +173,7 @@
 
 - name: copy the public ip address to GITLAB CI environment variable (first time)
   uri:
-    url: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2Frija-gigadb-website/variables"
+    url: "{{ gitlab_url }}/variables"
     method: POST
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
@@ -189,7 +189,7 @@
 
 - name: copy the public ip address to GITLAB CI environment variable (subsequently)
   uri:
-    url: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2Frija-gigadb-website/variables/{{ gigadb_environment }}_public_ip"
+    url: "{{ gitlab_url }}/variables/{{ gigadb_environment }}_public_ip"
     method: PUT
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"


### PR DESCRIPTION
# Pull request for issues: #281, #282, #283, #284 and #286

This is a pull request for the following functionalities:

* Provide up-to-date documentation for running CI/CD pipelines on GitLab
* Allocate GigaDB staging server with an elastic IP address
* Delete root volume on terminating AWS EC2 instance
* Allow GitLab CI/CD pipeline to run on code from different `gigadb-website` GitLab projects
* Update gitlab-ci.yml and nginx configuration files to use current GigaDB staging server domain name

## Changes to the provisioning

Minor changes have been made to the provisioning by Terraform, Ansible and GitLab CI:

### Terraform

Allows a static, elastic IP address to be allocated to the EC2 instance that hosts a GigaDB staging server. The EC2 instance is tagged with the name, `ec2-as1-staging-gigadb`. Terraform also now takes care of deleting the 8 GB EBS volume on EC2 instance termination which it didn't before.

### Ansible

The `docker-postinstall` role works on different GitLab projects now by configuring the GitLab project URL in an Ansible `vault` file.

### Docker and NGINX

The `Web-Dockerfile` helps to define the configuration of the NGINX including which NGINX conf file(s) are provided to the web server which is dependent on whether GigaDB deployment is to a local, staging or production environment. The two NGINX `staging` conf files have been altered so that the server_directive uses `gigadb-staging.gigatools.net` as one of the domain names. If another domain name needs to be used for staging GigaDB then the server_directive in these two NGINX staging conf files need to be updated as well.

### GitLab CI/CD

The GitLab CI/CD now uses the $STAGING_HOME_URL CI/CD environment variable to configure the staging server with its SSL certificate from Let's Encrypt.

Finally, documentation on running the GitLab CI/CD has been created in the `docs/SETUP_CI_CD_PIPELINE.md` file.

