### PR TITLE
Fix gateway timeout problem when retrieving publication information

### DIFF
--- a/protected/components/StoredDatasetConnections.php
+++ b/protected/components/StoredDatasetConnections.php
@@ -96,7 +96,7 @@ class StoredDatasetConnections extends DatasetComponents implements DatasetConne
 		foreach ($rows as $result) {
 			$response = null;
 			try {
-				$response = $this->_web->request('GET', 'http://dx.doi.org/'. $result['identifier'], [
+				$response = $this->_web->request('GET', 'https://doi.org/'. $result['identifier'], [
 									    'headers' => [
 									        'style' => 'apa',
 									        'Accept' => 'text/x-bibliography',

--- a/protected/tests/unit/StoredDatasetConnectionsTest.php
+++ b/protected/tests/unit/StoredDatasetConnectionsTest.php
@@ -137,7 +137,7 @@ class StoredDatasetConnectionsTest extends CDbTestCase
 					->method('request')
 					->withConsecutive(
 						[
-							'GET', 'http://dx.doi.org/10.1186/gb-2012-13-10-r100', [
+							'GET', 'https://doi.org/10.1186/gb-2012-13-10-r100', [
 							    'headers' => [
 							        'style' => 'apa',
 							        'Accept' => 'text/x-bibliography',
@@ -146,7 +146,7 @@ class StoredDatasetConnectionsTest extends CDbTestCase
 							]
 						],
 						[
-							'GET', 'http://dx.doi.org/10.1038/nature10158', [
+							'GET', 'https://doi.org/10.1038/nature10158', [
 							    'headers' => [
 							        'style' => 'apa',
 							        'Accept' => 'text/x-bibliography',


### PR DESCRIPTION
# Pull request for issue: #537

This is a pull request for the following functionalities:

* Update endpoint and use HTTPS for retrieving publication information

Acceptance tests involving the checking of content in dataset pages were failing because the pages were taking too long to load. This resulted in 504 Gateway Timeout errors that were caused when trying to retrieve citation information using a DOI with the `dx.doi.org` endpoint. Updating to the preferred `https://doi.org` endpoint appears to fix the timeout problem when running tests on a local deployment and on CI/CD.

We can investigate this problem in more detail if it arises in the future.

## Changes to the components classes

The `getPublications` function in `StoredDatasetConnections.php` has been updated so that it now uses the `https://doi.org/` endpoint for retrieving citation information. Previously, it used `http://dx.doi.org/` which is still [supported](https://www.doi.org/factsheets/DOIProxy.html) but `https://doi.org/` is now preferred. 

## Changes to the tests

The `StoredDatasetConnectionsTest` unit test has been updated to use the `https://doi.org/` endpoint in its tests.
