### PR TITLE
Change count numbers on the site index page

### DIFF
--- a/protected/controllers/SiteController.php
+++ b/protected/controllers/SiteController.php
@@ -485,11 +485,8 @@ class SiteController extends Controller {
 
     public function formatBytes($bytes, $precision = 2) {
         $units = array('B', 'KB', 'MB', 'GB', 'TB');
-
         $base = log($bytes, 1024);
-        $suffixes = array('', 'K', 'M', 'G', 'T');
-
-        return round(pow(1024, $base - floor($base)), $precision) .' '. $suffixes[floor($base)];
+        return round(pow(1024, $base - floor($base)), $precision) ;
     }
 
     /**

--- a/protected/tests/functional/SiteTest.php
+++ b/protected/tests/functional/SiteTest.php
@@ -56,7 +56,7 @@ class SiteTest extends FunctionalTesting
     public function testItShouldShowCountNumber()
     {
         // this is the content we expect to be in
-        $expectations = ["4", "2", "16", "2 G"];
+        $expectations = ["4", "2", "16", "2"];
         $actual = [];
         $url = "http://gigadb.dev/site/" ;
         $this->visitPageWithSessionAndUrlThenAssertContentHasOrNull($url, null);

--- a/protected/views/site/index.php
+++ b/protected/views/site/index.php
@@ -205,7 +205,7 @@
                                     <div class="home-color-background-block" onclick="window.location='/site/mapbrowse';">
                                         <div class="text-icon text-icon-o text-icon-lg">
                                             <img src="/images/new_interface_image/samples.svg" alt="Number of samples"></div>
-                                        <h4><? echo $count_sample ?></h4>
+                                        <h4><? echo number_format($count_sample) ?></h4>
                                         <p>Samples</p>
                                     </div>
                                 </div>
@@ -213,7 +213,7 @@
                                     <div class="home-color-background-block">
                                         <div class="text-icon text-icon-o text-icon-lg">
                                             <img src="/images/new_interface_image/files.svg" alt="Number of files"></div>
-                                        <h4><? echo $count_file ?></h4>
+                                        <h4><? echo number_format($count_file) ?></h4>
                                         <p>Files</p>
                                     </div>
                                 </div>
@@ -221,7 +221,7 @@
                                     <div class="home-color-background-block">
                                         <div class="text-icon text-icon-o text-icon-lg">
                                             <img src="/images/new_interface_image/volume.svg" alt="Total Volume of Data"></div>
-                                        <h4><? echo $count_size ?></h4>
+                                        <h4><? echo number_format($count_size) ?></h4>
                                         <p>Data volume(TB)</p>
                                     </div>
                                 </div>


### PR DESCRIPTION
This is a pull request for the following functionalities:

The main page shows some count numbers from the database, but the data volume number is not linked with database

http://gigadb.gigasciencejournal.com:9170

<img width="1218" alt="屏幕快照 2019-06-14 下午4 52 01" src="https://user-images.githubusercontent.com/1147873/59496900-fe23bd00-8ec4-11e9-8045-a5e10e804175.png">


## Changes to the controller classes

The SiteController actionIndex function changed, add new sql statement to sum all published datasets size and convert to TB unit then show on the main page.


## Changes to the tests

Add unit test in protected/tests/functional/SiteTest.php, to assert count numbers are correct


