### PR TITLE
Fix placeholder text alignment in front search bar

### DIFF
--- a/less/current.less
+++ b/less/current.less
@@ -2,7 +2,7 @@
 /* = current.less = */
 /* ================ */
 
-@import "current/base/destyle.less";
+//@import "current/base/destyle.less";
 @import "current/base/variables.less";
 @import "current/base/scaffolding.less";
 @import "current/base/type.less";


### PR DESCRIPTION
# Pull request for issue: #522 

This is a pull request for the following functionalities:

Ensure placeholder text is left-aligned in front search bar.

## Changes to the style

The import of `destyle.less` has been commented out in `current.less`. This allows the placeholder text to be left-aligned again in the front search bar. Having CSS reset functionality seems to be a good idea so that styling of all HTML elements are reset to a baseline that is consistent for all browsers and avoids cross-browser differences. For this reason, import of `destyle.less` has been commented out for the time being till when we can take another look at the CSS problem with GigaDB.
