### PR TITLE
Update link from GigaScience Press logo in footer

### DIFF
--- a/protected/views/layouts/new_datasetpage.php
+++ b/protected/views/layouts/new_datasetpage.php
@@ -164,7 +164,7 @@
             <div class="row">
                 <div class="col-xs-6">
                     <ul class="list-inline base-footer-logo-bar">
-                        <li><a href="https://academic.oup.com/gigascience"><img src="/images/new_interface_image/gigascience_white.png" alt="Go to GigaScience Journal web site"></a></li>
+                        <li><a href="http://gigasciencepress.com/"><img src="/images/new_interface_image/gigascience_white.png" alt="Go to GigaScience Journal web site"></a></li>
                         <li><a href="http://www.genomics.cn/"><img src="/images/new_interface_image/bgi_logo_white.png" alt="Go to 华大基因 BGI (Beijing Genomics Institute) website"></a></li>
                         <li><a href="https://www.cngb.org"><img src="/images/new_interface_image/chinagenbank.png" alt="Go to CNGB (China National Gene Bank) website"></a></li>
                     </ul>

--- a/protected/views/layouts/new_faq.php
+++ b/protected/views/layouts/new_faq.php
@@ -152,7 +152,7 @@
             <div class="row">
                 <div class="col-xs-6">
                     <ul class="list-inline base-footer-logo-bar">
-                        <li><a href="https://academic.oup.com/gigascience"><img src="/images/new_interface_image/gigascience_white.png" alt="Go to GigaScience Journal web site"></a></li>
+                        <li><a href="http://gigasciencepress.com/"><img src="/images/new_interface_image/gigascience_white.png" alt="Go to GigaScience Journal web site"></a></li>
                         <li><a href="http://www.genomics.cn/"><img src="/images/new_interface_image/bgi_logo_white.png" alt="Go to 华大基因 BGI (Beijing Genomics Institute) website"></a></li>
                         <li><a href="https://www.cngb.org"><img src="/images/new_interface_image/chinagenbank.png" alt="Go to CNGB (China National Gene Bank) website"></a></li>
                     </ul>

--- a/protected/views/layouts/new_main.php
+++ b/protected/views/layouts/new_main.php
@@ -152,7 +152,7 @@
             <div class="row">
                 <div class="col-xs-6">
                     <ul class="list-inline base-footer-logo-bar">
-                        <li><a href="https://academic.oup.com/gigascience"><img src="/images/new_interface_image/gigascience_white.png" alt="Go to GigaScience Journal web site"></a></li>
+                        <li><a href="http://gigasciencepress.com/"><img src="/images/new_interface_image/gigascience_white.png" alt="Go to GigaScience Journal web site"></a></li>
                         <li><a href="http://www.genomics.cn/"><img src="/images/new_interface_image/bgi_logo_white.png" alt="Go to 华大基因 BGI (Beijing Genomics Institute) website"></a></li>
                         <li><a href="https://www.cngb.org"><img src="/images/new_interface_image/chinagenbank.png" alt="Go to CNGB (China National Gene Bank) website"></a></li>
                     </ul>


### PR DESCRIPTION
# Pull request for issue: #525

This is a pull request for the following functionalities:

* Link from GigaScience Press logo updated to http://gigasciencepress.com/ on GigaDB webpage footer.

## Changes to the view template files

Link from GigaScience Press logo in the footer has been updated to http://gigasciencepress.com/ in three view classes:
* protected/views/layouts/new_datasetpage.php
* protected/views/layouts/new_faq.php
* protected/views/layouts/new_main.php
