### PR TITLE
Publishing port 5432 from database container onto port 54321 on dockerhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,17 @@ root@16b04afd18d5:/var/www# psql -h database -p 5432 -U gigadb gigadb
 ``` 
 
 >**Note:**
->Only the **test** and **application** containers have access to the 
-**database** container.
+>~~Only~~ The **test** and **application** containers have access to the 
+**database** container. In addition, you can access the PostgreSQL RDBMS in the 
+database container via the local dockerhost on port 54321. For example, you can
+use [pgAdmin](https://www.pgadmin.org) to connect to the gigadb PostgreSQL 
+database:
+
+**1.** Click on `Add New Server` and provide a `Name` for the connection in the 
+`General` tab.
+
+**2.** Click on the `Connection` tab and enter `localhost` as the `Host name/address` 
+and `54321` as the `Port` value. The `Maintenance database` is `gigadb`,  `username` is `gigadb`, and `password` is `vagrant`.
 
 For further investigation, check out the [docker-compose.yml](ops/deployment/docker-compose.yml) 
 to see how the services are assembled and what scripts they run.

--- a/ops/deployment/docker-compose.yml
+++ b/ops/deployment/docker-compose.yml
@@ -64,7 +64,10 @@ services:
       POSTGRES_USER: gigadb
       POSTGRES_PASSWORD: vagrant
     ports:
-    - "54321:5432"
+      - target: 5432
+        published: 54321
+        protocol: tcp
+        mode: host
     volumes:
       - ${DATA_SAVE_PATH}/postgres:/var/lib/postgresql/data
       - ${APPLICATION}/ops/configuration/postgresql-conf/bootstrap.sql:/docker-entrypoint-initdb.d/1-gigadb_testdata.sql

--- a/ops/deployment/docker-compose.yml
+++ b/ops/deployment/docker-compose.yml
@@ -63,13 +63,13 @@ services:
       POSTGRES_DB: gigadb
       POSTGRES_USER: gigadb
       POSTGRES_PASSWORD: vagrant
+    ports:
+    - "54321:5432"
     volumes:
       - ${DATA_SAVE_PATH}/postgres:/var/lib/postgresql/data
       - ${APPLICATION}/ops/configuration/postgresql-conf/bootstrap.sql:/docker-entrypoint-initdb.d/1-gigadb_testdata.sql
       - ${APPLICATION}/ops/configuration/postgresql-conf/pg_hba.conf:/etc/postgresql/pg_hba.conf
     command: postgres -c 'hba_file=/etc/postgresql/pg_hba.conf'
-    expose:
-      - "5432"
     networks:
       - db-tier
 


### PR DESCRIPTION
# Pull request for issue: #294 

This is a pull request for the following functionalities:

@jessesiu needs access to the GigaDB PostgreSQL database for developing custom applications on a local install of GigaDB. Another developer has requested access to the database using database tools such as pgAdmin when developing GigaDB.

Currently, the [docker-compose.yml](https://github.com/gigascience/gigadb-website/blob/develop/ops/deployment/docker-compose.yml) file tells the database container to only allow linked container services on the `db-tier` network access to PostgreSQL using the `expose` instruction.

`expose` will not allow communication via the defined ports to containers outside of the same network or to the host machine. To allow this to happen, we need to use the `ports` instruction to get port 5432 on the `database` container published to another port, e.g. `54321` on the local `dockerhost`. pgAdmin can then connect to PostgreSQL on the database container via `localhost` and port `54321`.

## Changes to the provisioning

The [docker-compose.yml](https://github.com/gigascience/gigadb-website/blob/develop/ops/deployment/docker-compose.yml) file has been altered according to the above information. An alternative, more explicit syntax of instructing the publication of port 5432 from the database container is used as suggested by @rija:
```
ports:
    - target: 5432
      published: 54321
      protocol: tcp
      mode: host
```

## Changes to the documentation

[README.md](https://github.com/pli888/gigadb-website/blob/port-5432/README.md) has been updated with instructions on how to connect pgAdmin to PostgreSQL on the database container. 

## Note on future work

For @jessesiu's work, a production GigaDB will have its dockerhost server port 54321 open. There will only be a low security risk since no connections external to the BGI network will be able to access dockerhost:54321 because of the BGI firewall.

However, if GigaDB is deployed on AWS then we will need to look into the security of having dockerhost:54321 open to external connections.