### PR TITLE
Fix for problems with building application image

### DIFF
--- a/ops/packaging/Dockerfile
+++ b/ops/packaging/Dockerfile
@@ -1,11 +1,16 @@
 ARG PHP_VERSION=7.0
 FROM php:${PHP_VERSION}-fpm-jessie
 
-# Problem with http://deb.debian.org repo - adding hk repo to use
-RUN echo "deb http://ftp.hk.debian.org/debian jessie main" | tee /etc/apt/sources.list && \
-    echo "deb http://ftp.hk.debian.org/debian-security jessie/updates main" | tee -a /etc/apt/sources.list && \
-    # Basic dependencies
-    apt-get update && \
+# Problem with Debian repos - adding official LTS repos to use below
+RUN echo "deb http://deb.debian.org/debian/ jessie main contrib non-free" | tee /etc/apt/sources.list && \
+    echo "deb-src http://deb.debian.org/debian/ jessie main contrib non-free" | tee -a /etc/apt/sources.list && \
+    echo "deb http://security.debian.org/ jessie/updates main contrib non-free" | tee -a /etc/apt/sources.list && \
+    echo "deb-src http://security.debian.org/ jessie/updates main contrib non-free" | tee -a /etc/apt/sources.list && \
+# the two repo below are the problematic ones, so commenting them out until debian fix them
+#    echo "deb http://deb.debian.org/debian/ jessie-updates main contrib non-free" | tee -a /etc/apt/sources.list && \
+#    echo "deb-src http://deb.debian.org/debian/ jessie-updates main contrib non-free" | tee -a /etc/apt/sources.list && \
+# basic dependencies
+    apt-get update -yq && \
     apt-get install -y --no-install-recommends \
         curl \
         libmemcached-dev \
@@ -149,9 +154,9 @@ RUN if [ ${INSTALL_TIDEWAYS_XHPROF} = true ]; then \
 ARG INSTALL_LIBSODIUM=false
 
 RUN if [ ${INSTALL_LIBSODIUM} = true ]; then \
-    # Problem with repo below - might be related to https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html
-    #echo "deb http://ftp.debian.org/debian jessie-backports main" | tee -a /etc/apt/sources.list && \
-    # Use archive repo
+    # Problem with using http://ftp.debian.org/debian for installing libsodium
+    # Might be related to https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html
+    # Using archive repo instead
     echo 'Acquire::Check-Valid-Until "0";' | tee -a /etc/apt/apt.conf.d/apt.conf && \
     echo "deb http://archive.debian.org/debian jessie-backports main" | tee -a /etc/apt/sources.list && \
     apt-get update && \

--- a/ops/packaging/Dockerfile
+++ b/ops/packaging/Dockerfile
@@ -1,12 +1,11 @@
 ARG PHP_VERSION=7.0
 FROM php:${PHP_VERSION}-fpm-jessie
 
-# Problem with Debian repos - adding repos to use below
+# Problem with http://deb.debian.org repo - adding hk repo to use
 RUN echo "deb http://ftp.hk.debian.org/debian jessie main" | tee /etc/apt/sources.list && \
     echo "deb http://ftp.hk.debian.org/debian-security jessie/updates main" | tee -a /etc/apt/sources.list && \
-    echo "deb http://ftp.cvut.cz/debian jessie-updates main" | tee -a /etc/apt/sources.list
-
-RUN apt-get update && \
+    # Basic dependencies
+    apt-get update && \
     apt-get install -y --no-install-recommends \
         curl \
         libmemcached-dev \

--- a/ops/packaging/Dockerfile
+++ b/ops/packaging/Dockerfile
@@ -1,7 +1,10 @@
 ARG PHP_VERSION=7.0
 FROM php:${PHP_VERSION}-fpm-jessie
 
-
+# Problem with Debian repos - adding repos to use below
+RUN echo "deb http://ftp.hk.debian.org/debian jessie main" | tee /etc/apt/sources.list && \
+    echo "deb http://ftp.hk.debian.org/debian-security jessie/updates main" | tee -a /etc/apt/sources.list && \
+    echo "deb http://ftp.cvut.cz/debian jessie-updates main" | tee -a /etc/apt/sources.list
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -147,7 +150,11 @@ RUN if [ ${INSTALL_TIDEWAYS_XHPROF} = true ]; then \
 ARG INSTALL_LIBSODIUM=false
 
 RUN if [ ${INSTALL_LIBSODIUM} = true ]; then \
-    echo "deb http://ftp.debian.org/debian jessie-backports main" | tee -a /etc/apt/sources.list && \
+    # Problem with repo below - might be related to https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html
+    #echo "deb http://ftp.debian.org/debian jessie-backports main" | tee -a /etc/apt/sources.list && \
+    # Use archive repo
+    echo 'Acquire::Check-Valid-Until "0";' | tee -a /etc/apt/apt.conf.d/apt.conf && \
+    echo "deb http://archive.debian.org/debian jessie-backports main" | tee -a /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y -t jessie-backports libsodium-dev && \
     pecl install libsodium && \


### PR DESCRIPTION
# Pull request for issue: #296 

This is a pull request for the following functionalities:

The `application` image has been failing to build from its [Dockerfile](https://github.com/gigascience/gigadb-website/blob/develop/ops/packaging/Dockerfile) due to problems with using Debian repos for installing basic dependencies and the [sodium](https://libsodium.gitbook.io/doc/) package. There appears to be problems with the Debian repos below:

- deb http://deb.debian.org/debian/ jessie-updates main contrib non-free
- deb-src http://deb.debian.org/debian/ jessie-updates main contrib non-free

Instead, @rija suggested we use the following repos:

- deb http://deb.debian.org/debian/ jessie main contrib non-free
- deb-src http://deb.debian.org/debian/ jessie main contrib non-free
- deb http://security.debian.org/ jessie/updates main contrib non-free
- deb-src http://security.debian.org/ jessie/updates main contrib non-free

The problem with installing `sodium` seems to be caused by using `http://ftp.debian.org/debian` which does not contain `jessie-backports` anymore which is explained [here](https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html). We will switch to using the [http://archive.debian.org/debian/](http://archive.debian.org/debian/) repo for installing `sodium` instead.

## Changes to the provisioning

The [ops/packaging/Dockerfile](https://github.com/gigascience/gigadb-website/blob/develop/ops/packaging/Dockerfile) has been updated according to the above information.