### PR TITLE
Fix affiliate sign in with LinkedIn

### DIFF
--- a/features/bootstrap/AffiliateLoginContext.php
+++ b/features/bootstrap/AffiliateLoginContext.php
@@ -307,7 +307,12 @@ class AffiliateLoginContext implements Context
             if( $this->minkContext->getSession()->getPage()->findButton("Allow") ) {
                 $this->minkContext->pressButton("Allow");
             }
-
+        }
+        else if ($arg1 == "LinkedIn") {
+            $this->minkContext->getSession()->wait(15000, '(typeof jQuery != "undefined" && 0 === jQuery.active)');
+            if( $this->minkContext->getSession()->getPage()->findButton("Allow") ) {
+                $this->minkContext->pressButton("Allow");
+            }
         }
         else if ($arg1 == "Orcid") {
             $this->minkContext->getSession()->wait(15000, '(typeof jQuery != "undefined" && 0 === jQuery.active)');

--- a/ops/configuration/php-conf/composer.json.dist
+++ b/ops/configuration/php-conf/composer.json.dist
@@ -16,7 +16,7 @@
         "opauth/facebook": "^0.4.2",
         "opauth/twitter": "^0.3.2",
         "opauth/google": "^0.2.2",
-        "opauth/linkedin": "^0.2.0",
+        "opauth/linkedin": "^0.3.0",
         "drewm/mailchimp-api": "^v2.5"
     },
     "require-dev": {


### PR DESCRIPTION
# Pull request for issue: #408

This is a pull request for the following functionalities:

* Fix affiliate sign in with LinkedIn

LinkedIn v1 API has been deprecated since May 2019 and problems in its
use can arise. GigaDB must have been using the v1 API and is
probably the reason why the corresponding LinkedIn acceptance test
was failing.

## Changes to the provisioning

To use LinkedIn v2 API, version `0.3.0` of the PHP `opauth/linkedin`
package is required; we had been using version `0.2.0`. Therefore,
the `opauth/linkedin` version requirement in `composer.json.dist` 
has been updated from `0.2.0` to `0.3.0`.

## Changes to the tests

The function `iAuthoriseGigadbFor($arg1)` in `AffiliateLoginContext.php`
now has a LinkedIn condition which will get Mink to click the Allow
button when LinkedIn requests the user to enable LinkedIn sign in to
log into the user's GigaDB account.

Issue #408 also describes tests failing for affiliate sign in with Google
(testerbotunleashed919468) and Twitter (testerbot_unleashed919468)
credentials. These were rectified using new registered email addresses.
