### PR TITLE
Disable ORCID acceptance tests

### DIFF
--- a/features/affiliate-login.feature
+++ b/features/affiliate-login.feature
@@ -58,16 +58,16 @@ SO THAT I can upload and manage the datasets for my papers
 		Then I'm logged in into the Gigadb web site
 		And a new Gigadb account is created with my "LinkedIn" details
 
-	#@ok @orcid @javascript @done
-	#Scenario: I sign in with ORCID with no existing Gigadb account
-		#Given I have a "Orcid" account
-		#But I don't have a Gigadb account for my "Orcid" account email
-		#When I am on "/site/login"
-		#And I click on the "ORCID" button
-		#And I sign in to "Orcid"
-		#And I authorise gigadb for "Orcid"
-		#Then I'm logged in into the Gigadb web site
-		#And a new Gigadb account is created with my "Orcid" details
+	@ok @orcid @javascript @done
+	Scenario: I sign in with ORCID with no existing Gigadb account
+		Given I have a "Orcid" account
+		But I don't have a Gigadb account for my "Orcid" account email
+		When I am on "/site/login"
+		And I click on the "ORCID" button
+		And I sign in to "Orcid"
+		And I authorise gigadb for "Orcid"
+		Then I'm logged in into the Gigadb web site
+		And a new Gigadb account is created with my "Orcid" details
 
 	@ok @facebook @javascript @done
 	Scenario: I have a Gigadb account and I sign in with my "Facebook" credentials

--- a/tests/acceptance
+++ b/tests/acceptance
@@ -20,7 +20,7 @@ fi
 
 echo "Running acceptance tests"
 if [[ "$GIGADB_ENV" == "dev" ]];then
-	bin/behat --tags "@ok&&~@facebook" -v --stop-on-failure
+	bin/behat --tags "@ok&&~@facebook&&~orcid" -v --stop-on-failure
 else
 	# we are on CI with remote runner, affilate login tests don't work becasause Google and Twitter block it
 	bin/behat --tags "@ok&&~@affiliate-login&&~@javascript" -v --stop-on-failure


### PR DESCRIPTION
Pull request for issue: #408

This is a pull request for the following functionalities:

Since the ORCID sign in button has been commented out on `/site/login` page, the ORCID acceptance tests are failing. Therefore, all ORCID tests are now excluded from running locally.

## Changes to the tests

ORCID tests have been excluded from running using a tilde character in the `acceptance` bash script. Originally, the `I sign in with ORCID with no existing Gigadb account` test in `affiliate-login.feature` had been commented out. This uncommented now but it will still not run because of the ORCID test exclusion in the `acceptance` bash script.

