### PR TITLE
Test data for submission wizard development

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ before_script:
   - env | grep -v "^DOCKER" | grep -v "^CI"  | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tlsauth)" > $APPLICATION/.env
   - env | grep -v "^DOCKER" | grep -v "^CI"  | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -v "ANALYTICS_PRIVATE_KEY" | grep -viE "tlsauth" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" > $APPLICATION/.secrets
   - apk add --no-cache py-pip
-  - pip install docker-compose
+  - pip install docker-compose~=1.23.0
   - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
 
 after_script:

--- a/docs/apidocs/files/features/bootstrap/DatasetViewContext.php.txt
+++ b/docs/apidocs/files/features/bootstrap/DatasetViewContext.php.txt
@@ -206,7 +206,7 @@ class DatasetViewContext implements Context
     public function iShouldSeeAButtonLinkingToSubmittersEmail($arg1)
     {
         $contactButton = $this->minkContext->getSession()->getPage()->findLink($arg1);
-        PHPUnit_Framework_Assert::assertEquals("mailto:liuxin@genomics.org.cn", $contactButton->getAttribute('href') );
+        PHPUnit_Framework_Assert::assertEquals("mailto:test+gigadb112@gigasciencejournal.com", $contactButton->getAttribute('href') );
     }
 
     /**

--- a/features/bootstrap/DatasetViewContext.php
+++ b/features/bootstrap/DatasetViewContext.php
@@ -206,7 +206,7 @@ class DatasetViewContext implements Context
     public function iShouldSeeAButtonLinkingToSubmittersEmail($arg1)
     {
         $contactButton = $this->minkContext->getSession()->getPage()->findLink($arg1);
-        PHPUnit_Framework_Assert::assertEquals("mailto:liuxin@genomics.org.cn", $contactButton->getAttribute('href') );
+        PHPUnit_Framework_Assert::assertEquals("mailto:A.xsI@madeup.com", $contactButton->getAttribute('href') );
     }
 
     /**

--- a/features/bootstrap/DatasetViewContext.php
+++ b/features/bootstrap/DatasetViewContext.php
@@ -206,7 +206,7 @@ class DatasetViewContext implements Context
     public function iShouldSeeAButtonLinkingToSubmittersEmail($arg1)
     {
         $contactButton = $this->minkContext->getSession()->getPage()->findLink($arg1);
-        PHPUnit_Framework_Assert::assertEquals("mailto:A.xsI@madeup.com", $contactButton->getAttribute('href') );
+        PHPUnit_Framework_Assert::assertEquals("mailto:test+gigadb112@gigasciencejournal.com", $contactButton->getAttribute('href') );
     }
 
     /**

--- a/protected/tests/unit/StoredDatasetMainSectionTest.php
+++ b/protected/tests/unit/StoredDatasetMainSectionTest.php
@@ -232,37 +232,37 @@ class StoredDatasetMainSectionTest extends CDbTestCase
 		$this->assertEquals($expected, $daoUnderTest->getFunding());
 	}
 
-	public function citationsQueriesExamples()
-	{
-		return [
-			"no_argument"=> [
-				null,
-				array(
-		            'scholar_query' => 'http://scholar.google.com/scholar?q=10.5072/100243',
-		            'ePMC_query' => "http://europepmc.org/search?scope=fulltext&query=(REF:'10.5072/100243')",
+    public function citationsQueriesExamples()
+    {
+        return [
+            "no_argument" => [
+                null,
+                array(
+                    'scholar_query' => 'http://scholar.google.com/scholar?q=10.5072/100243',
+                    'ePMC_query' => "http://europepmc.org/search?scope=fulltext&query=(REF:'10.5072/100243')",
                     'dimension_query' => "https://app.dimensions.ai/discover/publication?search_text=10.5072/100243",
-		        ),
-	        ],
-			"scholar_argument"=> [
-				"scholar_query",
-				array(
-		            'scholar_query' => 'http://scholar.google.com/scholar?q=10.5072/100243',
-		        ),
-	        ],
-			"ePMC_argument"=> [
-				"ePMC_query",
-				array(
-		            'ePMC_query' => "http://europepmc.org/search?scope=fulltext&query=(REF:'10.5072/100243')",
-		        ),
-	        ],
-            "dimension_argument"=> [
+                ),
+            ],
+            "scholar_argument" => [
+                "scholar_query",
+                array(
+                    'scholar_query' => 'http://scholar.google.com/scholar?q=10.5072/100243',
+                ),
+            ],
+            "ePMC_argument" => [
+                "ePMC_query",
+                array(
+                    'ePMC_query' => "http://europepmc.org/search?scope=fulltext&query=(REF:'10.5072/100243')",
+                ),
+            ],
+            "dimension_argument" => [
                 "dimension_query",
                 array(
                     'dimension_query' => "https://app.dimensions.ai/discover/publication?search_text=10.5072/100243",
                 ),
             ],
-		];
-	}
+        ];
+    }
 }
 
 ?>


### PR DESCRIPTION
# Pull request for issue: #292 

This is a pull request for the following functionalities:

The `production_like.pgdmp` database dump file contains sensitive GigaDB users' info in the `gigadb_user` table. This commit changes the problematic users' names and email addresses so that email addresses are in the format: `test+gigadb#@gigasciencejournal.com`, where `#` denotes a number based on its database table ID. Their first names and last names are replaced with `test` and `gigadb#`, respectively.

The `GIGADB_admin_tester_email`, `local-gigadb-admin@rijam.ml1.net` and all users with email addresses ending with `gigasciencejournal.com` have been kept for testing purposes. The example user with `gigadb_user` table `id` = `2` has been set with an email address `exampleuser@madeup.com`.  You can use `exampleuser@madeup.com` to log into its user account in the GigaDB application with `gigadb` as the password.

To restore the `production_like.pgdmp` backup in a local deployment of GigaDB, the following steps are required: 
```
# Drop into bash in the test container
$ docker-compose run --rm test bash
# Access the postgres database using `vagrant` as the password
bash-4.4# psql -h database -p 5432 -U gigadb postgres
Password for user gigadb: 
psql (9.4.21)
Type "help" for help.

postgres=# select pg_terminate_backend(pg_stat_activity.pid) from pg_stat_activity where datname='gigadb';
 pg_terminate_backend 
----------------------
 t
 t
 t
 t
 t
(5 rows)

postgres=# drop database gigadb;
DROP DATABASE
postgres=# create database gigadb owner gigadb;
CREATE DATABASE
postgres-# \q
# Restore the `production_like.pgdmp` database
root@9aece9101f03:/var/www# pg_restore -h database -p 5432 -U gigadb -d gigadb -v ./sql/production_like.pgdmp 
```

## Changes to the tests

The dataset-view.feature:
```
PHPUnit_Framework_Assert::assertEquals("mailto:liuxin@genomics.org.cn", $contactButton->getAttribute('href') );
```

Since the email address changed, it has been updated to `test+gigadb112@gigasciencejournal.com`.

