### PR TITLE
Displaying website images in local and staging GigaDB

### DIFF
--- a/ops/deployment/docker-compose.build.yml
+++ b/ops/deployment/docker-compose.build.yml
@@ -14,7 +14,7 @@ services:
         - GIGADB_ENV=${GIGADB_ENV}
     volumes:
       - ../../assets:/var/www/assets
-      - ../../images:/var/www/images
+#      - ../../images:/var/www/images
 
   production_app:
     build:

--- a/ops/deployment/docker-compose.build.yml
+++ b/ops/deployment/docker-compose.build.yml
@@ -14,6 +14,7 @@ services:
         - GIGADB_ENV=${GIGADB_ENV}
     volumes:
       - ../../assets:/var/www/assets
+      - ../../images:/var/www/images
 
   production_app:
     build:

--- a/ops/deployment/docker-compose.build.yml
+++ b/ops/deployment/docker-compose.build.yml
@@ -14,7 +14,6 @@ services:
         - GIGADB_ENV=${GIGADB_ENV}
     volumes:
       - ../../assets:/var/www/assets
-#      - ../../images:/var/www/images
 
   production_app:
     build:

--- a/ops/deployment/docker-compose.build.yml
+++ b/ops/deployment/docker-compose.build.yml
@@ -8,7 +8,7 @@ services:
       YII2_PATH: ${YII2_PATH}
     build:
       context: ../..
-      dockerfile: ops/packaging/Web-Dockerfile
+      dockerfile: ops/packaging/Production-Web-Dockerfile
       args:
         - NGINX_VERSION=${NGINX_VERSION}
         - GIGADB_ENV=${GIGADB_ENV}

--- a/ops/deployment/docker-compose.staging.yml
+++ b/ops/deployment/docker-compose.staging.yml
@@ -13,7 +13,7 @@ services:
       - le_webrootpath:/var/www/.le
 #      - tempcaptcha:/var/www/images/tempcaptcha
       - type: bind
-        source: /tmp/tempcaptcha
+        source: /tmp
         target: /var/www/images/tempcaptcha
     ports:
       - "${STAGING_PUBLIC_HTTP_PORT}:80"

--- a/ops/deployment/docker-compose.staging.yml
+++ b/ops/deployment/docker-compose.staging.yml
@@ -11,10 +11,10 @@ services:
       - assets:/var/www/assets
       - le_config:/etc/letsencrypt
       - le_webrootpath:/var/www/.le
-      - tempcaptcha:/var/www/images/tempcaptcha
-#      - type: bind
-#        source: /tmp/tempcaptcha
-#        target: /var/www/images/tempcaptcha
+#      - tempcaptcha:/var/www/images/tempcaptcha
+      - type: bind
+        source: /tmp/tempcaptcha
+        target: /var/www/images/tempcaptcha
     ports:
       - "${STAGING_PUBLIC_HTTP_PORT}:80"
       - "${STAGING_PUBLIC_HTTPS_PORT}:443"

--- a/ops/deployment/docker-compose.staging.yml
+++ b/ops/deployment/docker-compose.staging.yml
@@ -11,10 +11,10 @@ services:
       - assets:/var/www/assets
       - le_config:/etc/letsencrypt
       - le_webrootpath:/var/www/.le
-#      - tempcaptcha:/var/www/images/tempcaptcha
-      - type: bind
-        source: /tmp
-        target: /var/www/images/tempcaptcha
+      - tempcaptcha:/var/www/images/tempcaptcha
+#      - type: bind
+#        source: /tmp
+#        target: /var/www/images/tempcaptcha
     ports:
       - "${STAGING_PUBLIC_HTTP_PORT}:80"
       - "${STAGING_PUBLIC_HTTPS_PORT}:443"
@@ -45,6 +45,10 @@ services:
       YII2_PATH: ${YII2_PATH}
     volumes:
       - assets:/var/www/assets
+      - tempcaptcha:/var/www/images/tempcaptcha
+#      - type: bind
+#      source: /tmp
+#      target: /var/www/images/tempcaptcha
     expose:
       - "9000"
     networks:

--- a/ops/deployment/docker-compose.staging.yml
+++ b/ops/deployment/docker-compose.staging.yml
@@ -13,7 +13,7 @@ services:
       - le_webrootpath:/var/www/.le
       - tempcaptcha:/var/www/images/tempcaptcha
 #      - type: bind
-#        source: /tmp
+#        source: /tmp/tempcaptcha
 #        target: /var/www/images/tempcaptcha
     ports:
       - "${STAGING_PUBLIC_HTTP_PORT}:80"

--- a/ops/deployment/docker-compose.staging.yml
+++ b/ops/deployment/docker-compose.staging.yml
@@ -12,9 +12,6 @@ services:
       - le_config:/etc/letsencrypt
       - le_webrootpath:/var/www/.le
       - tempcaptcha:/var/www/images/tempcaptcha
-#      - type: bind
-#        source: /tmp
-#        target: /var/www/images/tempcaptcha
     ports:
       - "${STAGING_PUBLIC_HTTP_PORT}:80"
       - "${STAGING_PUBLIC_HTTPS_PORT}:443"
@@ -46,9 +43,6 @@ services:
     volumes:
       - assets:/var/www/assets
       - tempcaptcha:/var/www/images/tempcaptcha
-#      - type: bind
-#      source: /tmp
-#      target: /var/www/images/tempcaptcha
     expose:
       - "9000"
     networks:

--- a/ops/deployment/docker-compose.staging.yml
+++ b/ops/deployment/docker-compose.staging.yml
@@ -11,9 +11,10 @@ services:
       - assets:/var/www/assets
       - le_config:/etc/letsencrypt
       - le_webrootpath:/var/www/.le
-      - type: bind
-        source: /tmp
-        target: /var/www/images/tempcaptcha
+      - tempcaptcha:/var/www/images/tempcaptcha
+#      - type: bind
+#        source: /tmp
+#        target: /var/www/images/tempcaptcha
     ports:
       - "${STAGING_PUBLIC_HTTP_PORT}:80"
       - "${STAGING_PUBLIC_HTTPS_PORT}:443"
@@ -85,4 +86,5 @@ volumes:
   assets:
   le_config:
   le_webrootpath:
+  tempcaptcha:
 

--- a/ops/deployment/docker-compose.staging.yml
+++ b/ops/deployment/docker-compose.staging.yml
@@ -11,6 +11,9 @@ services:
       - assets:/var/www/assets
       - le_config:/etc/letsencrypt
       - le_webrootpath:/var/www/.le
+      - type: bind
+        source: /tmp
+        target: /var/www/images/tempcaptcha
     ports:
       - "${STAGING_PUBLIC_HTTP_PORT}:80"
       - "${STAGING_PUBLIC_HTTPS_PORT}:443"

--- a/ops/deployment/docker-compose.yml
+++ b/ops/deployment/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - "${PUBLIC_HTTPS_PORT}:443"
     volumes:
       - ${APPLICATION}/assets:/var/www/assets
+      - ${APPLICATION}/images:/var/www/images
       - ${APPLICATION}/css:/var/www/css
       - le_config:/etc/letsencrypt
       - le_webrootpath:/var/www/.le

--- a/ops/packaging/Production-Web-Dockerfile
+++ b/ops/packaging/Production-Web-Dockerfile
@@ -1,0 +1,24 @@
+ARG NGINX_VERSION=1.15
+FROM nginx:${NGINX_VERSION}-alpine
+
+ARG GIGADB_ENV=dev
+
+COPY ops/configuration/nginx-conf/sites/gigadb.${GIGADB_ENV}.* /etc/nginx/sites-available/
+COPY ops/configuration/nginx-conf/nginx.conf /etc/nginx/nginx.conf
+COPY ops/configuration/nginx-conf/upstream.conf /etc/nginx/conf.d/upstream.conf
+COPY css /var/www/css
+COPY docs /var/www/docs
+COPY favicon.ico /var/www/favicon.ico
+COPY fonts /var/www/fonts
+COPY images /var/www/images
+COPY index.php /var/www/index.php
+COPY js /var/www/js
+COPY less /var/www/less
+
+RUN apk --no-cache add openssl && \
+    mkdir -vp /etc/ssl/nginx && chmod 700 /etc/ssl/nginx && \
+    mkdir -vp /etc/ssl/nginx/certs && chmod 700 /etc/ssl/nginx/certs && \
+    mkdir -vp /var/www/.le && \
+    openssl dhparam -out /etc/ssl/nginx/dhparam.pem 2048 && \
+    mkdir -vp /etc/nginx/sites-enabled && \
+    ln -s /etc/nginx/sites-available/gigadb.${GIGADB_ENV}.http.conf /etc/nginx/sites-enabled/http.server.conf

--- a/ops/packaging/Web-Dockerfile
+++ b/ops/packaging/Web-Dockerfile
@@ -10,7 +10,6 @@ COPY css /var/www/css
 COPY docs /var/www/docs
 COPY favicon.ico /var/www/favicon.ico
 COPY fonts /var/www/fonts
-COPY images /var/www/images
 COPY index.php /var/www/index.php
 COPY js /var/www/js
 COPY less /var/www/less

--- a/protected/controllers/SiteController.php
+++ b/protected/controllers/SiteController.php
@@ -501,7 +501,7 @@ class SiteController extends Controller {
     		$font = '/fonts/times_new_yorker.ttf';
     		imagettftext($im, 70, 0, 20, 80, $black, $font, $text);
 
-    		imagejpeg($im, 'images/tempcaptcha/'.$text.".png");
+    		imagepng($im, 'images/tempcaptcha/'.$text.".png");
     		imagedestroy($im);
     		$_SESSION["captcha"] = $text;
     		return $text;

--- a/protected/tests/functional/CaptchaImageTest.php
+++ b/protected/tests/functional/CaptchaImageTest.php
@@ -33,9 +33,7 @@ class CaptchaImageTest extends FunctionalTesting
         // Get size info for captcha image
         $img_url = 'http://gigadb.dev'.$img_path;
         $img_size = getimagesize($img_url);
-        $img_mime = strtolower(substr($img_size['mime'], 0, 5));
-
-        $this->assertEquals("image", $img_mime, $img_url." is not an image");
+        $this->assertEquals("image/png", $img_size['mime'], $img_url." is not a PNG image");
         $this->assertEquals("600", $img_size[0], "Captcha image has wrong width");
         $this->assertEquals("100", $img_size[1], "Captcha image has wrong height");
     }

--- a/protected/tests/functional/CaptchaImageTest.php
+++ b/protected/tests/functional/CaptchaImageTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Functional test for captcha image display
+ *
+ * @author Peter Li <peter+git@gigasciencejournal.com>
+ * @license GPL-3.0
+ */
+class CaptchaImageTest extends FunctionalTesting
+{
+    use BrowserPageSteps;
+
+    /**
+     * The /site/contact page should display a captcha image
+     *
+     * @uses \BrowserPageSteps::getTagsWithSessionAndUrl($url, $tag)
+     */
+    public function testItShouldDisplayCaptchaImageOnContactPage() {
+
+        // Go to Contact page
+        $url = "http://gigadb.dev/site/contact";
+        $img_tags = $this->getTagsWithSessionAndUrl($url, "img");
+        $img_path = "";
+        foreach($img_tags[0] as $img_tag)
+        {
+            // Extract src metadata for captcha img tag
+            if (strpos($img_tag, 'tempcaptcha') !== false) {
+                preg_match('/<img(.*)src(.*)=(.*)"(.*)"/U', $img_tag, $matches);
+                $img_path = array_pop($matches);
+            }
+        }
+        $this->assertFalse($img_path == "", "Could not find a path to a captcha image");
+
+        // Get size info for captcha image
+        $img_url = 'http://gigadb.dev'.$img_path;
+        $img_size = getimagesize($img_url);
+        $img_mime = strtolower(substr($img_size['mime'], 0, 5));
+
+        $this->assertEquals("image", $img_mime, $img_url." is not an image");
+        $this->assertEquals("600", $img_size[0], "Captcha image has wrong width");
+        $this->assertEquals("100", $img_size[1], "Captcha image has wrong height");
+    }
+}
+
+?>

--- a/protected/tests/support/BrowserPageSteps.php
+++ b/protected/tests/support/BrowserPageSteps.php
@@ -48,6 +48,22 @@ trait BrowserPageSteps
         return $feed;
 	}
 
+    /**
+     * Visit a page at $url, fetch content and return metadata for a given $tag
+     *
+     * @param string $url
+     * @return string[][]
+     */
+    public function getTagsWithSessionAndUrl($url, $tag)
+    {
+        $this->session->visit($url);
+        $html = $this->session->getPage()->getContent();
+        // Match text in $html with regexp and output results to array. Matches
+        // are case insensitive with "i" option
+        preg_match_all('/<'.$tag.'[^>]+>/i', $html, $matching_tags);
+        return $matching_tags;
+    }
+
 	/**
 	 * Assert for presence of $content in the current page
 	 *


### PR DESCRIPTION
# Pull request for issue: #342 

This is a pull request for the following functionalities:

* Fix problems with displaying images in GigaDB website on local and staging deployments

## Changes to the provisioning

When new images are added into a local deployment of GigaDB, they cannot be seen on the website since images are baked into the **web** Docker image. This has been addressed by mounting the `images` directory as a volume into the **web** container in `docker-compose.yml`. Image files are no longer copied into the Docker **web** image in `Web-Dockerfile`. New images added to a local GigaDB are now immediately visible on the web site.

The `Web-Dockerfile` was being used to create the  **web** Docker container for the staging server. Since image files are no longer being baked into it because of the above change, the consequence was that website images were missing in the GigaDB website on the staging server. A new `Production-Web-Dockerfile` has been created with the `COPY images /var/www/images` instruction reinstated which the **web** container for the staging server now uses so that it again has access to the website image files.

Another problem occurred with captcha images not being displayed by GigaDB on the staging server. These captcha images are programmatically created by the **production_app** container in `/var/www/images/tempcaptcha`. This folder is not available to the **web** container which is why they were not being seen on the website. This directory is now mounted as a volume and made available to the **web** container *via* `docker-compose.staging.yml`.

## Changes to the tests

A functional test in `CaptchaImageTest.php` has been written to check for the presence of a captcha image on the contact web page at `/site/contact`. It uses a new function called `getTagsWithSessionAndUrl($url, $tag)` in `BrowserPageSteps.php` to return HTML `img` tags in the `/site/contact` web page. The functional test looks for the captcha img tag to parse out its `src` metadata which it uses to reconstruct the URL for the captcha image. This image is then downloaded and checked that it is an actual image with the expected size dimensions.
