### PR TITLE
Restrict package drewm/mailchimp to v2.5 only

### DIFF
--- a/ops/configuration/php-conf/composer.json.dist
+++ b/ops/configuration/php-conf/composer.json.dist
@@ -17,7 +17,7 @@
         "opauth/twitter": "^0.3.2",
         "opauth/google": "^0.2.2",
         "opauth/linkedin": "^0.3.0",
-        "drewm/mailchimp-api": "^v2.5"
+        "drewm/mailchimp-api": "^2.5"
     },
     "require-dev": {
         "behat/behat":  "^3.5",

--- a/ops/configuration/php-conf/composer.json.dist
+++ b/ops/configuration/php-conf/composer.json.dist
@@ -17,7 +17,7 @@
         "opauth/twitter": "^0.3.2",
         "opauth/google": "^0.2.2",
         "opauth/linkedin": "^0.3.0",
-        "drewm/mailchimp-api": "^2.5"
+        "drewm/mailchimp-api": "v2.5"
     },
     "require-dev": {
         "behat/behat":  "^3.5",

--- a/ops/configuration/php-conf/composer.json.dist
+++ b/ops/configuration/php-conf/composer.json.dist
@@ -17,7 +17,7 @@
         "opauth/twitter": "^0.3.2",
         "opauth/google": "^0.2.2",
         "opauth/linkedin": "^0.3.0",
-        "drewm/mailchimp-api": "v2.5"
+        "drewm/mailchimp-api": "v2.5.3"
     },
     "require-dev": {
         "behat/behat":  "^3.5",


### PR DESCRIPTION
# Pull request for issue: #410 

This is a pull request for the following functionalities:

Download only version 2.5 of `drewm/mailchimp-api` package into
vendor directory.

The latest version (2.5.4) of the `drewm/mailchimp-api` package was being
downloaded and used which breaks `NewsletterServiceTest`. Version 2.5.4 is
downloaded because `composer.json.dist` specifies it as `^v2.5`. Version
2.5.4 includes changing subscriberHash to a static function which might
be the cause of the test breaking.

If `"drewm/mailchimp-api": "v2.5.3"` is downloaded then this most recent 
version allows `NewsletterServiceTest` to pass.

## Changes to the provisioning

Update `composer.json.dist` with:
```
"drewm/mailchimp-api": "v2.5.3"
```


