### PR TITLE
Fix application container build problems when staging GigaDB website

### DIFF
--- a/ops/packaging/Production-Dockerfile
+++ b/ops/packaging/Production-Dockerfile
@@ -1,7 +1,16 @@
 ARG PHP_VERSION=7.0
 FROM php:${PHP_VERSION}-fpm-jessie
 
-RUN apt-get update && \
+# Problem with Debian repos - adding official LTS repos to use below
+RUN echo "deb http://deb.debian.org/debian/ jessie main contrib non-free" | tee /etc/apt/sources.list && \
+    echo "deb-src http://deb.debian.org/debian/ jessie main contrib non-free" | tee -a /etc/apt/sources.list && \
+    echo "deb http://security.debian.org/ jessie/updates main contrib non-free" | tee -a /etc/apt/sources.list && \
+    echo "deb-src http://security.debian.org/ jessie/updates main contrib non-free" | tee -a /etc/apt/sources.list && \
+# the two repo below are the problematic ones, so commenting them out until debian fix them
+#    echo "deb http://deb.debian.org/debian/ jessie-updates main contrib non-free" | tee -a /etc/apt/sources.list && \
+#    echo "deb-src http://deb.debian.org/debian/ jessie-updates main contrib non-free" | tee -a /etc/apt/sources.list && \
+# basic dependencies
+    apt-get update && \
     apt-get install -y --no-install-recommends \
         curl \
         libmemcached-dev \

--- a/ops/packaging/Production-Dockerfile
+++ b/ops/packaging/Production-Dockerfile
@@ -154,7 +154,11 @@ RUN if [ ${INSTALL_TIDEWAYS_XHPROF} = true ]; then \
 ARG INSTALL_LIBSODIUM=false
 
 RUN if [ ${INSTALL_LIBSODIUM} = true ]; then \
-    echo "deb http://ftp.debian.org/debian jessie-backports main" | tee -a /etc/apt/sources.list && \
+    # Problem with using http://ftp.debian.org/debian for installing libsodium
+    # Might be related to https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html
+    # Using archive repo instead
+    echo 'Acquire::Check-Valid-Until "0";' | tee -a /etc/apt/apt.conf.d/apt.conf && \
+    echo "deb http://archive.debian.org/debian jessie-backports main" | tee -a /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y -t jessie-backports libsodium-dev && \
     pecl install libsodium && \


### PR DESCRIPTION
# Pull request for re-opened issue: #296

This is a pull request to fix application container build problems which occur when staging GigaDB web application from running the gitlab.com CI/CD pipeline. The `application` image fails to build from its [Production-Dockerfile](https://github.com/gigascience/gigadb-website/blob/develop/ops/packaging/Production-Dockerfile) due to problems with using Debian repos for installing basic dependencies and the [sodium](https://libsodium.gitbook.io/doc/) package. There appears to be problems with the Debian repos below:

- deb http://deb.debian.org/debian/ jessie-updates main contrib non-free
- deb-src http://deb.debian.org/debian/ jessie-updates main contrib non-free

Rija suggested we use the following repos:

- deb http://deb.debian.org/debian/ jessie main contrib non-free
- deb-src http://deb.debian.org/debian/ jessie main contrib non-free
- deb http://security.debian.org/ jessie/updates main contrib non-free
- deb-src http://security.debian.org/ jessie/updates main contrib non-free

The problem with installing `sodium` seems to be caused by using `http://ftp.debian.org/debian` which does not contain `jessie-backports` anymore which is explained [here](https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html). We will switch to using the [http://archive.debian.org/debian/](http://archive.debian.org/debian/) repo for installing `sodium` instead.

Basically, we forgot to update [Production-Dockerfile](https://github.com/gigascience/gigadb-website/blob/develop/ops/packaging/Production-Dockerfile) when the fixes to [Dockerfile](https://github.com/gigascience/gigadb-website/blob/develop/ops/packaging/Dockerfile) for deploying a local GigaDB web app were made.

## Changes to the provisioning

The [ops/packaging/Production-Dockerfile](https://github.com/gigascience/gigadb-website/blob/develop/ops/packaging/Production-Dockerfile) has been updated according to the above information.
