### PR TITLE
Add guidelines to dataset page

### DIFF
--- a/protected/views/layouts/new_datasetpage.php
+++ b/protected/views/layouts/new_datasetpage.php
@@ -146,6 +146,7 @@
                             <ul class="dropdown-menu">
                                 <li><a href="/site/help">Help</a></li>
                                 <li><a href="/site/faq">FAQ</a></li>
+                                <li><a href="/site/guide">Guidelines</a></li>
                             </ul>
                         </li>
                         <li><a href="/site/term">Terms of use</a></li>


### PR DESCRIPTION
# Pull request for issue: #494 

### Changes to the view template files
Allow `guidelines` page redirection in the dataset page by adding `site/guide` to `new_datasetpage.php`.

### Problem
Every changes in the view of `new_main.php`, that have to do the same in the `new_dataset.php` and `new_faq.php` , otherwise these two pages do work properly. Why these two files are separated from the main? Do we have to think about how the changes made in `new_main.php` effect in these two files too?
