### PR TITLE
Update default columns in the table setting

### DIFF
--- a/features/bootstrap/DatasetViewContext.php
+++ b/features/bootstrap/DatasetViewContext.php
@@ -282,20 +282,26 @@ class DatasetViewContext implements Context
                     $this->minkContext->getSession()->getPage()->hasContent($row['File name']), "File name match"
                 );
                 PHPUnit_Framework_Assert::assertTrue(
-                    $this->minkContext->getSession()->getPage()->hasContent($row['Sample ID']), "Sample ID match"
+                    $this->minkContext->getSession()->getPage()->hasContent($row['Description']), "Description match"
                 );
+//                PHPUnit_Framework_Assert::assertTrue(
+//                    $this->minkContext->getSession()->getPage()->hasContent($row['Sample ID']), "Sample ID match"
+//                );
                 PHPUnit_Framework_Assert::assertTrue(
                     $this->minkContext->getSession()->getPage()->hasContent($row['Data Type']), "Data Type match"
                 );
-                PHPUnit_Framework_Assert::assertTrue(
-                    $this->minkContext->getSession()->getPage()->hasContent($row['File Format']), "File Format match"
-                );
+//                PHPUnit_Framework_Assert::assertTrue(
+//                    $this->minkContext->getSession()->getPage()->hasContent($row['File Format']), "File Format match"
+//                );
                 PHPUnit_Framework_Assert::assertTrue(
                     $this->minkContext->getSession()->getPage()->hasContent($row['Size']), "Size match"
                 );
                 PHPUnit_Framework_Assert::assertTrue(
-                    $this->minkContext->getSession()->getPage()->hasContent($row['Release date']), "Release date match"
+                    $this->minkContext->getSession()->getPage()->hasContent($row['File Attributes']), "File Attributes match"
                 );
+//                PHPUnit_Framework_Assert::assertTrue(
+//                    $this->minkContext->getSession()->getPage()->hasContent($row['Release date']), "Release date match"
+//                );
                 if ($link) {
                     $this->minkContext->assertSession()->elementExists('css',"a.download-btn[href='$link']");
                 }

--- a/features/bootstrap/DatasetViewContext.php
+++ b/features/bootstrap/DatasetViewContext.php
@@ -275,11 +275,11 @@ class DatasetViewContext implements Context
             }
         }
         elseif("Files" == $arg1) {
-            //| File name                                        | Sample ID  | Data Type         | File Format | Size      | Release date | link |
+            //| File Name                                        | Sample ID  | Data Type         | File Format | Size      | Release date | link |
             foreach($table as $row) {
                 $link = $row['link'];
                 PHPUnit_Framework_Assert::assertTrue(
-                    $this->minkContext->getSession()->getPage()->hasContent($row['File name']), "File name match"
+                    $this->minkContext->getSession()->getPage()->hasContent($row['File Name']), "File Name match"
                 );
                 PHPUnit_Framework_Assert::assertTrue(
                     $this->minkContext->getSession()->getPage()->hasContent($row['Description']), "Description match"
@@ -333,22 +333,22 @@ class DatasetViewContext implements Context
      */
     public function iShouldNotSeeTabWithTable($arg1, TableNode $table)
     {
-        //| File name                                        | Sample ID  | Data Type         | File Format | Size      | Release date | link |
+        //| File Name                                        | Sample ID  | Data Type         | File Format | Size      | Release date | link |
         foreach($table as $row) {
             if ("Files" == $arg1) {
                 PHPUnit_Framework_Assert::assertFalse(
-                    $this->minkContext->getSession()->getPage()->hasContent($row['File name']), "File name match"
+                    $this->minkContext->getSession()->getPage()->hasContent($row['File Name']), "File Name match"
                 );
             }
             elseif("Sample" == $arg1) {
                 if ($row['Sample ID']) {
                     PHPUnit_Framework_Assert::assertFalse(
-                        $this->minkContext->getSession()->getPage()->hasContent($row['Sample ID']), "File name match"
+                        $this->minkContext->getSession()->getPage()->hasContent($row['Sample ID']), "File Name match"
                     );
                 }
                 if ($row['Common Name']) {
                     PHPUnit_Framework_Assert::assertFalse(
-                        $this->minkContext->getSession()->getPage()->hasContent($row['Common Name']), "File name match"
+                        $this->minkContext->getSession()->getPage()->hasContent($row['Common Name']), "File Name match"
                     );
                 }
             }

--- a/features/bootstrap/DatasetViewContext.php
+++ b/features/bootstrap/DatasetViewContext.php
@@ -284,24 +284,15 @@ class DatasetViewContext implements Context
                 PHPUnit_Framework_Assert::assertTrue(
                     $this->minkContext->getSession()->getPage()->hasContent($row['Description']), "Description match"
                 );
-//                PHPUnit_Framework_Assert::assertTrue(
-//                    $this->minkContext->getSession()->getPage()->hasContent($row['Sample ID']), "Sample ID match"
-//                );
                 PHPUnit_Framework_Assert::assertTrue(
                     $this->minkContext->getSession()->getPage()->hasContent($row['Data Type']), "Data Type match"
                 );
-//                PHPUnit_Framework_Assert::assertTrue(
-//                    $this->minkContext->getSession()->getPage()->hasContent($row['File Format']), "File Format match"
-//                );
                 PHPUnit_Framework_Assert::assertTrue(
                     $this->minkContext->getSession()->getPage()->hasContent($row['Size']), "Size match"
                 );
                 PHPUnit_Framework_Assert::assertTrue(
                     $this->minkContext->getSession()->getPage()->hasContent($row['File Attributes']), "File Attributes match"
                 );
-//                PHPUnit_Framework_Assert::assertTrue(
-//                    $this->minkContext->getSession()->getPage()->hasContent($row['Release date']), "Release date match"
-//                );
                 if ($link) {
                     $this->minkContext->assertSession()->elementExists('css',"a.download-btn[href='$link']");
                 }

--- a/features/bootstrap/DatasetViewContext.php
+++ b/features/bootstrap/DatasetViewContext.php
@@ -343,12 +343,12 @@ class DatasetViewContext implements Context
             elseif("Sample" == $arg1) {
                 if ($row['Sample ID']) {
                     PHPUnit_Framework_Assert::assertFalse(
-                        $this->minkContext->getSession()->getPage()->hasContent($row['Sample ID']), "File Name match"
+                        $this->minkContext->getSession()->getPage()->hasContent($row['Sample ID']), "Sample ID match"
                     );
                 }
                 if ($row['Common Name']) {
                     PHPUnit_Framework_Assert::assertFalse(
-                        $this->minkContext->getSession()->getPage()->hasContent($row['Common Name']), "File Name match"
+                        $this->minkContext->getSession()->getPage()->hasContent($row['Common Name']), "Common Name match"
                     );
                 }
             }

--- a/features/bootstrap/DatasetViewContext.php
+++ b/features/bootstrap/DatasetViewContext.php
@@ -275,7 +275,7 @@ class DatasetViewContext implements Context
             }
         }
         elseif("Files" == $arg1) {
-            //| File Name                                        | Sample ID  | Data Type         | File Format | Size      | Release date | link |
+            //| File Name | Description | Data Type | Size | File Attributes | link |
             foreach($table as $row) {
                 $link = $row['link'];
                 PHPUnit_Framework_Assert::assertTrue(

--- a/features/bootstrap/DatasetViewContext.php
+++ b/features/bootstrap/DatasetViewContext.php
@@ -338,9 +338,9 @@ class DatasetViewContext implements Context
     }
 
     /**
-     * @Then I sould not see :arg1 tab with table
+     * @Then I should not see :arg1 tab with table
      */
-    public function iSouldNotSeeTabWithTable($arg1, TableNode $table)
+    public function iShouldNotSeeTabWithTable($arg1, TableNode $table)
     {
         //| File name                                        | Sample ID  | Data Type         | File Format | Size      | Release date | link |
         foreach($table as $row) {

--- a/features/dataset-view.feature
+++ b/features/dataset-view.feature
@@ -184,7 +184,11 @@ Feature: a user visit the dataset page
 	Scenario: Files
 		Given I am not logged in to Gigadb web site
 		When I go to "/dataset/101001"
+		#When I go to "/dataset/100004"
 		Then I should see "Files" tab with table
+#		| File name        | Description                                               | Data Type         | Size          | File Attribute| Link |
+#		| CS-master.tar.gz | compressed archive of the Analysis scripts (CS) files     | Script            | 114B          |               | ftp://climb.genomics.cn/pub/10.5524/100001_101000/100094/CS-master.tar.gz |
+#		| GD-master.tar.gz | compressed archive of the mock data and scripts GD files  | Mixed archive     | 163B          |               | ftp://climb.genomics.cn/pub/10.5524/100001_101000/100094/GD-master.tar.gz |
 		| File name              							| Sample ID  	| Data Type       	| File Format 	| Size  		| Release date| link |
 		| Anas_platyrhynchos.cds 							| Pekin duck 	| Coding sequence  	| FASTA 	   	| 21.50 MiB     | 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.cds |
 	 	| Anas_platyrhynchos.gff 							| Pekin duck 	| Annotation 		| GFF        	| 10.10 MiB 	| 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.gff |

--- a/features/dataset-view.feature
+++ b/features/dataset-view.feature
@@ -180,12 +180,12 @@ Feature: a user visit the dataset page
 		When I go to "/dataset/101001"
 		Then I should see "JBrowse" tab with text "Open the JBrowse"
 
-	@wip @files
+	@ok @files @pr464
 	Scenario: Files
 		Given I am not logged in to Gigadb web site
 		When I go to "/dataset/101001"
 		Then I should see "Files" tab with table
-		| File Name              							| Description  	                                                                    | Data Type       	| Size  		| File Attributes | link |
+		| File name              							| Description  	                                                                    | Data Type       	| Size  		| File Attributes | link |
 		| Anas_platyrhynchos.cds 							| predicted coding sequences from draft genome, confirmed with RNAseq data.	        | Coding sequence  	| 21.50 MiB     |                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.cds |
 		| Anas_platyrhynchos.gff 							| genome annotations	                                                            | Annotation 		| 10.10 MiB 	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.gff |
 		| Anas_platyrhynchos.pep 							| amino acid translations of coding sequences                                       | Protein sequence 	| 7.80 MiB  	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.pep |
@@ -193,15 +193,6 @@ Feature: a user visit the dataset page
 		| duck.scafSeq.gapFilled.noMito 					| draft genome assembly                                                             | Sequence assembly	| 1.03 GiB 		|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/duck.scafSeq.gapFilled.noMito |
 		| pre_03AUG2015_update 								| folder containing originally submitted data files, prior to update Aug 3rd 2015.	| Directory 		| 50.00 MiB 	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/pre_03AUG2015_update |
 		| readme.txt 										|				                                                                    | Readme 			| 337 B 		|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/readme.txt |
-
-#		| File name              							| Sample ID  	| Data Type       	| File Format 	| Size  		| Release date| link |
-#		| Anas_platyrhynchos.cds 							| Pekin duck 	| Coding sequence  	| FASTA 	   	| 21.50 MiB     | 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.cds |
-#	 	| Anas_platyrhynchos.gff 							| Pekin duck 	| Annotation 		| GFF        	| 10.10 MiB 	| 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.gff |
-#		| Anas_platyrhynchos.pep 							| Pekin duck 	| Protein sequence 	| FASTA      	| 7.80 MiB  	| 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.pep |
-#		| Anas_platyrhynchos_domestica.RepeatMasker.out.gz 	| Pekin duck 	| Other 			| UNKNOWN    	| 7.79 MiB  	| 2015-03-23  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos_domestica.RepeatMasker.out.gz |
-#		| duck.scafSeq.gapFilled.noMito 					| Pekin duck 	| Sequence assembly	| FASTA 		| 1.03 GiB 		| 2013-01-23  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/duck.scafSeq.gapFilled.noMito |
-#		| pre_03AUG2015_update 								|				| Directory 		| UNKNOWN 		| 50.00 MiB 	| 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/pre_03AUG2015_update |
-#		| readme.txt 										|				| Readme 			| TEXT 			| 337 B 		| 2013-01-23  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/readme.txt |
 
 	@ok @files @pr464
 	Scenario: Files - Call to Actions

--- a/features/dataset-view.feature
+++ b/features/dataset-view.feature
@@ -314,7 +314,7 @@ Feature: a user visit the dataset page
 		And I should see a button "Save changes" with no link
 		And I should see a button "Close" with no link
 
-	@ok @samples @javascript
+	@ok @samples @javascript @pr464
 	Scenario: Samples - Items per page
 		Given I am not logged in to Gigadb web site
 		And I am on "/dataset/100197"
@@ -327,11 +327,11 @@ Feature: a user visit the dataset page
 		| Ssol.cltw.A.07 	| |	Schistocephalus solidus |	Description:short PE reads| 70667 | |
 		| Ssol.cltw.A.12 	| |	Schistocephalus solidus |	Description:long PE reads | 70667 | |
 		| Ssol.cltw.I.01 	| |	Schistocephalus solidus |	Description:short PE reads| 70667 | |
-		And I sould not see "Sample" tab with table
+		And I should not see "Sample" tab with table
 		| Sample ID 	 |
 		| Ssol.cltw.I.67 |
 
-	@ok @samples @javascript
+	@ok @samples @javascript @pr464
 	Scenario: Samples - Columns
 		Given I am not logged in to Gigadb web site
 		And I am on "/dataset/101001"
@@ -343,7 +343,7 @@ Feature: a user visit the dataset page
 		Then I should see "Sample" tab with table
 		| Sample ID  	| Scientific Name 			| Sample Attributes | Taxonomic ID | Genbank Name |
 		| Pekin duck 	| Anas platyrhynchos 	| Estimated genome size:1.4 | 8839  |	mallard |
-		And I sould not see "Sample" tab with table
+		And I should not see "Sample" tab with table
 		| Common Name 	 |
 		| Mallard duck |
 

--- a/features/dataset-view.feature
+++ b/features/dataset-view.feature
@@ -231,7 +231,7 @@ Feature: a user visit the dataset page
 		And I should see a button "Save changes" with no link
 		And I should see a button "Close" with no link
 
-	@wip @pageSize @files @javascript @pr464
+	@ok @pageSize @files @javascript @pr464
 	Scenario: Files - Items per page
 		Given I am not logged in to Gigadb web site
 		And I am on "/dataset/101001"

--- a/features/dataset-view.feature
+++ b/features/dataset-view.feature
@@ -180,7 +180,7 @@ Feature: a user visit the dataset page
 		When I go to "/dataset/101001"
 		Then I should see "JBrowse" tab with text "Open the JBrowse"
 
-	@ok @files
+	@wip @files
 	Scenario: Files
 		Given I am not logged in to Gigadb web site
 		When I go to "/dataset/101001"
@@ -258,7 +258,7 @@ Feature: a user visit the dataset page
 		| pre_03AUG2015_update |
 		| readme.txt |
 
-	@wip @files
+	@ok @files @pr464
 	Scenario: Files - Columns
 		Given I am not logged in to Gigadb web site
 		And I am on "/dataset/101001"

--- a/features/dataset-view.feature
+++ b/features/dataset-view.feature
@@ -185,7 +185,7 @@ Feature: a user visit the dataset page
 		Given I am not logged in to Gigadb web site
 		When I go to "/dataset/101001"
 		Then I should see "Files" tab with table
-		| File name              							| Description  	                                                                    | Data Type       	| Size  		| File Attributes | link |
+		| File Name              							| Description  	                                                                    | Data Type       	| Size  		| File Attributes | link |
 		| Anas_platyrhynchos.cds 							| predicted coding sequences from draft genome, confirmed with RNAseq data.	        | Coding sequence  	| 21.50 MiB     |                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.cds |
 		| Anas_platyrhynchos.gff 							| genome annotations	                                                            | Annotation 		| 10.10 MiB 	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.gff |
 		| Anas_platyrhynchos.pep 							| amino acid translations of coding sequences                                       | Protein sequence 	| 7.80 MiB  	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.pep |
@@ -238,14 +238,14 @@ Feature: a user visit the dataset page
 		When I follow "Files"
 		And I have set pageSize to "5" on "files_table_settings"
 		Then I should see "Files" tab with table
-		| File name              							| Description  	                                                                    | Data Type       	| Size  		| File Attributes | link |
+		| File Name              							| Description  	                                                                    | Data Type       	| Size  		| File Attributes | link |
 		| Anas_platyrhynchos.cds 							| predicted coding sequences from draft genome, confirmed with RNAseq data.	        | Coding sequence  	| 21.50 MiB     |                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.cds |
 		| Anas_platyrhynchos.gff 							| genome annotations	                                                            | Annotation 		| 10.10 MiB 	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.gff |
 		| Anas_platyrhynchos.pep 							| amino acid translations of coding sequences                                       | Protein sequence 	| 7.80 MiB  	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.pep |
 		| Anas_platyrhynchos_domestica.RepeatMasker.out.gz 	| repeat masker output 	                                                            | Other 			| 7.79 MiB  	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos_domestica.RepeatMasker.out.gz |
 		| duck.scafSeq.gapFilled.noMito 					| draft genome assembly                                                             | Sequence assembly	| 1.03 GiB 		|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/duck.scafSeq.gapFilled.noMito |
 		And I should not see "Files" tab with table
-		| File name |
+		| File Name |
 		| pre_03AUG2015_update |
 		| readme.txt |
 
@@ -260,7 +260,7 @@ Feature: a user visit the dataset page
 		And I uncheck "location"
 		And I follow "save-files-settings"
 		Then I should see "Files" tab with table
-		| File name | Description |  Data Type    | Size  		| File Attributes|
+		| File Name | Description |  Data Type    | Size  		| File Attributes|
 		| Anas_platyrhynchos.cds | predicted coding sequences from draft genome, confirmed with RNAseq data. | Coding sequence  	| 21.50 MiB     |  |
 
 	@ok @files @javascript @pr464
@@ -273,7 +273,7 @@ Feature: a user visit the dataset page
 		# And I take a screenshot named "Files tab before clicking pager"
 		And I follow "2"
 		Then I should see "Files" tab with table
-		| File name              							| Description  	                                                                    | Data Type       	| Size  		| File Attributes | link |
+		| File Name              							| Description  	                                                                    | Data Type       	| Size  		| File Attributes | link |
 		| pre_03AUG2015_update 								| folder containing originally submitted data files, prior to update Aug 3rd 2015.	| Directory 		| 50.00 MiB 	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/pre_03AUG2015_update |
 		| readme.txt 										|				                                                                    | Readme 			| 337 B 		|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/readme.txt |
 

--- a/features/dataset-view.feature
+++ b/features/dataset-view.feature
@@ -180,23 +180,28 @@ Feature: a user visit the dataset page
 		When I go to "/dataset/101001"
 		Then I should see "JBrowse" tab with text "Open the JBrowse"
 
-	@ok @files
+	@wip @files
 	Scenario: Files
 		Given I am not logged in to Gigadb web site
 		When I go to "/dataset/101001"
-		#When I go to "/dataset/100004"
 		Then I should see "Files" tab with table
-#		| File name        | Description                                               | Data Type         | Size          | File Attribute| Link |
-#		| CS-master.tar.gz | compressed archive of the Analysis scripts (CS) files     | Script            | 114B          |               | ftp://climb.genomics.cn/pub/10.5524/100001_101000/100094/CS-master.tar.gz |
-#		| GD-master.tar.gz | compressed archive of the mock data and scripts GD files  | Mixed archive     | 163B          |               | ftp://climb.genomics.cn/pub/10.5524/100001_101000/100094/GD-master.tar.gz |
-		| File name              							| Sample ID  	| Data Type       	| File Format 	| Size  		| Release date| link |
-		| Anas_platyrhynchos.cds 							| Pekin duck 	| Coding sequence  	| FASTA 	   	| 21.50 MiB     | 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.cds |
-	 	| Anas_platyrhynchos.gff 							| Pekin duck 	| Annotation 		| GFF        	| 10.10 MiB 	| 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.gff |
-		| Anas_platyrhynchos.pep 							| Pekin duck 	| Protein sequence 	| FASTA      	| 7.80 MiB  	| 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.pep |
-		| Anas_platyrhynchos_domestica.RepeatMasker.out.gz 	| Pekin duck 	| Other 			| UNKNOWN    	| 7.79 MiB  	| 2015-03-23  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos_domestica.RepeatMasker.out.gz |
-		| duck.scafSeq.gapFilled.noMito 					| Pekin duck 	| Sequence assembly	| FASTA 		| 1.03 GiB 		| 2013-01-23  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/duck.scafSeq.gapFilled.noMito |
-		| pre_03AUG2015_update 								|				| Directory 		| UNKNOWN 		| 50.00 MiB 	| 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/pre_03AUG2015_update |
-		| readme.txt 										|				| Readme 			| TEXT 			| 337 B 		| 2013-01-23  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/readme.txt |
+		| File Name              							| Description  	                                                                    | Data Type       	|  Size  		| File Attributes | link |
+		| Anas_platyrhynchos.cds 							| predicted coding sequences from draft genome, confirmed with RNAseq data.	        | Coding sequence  	| 21.50 MiB     |                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.cds |
+		| Anas_platyrhynchos.gff 							| genome annotations	                                                            | Annotation 		| 10.10 MiB 	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.gff |
+		| Anas_platyrhynchos.pep 							| amino acid translations of coding sequences                                       | Protein sequence 	| 7.80 MiB  	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.pep |
+		| Anas_platyrhynchos_domestica.RepeatMasker.out.gz 	| repeat masker output 	                                                            | Other 			| 7.79 MiB  	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos_domestica.RepeatMasker.out.gz |
+		| duck.scafSeq.gapFilled.noMito 					| draft genome assembly                                                             | Sequence assembly	| 1.03 GiB 		|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/duck.scafSeq.gapFilled.noMito |
+		| pre_03AUG2015_update 								| folder containing originally submitted data files, prior to update Aug 3rd 2015.	| Directory 		| 50.00 MiB 	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/pre_03AUG2015_update |
+		| readme.txt 										|				                                                                    | Readme 			| 337 B 		|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/readme.txt |
+
+#		| File name              							| Sample ID  	| Data Type       	| File Format 	| Size  		| Release date| link |
+#		| Anas_platyrhynchos.cds 							| Pekin duck 	| Coding sequence  	| FASTA 	   	| 21.50 MiB     | 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.cds |
+#	 	| Anas_platyrhynchos.gff 							| Pekin duck 	| Annotation 		| GFF        	| 10.10 MiB 	| 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.gff |
+#		| Anas_platyrhynchos.pep 							| Pekin duck 	| Protein sequence 	| FASTA      	| 7.80 MiB  	| 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.pep |
+#		| Anas_platyrhynchos_domestica.RepeatMasker.out.gz 	| Pekin duck 	| Other 			| UNKNOWN    	| 7.79 MiB  	| 2015-03-23  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos_domestica.RepeatMasker.out.gz |
+#		| duck.scafSeq.gapFilled.noMito 					| Pekin duck 	| Sequence assembly	| FASTA 		| 1.03 GiB 		| 2013-01-23  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/duck.scafSeq.gapFilled.noMito |
+#		| pre_03AUG2015_update 								|				| Directory 		| UNKNOWN 		| 50.00 MiB 	| 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/pre_03AUG2015_update |
+#		| readme.txt 										|				| Readme 			| TEXT 			| 337 B 		| 2013-01-23  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/readme.txt |
 
 	@ok @files
 	Scenario: Files - Call to Actions

--- a/features/dataset-view.feature
+++ b/features/dataset-view.feature
@@ -185,7 +185,7 @@ Feature: a user visit the dataset page
 		Given I am not logged in to Gigadb web site
 		When I go to "/dataset/101001"
 		Then I should see "Files" tab with table
-		| File Name              							| Description  	                                                                    | Data Type       	|  Size  		| File Attributes | link |
+		| File Name              							| Description  	                                                                    | Data Type       	| Size  		| File Attributes | link |
 		| Anas_platyrhynchos.cds 							| predicted coding sequences from draft genome, confirmed with RNAseq data.	        | Coding sequence  	| 21.50 MiB     |                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.cds |
 		| Anas_platyrhynchos.gff 							| genome annotations	                                                            | Annotation 		| 10.10 MiB 	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.gff |
 		| Anas_platyrhynchos.pep 							| amino acid translations of coding sequences                                       | Protein sequence 	| 7.80 MiB  	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.pep |

--- a/features/dataset-view.feature
+++ b/features/dataset-view.feature
@@ -231,7 +231,7 @@ Feature: a user visit the dataset page
 		And I should see a button "Save changes" with no link
 		And I should see a button "Close" with no link
 
-	@ok @pageSize @files @javascript @pr464
+	@wip @pageSize @files @javascript @pr464
 	Scenario: Files - Items per page
 		Given I am not logged in to Gigadb web site
 		And I am on "/dataset/101001"
@@ -244,7 +244,7 @@ Feature: a user visit the dataset page
 		| Anas_platyrhynchos.pep 							| amino acid translations of coding sequences                                       | Protein sequence 	| 7.80 MiB  	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.pep |
 		| Anas_platyrhynchos_domestica.RepeatMasker.out.gz 	| repeat masker output 	                                                            | Other 			| 7.79 MiB  	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos_domestica.RepeatMasker.out.gz |
 		| duck.scafSeq.gapFilled.noMito 					| draft genome assembly                                                             | Sequence assembly	| 1.03 GiB 		|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/duck.scafSeq.gapFilled.noMito |
-		And I sould not see "Files" tab with table
+		And I should not see "Files" tab with table
 		| File name |
 		| pre_03AUG2015_update |
 		| readme.txt |

--- a/features/dataset-view.feature
+++ b/features/dataset-view.feature
@@ -231,19 +231,19 @@ Feature: a user visit the dataset page
 		And I should see a button "Save changes" with no link
 		And I should see a button "Close" with no link
 
-	@ok @pageSize @files @javascript
+	@ok @pageSize @files @javascript @pr464
 	Scenario: Files - Items per page
 		Given I am not logged in to Gigadb web site
 		And I am on "/dataset/101001"
 		When I follow "Files"
 		And I have set pageSize to "5" on "files_table_settings"
 		Then I should see "Files" tab with table
-		| File name              							| Sample ID  	| Data Type       	| File Format 	| Size  		| Release date| link |
-		| Anas_platyrhynchos.cds 							| Pekin duck 	| Coding sequence  	| FASTA 	   	| 21.50 MiB     | 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.cds |
-	 	| Anas_platyrhynchos.gff 							| Pekin duck 	| Annotation 		| GFF        	| 10.10 MiB 	| 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.gff |
-		| Anas_platyrhynchos.pep 							| Pekin duck 	| Protein sequence 	| FASTA      	| 7.80 MiB  	| 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.pep |
-		| Anas_platyrhynchos_domestica.RepeatMasker.out.gz 	| Pekin duck 	| Other 			| UNKNOWN    	| 7.79 MiB  	| 2015-03-23  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos_domestica.RepeatMasker.out.gz |
-		| duck.scafSeq.gapFilled.noMito 					| Pekin duck 	| Sequence assembly	| FASTA 		| 1.03 GiB 		| 2013-01-23  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/duck.scafSeq.gapFilled.noMito |
+		| File name              							| Description  	                                                                    | Data Type       	| Size  		| File Attributes | link |
+		| Anas_platyrhynchos.cds 							| predicted coding sequences from draft genome, confirmed with RNAseq data.	        | Coding sequence  	| 21.50 MiB     |                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.cds |
+		| Anas_platyrhynchos.gff 							| genome annotations	                                                            | Annotation 		| 10.10 MiB 	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.gff |
+		| Anas_platyrhynchos.pep 							| amino acid translations of coding sequences                                       | Protein sequence 	| 7.80 MiB  	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos.pep |
+		| Anas_platyrhynchos_domestica.RepeatMasker.out.gz 	| repeat masker output 	                                                            | Other 			| 7.79 MiB  	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/Anas_platyrhynchos_domestica.RepeatMasker.out.gz |
+		| duck.scafSeq.gapFilled.noMito 					| draft genome assembly                                                             | Sequence assembly	| 1.03 GiB 		|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/duck.scafSeq.gapFilled.noMito |
 		And I sould not see "Files" tab with table
 		| File name |
 		| pre_03AUG2015_update |
@@ -263,7 +263,7 @@ Feature: a user visit the dataset page
 		| File name | Description |  Data Type    | Size  		| File Attributes|
 		| Anas_platyrhynchos.cds | predicted coding sequences from draft genome, confirmed with RNAseq data. | Coding sequence  	| 21.50 MiB     |  |
 
-	@ok @files @javascript
+	@ok @files @javascript @pr464
 	Scenario: Files - Pagination
 		Given I am not logged in to Gigadb web site
 		And I am on "/dataset/101001"
@@ -273,9 +273,9 @@ Feature: a user visit the dataset page
 		# And I take a screenshot named "Files tab before clicking pager"
 		And I follow "2"
 		Then I should see "Files" tab with table
-		| File name | Sample ID | Data Type | File Format 	| Size | Release date | link |
-		| pre_03AUG2015_update 								|				| Directory 		| UNKNOWN 		| 50.00 MiB 	| 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/pre_03AUG2015_update |
-		| readme.txt 										|				| Readme 			| TEXT 			| 337 B 		| 2013-01-23  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/readme.txt |
+		| File name              							| Description  	                                                                    | Data Type       	| Size  		| File Attributes | link |
+		| pre_03AUG2015_update 								| folder containing originally submitted data files, prior to update Aug 3rd 2015.	| Directory 		| 50.00 MiB 	|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/pre_03AUG2015_update |
+		| readme.txt 										|				                                                                    | Readme 			| 337 B 		|                 | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/readme.txt |
 
 	@ok @samples
 	Scenario: Samples

--- a/features/dataset-view.feature
+++ b/features/dataset-view.feature
@@ -180,7 +180,7 @@ Feature: a user visit the dataset page
 		When I go to "/dataset/101001"
 		Then I should see "JBrowse" tab with text "Open the JBrowse"
 
-	@wip @files
+	@ok @files
 	Scenario: Files
 		Given I am not logged in to Gigadb web site
 		When I go to "/dataset/101001"
@@ -203,7 +203,7 @@ Feature: a user visit the dataset page
 #		| pre_03AUG2015_update 								|				| Directory 		| UNKNOWN 		| 50.00 MiB 	| 2015-08-03  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/pre_03AUG2015_update |
 #		| readme.txt 										|				| Readme 			| TEXT 			| 337 B 		| 2013-01-23  | ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/readme.txt |
 
-	@ok @files
+	@ok @files @pr464
 	Scenario: Files - Call to Actions
 		Given I am not logged in to Gigadb web site
 		When I go to "/dataset/101001"
@@ -211,7 +211,7 @@ Feature: a user visit the dataset page
 		Then I should see a link "(FTP site)" to "ftp://climb.genomics.cn/pub/10.5524/101001_102000/101001/" with title "FTP site"
 		Then I should see a button "Table Settings"
 
-	@ok @files
+	@ok @files @pr464
 	Scenario: Files - Table settings controls
 		Given I am not logged in to Gigadb web site
 		When I go to "/dataset/101001"
@@ -222,21 +222,21 @@ Feature: a user visit the dataset page
 		And I should see an "select.selectPageSize" element
 		And I should see "Columns:"
 		And I should see "File Description"
-		And the "description" checkbox is unchecked
+		And the "description" checkbox is checked
 		And I should see "Sample ID"
-		And the "sample_id" checkbox is checked
+		And the "sample_id" checkbox is unchecked
 		And I should see "Data Type"
 		And the "type_id" checkbox is checked
 		And I should see "File Format"
-		And the "format_id" checkbox is checked
+		And the "format_id" checkbox is unchecked
 		And I should see "Size"
 		And the "size" checkbox is checked
 		And I should see "Release Date"
-		And the "date_stamp" checkbox is checked
+		And the "date_stamp" checkbox is unchecked
 		And I should see "Download Link"
 		And the "location" checkbox is checked
 		And I should see "File Attributes"
-		And the "attribute" checkbox is unchecked
+		And the "attribute" checkbox is checked
 		And I should see a button "Save changes" with no link
 		And I should see a button "Close" with no link
 
@@ -258,7 +258,7 @@ Feature: a user visit the dataset page
 		| pre_03AUG2015_update |
 		| readme.txt |
 
-	@ok @files
+	@wip @files
 	Scenario: Files - Columns
 		Given I am not logged in to Gigadb web site
 		And I am on "/dataset/101001"
@@ -269,8 +269,8 @@ Feature: a user visit the dataset page
 		And I uncheck "location"
 		And I follow "save-files-settings"
 		Then I should see "Files" tab with table
-		| File name | Description | Sample ID  	| Data Type       	| File Format 	| Size  		| Release date|
-		| Anas_platyrhynchos.cds | predicted coding sequences from draft genome, confirmed with RNAseq data. | Pekin duck 	| Coding sequence  	| FASTA 	   	| 21.50 MiB     | 2015-08-03  |
+		| File name | Description |  Data Type    | Size  		| File Attributes|
+		| Anas_platyrhynchos.cds | predicted coding sequences from draft genome, confirmed with RNAseq data. | Coding sequence  	| 21.50 MiB     |  |
 
 	@ok @files @javascript
 	Scenario: Files - Pagination

--- a/protected/components/DatasetPageSettings.php
+++ b/protected/components/DatasetPageSettings.php
@@ -1,6 +1,11 @@
 <?php
 
-class DataPageSettings
+/**
+ * Class DatasetPageSettings
+ *
+ * To assign the default column names of files table to a constant
+ */
+class DatasetPageSettings
 {
-    const VIEW_DEFAULT_FILE_COLUMNS = ['name','size', 'type_id' , 'location',  'description', 'attribute'];
+    const VIEW_DEFAULT_FILE_COLUMNS = ['name', 'description', 'type_id' , 'size', 'attribute', 'location'];
 }

--- a/protected/components/DatasetPageSettings.php
+++ b/protected/components/DatasetPageSettings.php
@@ -1,0 +1,6 @@
+<?php
+
+class DataPageSettings
+{
+    const VIEW_DEFAULT_FILE_COLUMNS = ['name','size', 'type_id' , 'location',  'description', 'attribute'];
+}

--- a/protected/controllers/DatasetController.php
+++ b/protected/controllers/DatasetController.php
@@ -79,7 +79,7 @@ class DatasetController extends Controller
 
         $cookies = Yii::app()->request->cookies;
         // file
-        $setting = array('name','size', 'type_id' , 'location',  'description', 'attribute'); // 'format_id','date_stamp', 'sample_id' are hidden by default
+        $setting = DatasetPageSettings::VIEW_DEFAULT_FILE_COLUMNS;
         $pageSize = 10;
         $flag=null;
 

--- a/protected/controllers/DatasetController.php
+++ b/protected/controllers/DatasetController.php
@@ -79,7 +79,7 @@ class DatasetController extends Controller
 
         $cookies = Yii::app()->request->cookies;
         // file
-        $setting = array('name','size', 'type_id', 'format_id', 'location', 'date_stamp','sample_id', 'description', 'attribute'); // 'description','attribute' are hidden by default
+        $setting = array('name','size', 'type_id' , 'location',  'description', 'attribute'); // 'format_id','date_stamp', 'sample_id' are hidden by default
         $pageSize = 10;
         $flag=null;
 

--- a/protected/controllers/DatasetController.php
+++ b/protected/controllers/DatasetController.php
@@ -79,7 +79,7 @@ class DatasetController extends Controller
 
         $cookies = Yii::app()->request->cookies;
         // file
-        $setting = array('name','size', 'type_id', 'format_id', 'location', 'date_stamp','sample_id'); // 'description','attribute' are hidden by default
+        $setting = array('name','size', 'type_id', 'format_id', 'location', 'date_stamp','sample_id', 'description', 'attribute'); // 'description','attribute' are hidden by default
         $pageSize = 10;
         $flag=null;
 

--- a/protected/views/dataset/_files_setting.php
+++ b/protected/views/dataset/_files_setting.php
@@ -32,7 +32,7 @@
                                 <div class="row">
                                     <div class="span3"><?= Yii::t('app','File Description') ?></div>
                                     <div class="span1"><input id="description" type="checkbox" name="setting[]" value="description"
-                                        <?= (in_array("description", $setting))? "" : "checked"?> />
+                                        <?= (in_array("description", $setting))? "checked" : ""?> />
                                     </div>
                                 </div>
                                 <div class="row">
@@ -77,7 +77,7 @@
                                 <div class="row">
                                     <div class="span3"><?= Yii::t('app','File Attributes') ?></div>
                                     <div class="span1"><input id="attribute" type="checkbox" name="setting[]" value="attribute"
-                                    <?= (in_array("attribute", $setting))? "" : "checked"?> />
+                                    <?= (in_array("attribute", $setting))? "checked" : ""?> />
                                     </div>
                                 </div>
                             </div>

--- a/protected/views/dataset/_files_setting.php
+++ b/protected/views/dataset/_files_setting.php
@@ -32,13 +32,13 @@
                                 <div class="row">
                                     <div class="span3"><?= Yii::t('app','File Description') ?></div>
                                     <div class="span1"><input id="description" type="checkbox" name="setting[]" value="description"
-                                        <?= (in_array("description", $setting))? "checked" : ""?> />
+                                        <?= (in_array("description", $setting))? "" : "checked"?> />
                                     </div>
                                 </div>
                                 <div class="row">
                                     <div class="span3"><?= Yii::t('app','Sample ID') ?></div>
                                     <div class="span1"><input id="sample_id" type="checkbox" name="setting[]" value="sample_id"
-                                        <?= (in_array("sample_id", $setting))? "checked" : ""?> />
+                                        <?= (in_array("sample_id", $setting))? "" : "checked"?> />
                                     </div>
                                 </div>
                                 <div class="row">
@@ -50,7 +50,7 @@
                                 <div class="row">
                                     <div class="span3"><?= Yii::t('app','File Format') ?></div>
                                     <div class="span1"><input id="format_id" type="checkbox" name="setting[]" value="format_id"
-                                    <?= (in_array("format_id", $setting))? "checked" : ""?> />
+                                    <?= (in_array("format_id", $setting))? "" : "checked"?> />
                                     </div>
                                 </div>
                             </div>
@@ -65,7 +65,7 @@
                                 <div class="row">
                                     <div class="span3"><?= Yii::t('app','Release Date') ?></div>
                                     <div class="span1"><input id="date_stamp" type="checkbox" name="setting[]" value="date_stamp"
-                                    <?= (in_array("date_stamp", $setting))? "checked" : ""?> />
+                                    <?= (in_array("date_stamp", $setting))? "" : "checked"?> />
                                     </div>
                                 </div>
                                 <div class="row">
@@ -77,7 +77,7 @@
                                 <div class="row">
                                     <div class="span3"><?= Yii::t('app','File Attributes') ?></div>
                                     <div class="span1"><input id="attribute" type="checkbox" name="setting[]" value="attribute"
-                                    <?= (in_array("attribute", $setting))? "checked" : ""?> />
+                                    <?= (in_array("attribute", $setting))? "" : "checked"?> />
                                     </div>
                                 </div>
                             </div>

--- a/protected/views/dataset/_files_setting.php
+++ b/protected/views/dataset/_files_setting.php
@@ -38,7 +38,7 @@
                                 <div class="row">
                                     <div class="span3"><?= Yii::t('app','Sample ID') ?></div>
                                     <div class="span1"><input id="sample_id" type="checkbox" name="setting[]" value="sample_id"
-                                        <?= (in_array("sample_id", $setting))? "" : "checked"?> />
+                                        <?= (in_array("sample_id", $setting))? "checked" : ""?> />
                                     </div>
                                 </div>
                                 <div class="row">
@@ -50,7 +50,7 @@
                                 <div class="row">
                                     <div class="span3"><?= Yii::t('app','File Format') ?></div>
                                     <div class="span1"><input id="format_id" type="checkbox" name="setting[]" value="format_id"
-                                    <?= (in_array("format_id", $setting))? "" : "checked"?> />
+                                    <?= (in_array("format_id", $setting))? "checked" : ""?> />
                                     </div>
                                 </div>
                             </div>
@@ -65,7 +65,7 @@
                                 <div class="row">
                                     <div class="span3"><?= Yii::t('app','Release Date') ?></div>
                                     <div class="span1"><input id="date_stamp" type="checkbox" name="setting[]" value="date_stamp"
-                                    <?= (in_array("date_stamp", $setting))? "" : "checked"?> />
+                                    <?= (in_array("date_stamp", $setting))? "checked" : ""?> />
                                     </div>
                                 </div>
                                 <div class="row">


### PR DESCRIPTION
# Pull request for issue: #462 

This is a pull request for the following functionalities:
## Changes to the view template files
1. To check the column boxes by updating the `in_array` return value.


## Problem
Please help to have a look.
1. Items in the `$setting`:
![image](https://user-images.githubusercontent.com/64770635/86996187-8c0fcb80-c1dd-11ea-991b-f404a2cee681.png)

2. `description` and `attribute` are in the `$setting`,  but in `in_array` returns `false`.

