### PR TITLE
Fix git not found error in Profiler installation step

### DIFF
--- a/ops/packaging/Dockerfile
+++ b/ops/packaging/Dockerfile
@@ -147,6 +147,7 @@ RUN if [ ${INSTALL_TIDEWAYS_XHPROF} = true ]; then \
     cd /usr/local/src/ && \
     tar xzvf /usr/local/src/xhgui.tar.gz && \
     cd xhgui-0.8.1 && \
+    apt-get install -y git && \
     composer install && \
     echo "auto_prepend_file=/usr/local/src/xhgui-0.8.1/external/header.php" > /usr/local/etc/php/conf.d/xhgui.ini \
 ;fi


### PR DESCRIPTION
# Pull request for issue: #527

This is a pull request for the following functionalities:

* Fix git not found error when installing Profiler in `Dockerfile`. This results in `docker-compose run --rm webapp` failing and the webapp docker service defined in docker-compose.yml not being able to start since `application` image cannot complete its build.

## Changes to the provisioning

`git` is installed as part of the Tideways Profiler installation in `Dockerfile`.
