### PR TITLE
Pin Compose version to 1.23.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,8 @@ before_script:
   - env | grep -v "^DOCKER" | grep -v "^CI"  | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tlsauth)" > $APPLICATION/.env
   - env | grep -v "^DOCKER" | grep -v "^CI"  | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -v "ANALYTICS_PRIVATE_KEY" | grep -viE "tlsauth" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" > $APPLICATION/.secrets
   - apk add --no-cache py-pip
-  - pip install docker-compose
+  # Pin docker-compose version to stop installation error
+  - pip install docker-compose~=1.23.0
   - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
 
 after_script:


### PR DESCRIPTION
# Pull request for issue: #301 

This is a pull request to fix the GitLab CI build which has started fail with the following error message:

`Command "/usr/bin/python2 -m pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-NdEwYj --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- setuptools wheel "cffi>=1.1; python_implementation != 'PyPy'"" failed with error code 1 in None`

This appears to be caused when running the step:`pip install docker-compose` in the `gitlab-ci.yml` file which will try to install the latest version, Compose-1.24. This fix uses the previous 1.23 version of Compose:

```
- pip install docker-compose~=1.23.0
```

The latest 1.24 Compose version has new SSH support which requires new dependencies. Another option to fix the CI build is to manually install the dependencies in the `gitlab-ci.yml` file :
```
- apk add py-pip python-dev libffi-dev openssl-dev gcc libc-dev make
- pip install docker-compose
```

Yet another alternative is to replace `docker:stable` with `docker/compose:1.24.0` as base image.

The above is documented [here](https://github.com/docker/compose/issues/6617).

## Changes to the provisioning

The `gitlab-ci.yml` file has been updated to specifically install Docker Compose version 1.23.