### PR TITLE
Fix build_webapp stage in CI/CD pipeline

### DIFF
--- a/ops/packaging/Dockerfile
+++ b/ops/packaging/Dockerfile
@@ -125,6 +125,7 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 RUN if [ ${INSTALL_COMPOSER} = true ]; then \
     docker-php-ext-install zip \
+    && apt-get update -yq \
     && apt-get install -y unzip wget \
     && EXPECTED_SIGNATURE="$(wget -q -O - https://composer.github.io/installer.sig)" \
     && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \

--- a/ops/packaging/Dockerfile
+++ b/ops/packaging/Dockerfile
@@ -62,6 +62,7 @@ ARG INSTALL_INTL=false
 
 RUN if [ ${INSTALL_INTL} = true ]; then \
     # Install intl and requirements
+    apt-get update -yq && \
     apt-get install -y zlib1g-dev libicu-dev g++ && \
     docker-php-ext-configure intl && \
     docker-php-ext-install intl \
@@ -83,6 +84,7 @@ RUN if [ ${INSTALL_PG_CLIENT} = true ]; then \
     mkdir -p /usr/share/man/man1 && \
     mkdir -p /usr/share/man/man7 && \
     # Install the pgsql client
+    apt-get update -yq && \
     apt-get install -y postgresql-client-${PG_CLIENT_VERSION} \
 ;fi
 
@@ -107,6 +109,7 @@ RUN if [ ${INSTALL_NETCAT_JQ} = true ]; then \
     mkdir -p /usr/share/man/man1 && \
     mkdir -p /usr/share/man/man7 && \
     # Install netcat-openbsd and jq
+    apt-get update -yq && \
     apt-get install -y netcat-openbsd jq \
 ;fi
 
@@ -169,6 +172,7 @@ RUN if [ ${INSTALL_LIBSODIUM} = true ]; then \
 
 ARG INSTALL_GIT=false
 RUN if [ ${INSTALL_GIT} = true ]; then \
+    apt-get update -yq && \
     apt-get install -y git \
 ;fi
 


### PR DESCRIPTION
# Pull request for issue: #558 

This is a pull request for the following functionalities:

A fix for the `build_webapp` stage in the GitLab CI/CD pipeline.

The CI/CD pipeline appeared to be breaking when `apt-get update` is not executed before a package is installed in `Dockerfile`. This results in the build complaining that it cannot find the package in the repository because it computed the URL based on an old version of the list which listed an older version of the package.

## Changes to the provisioning

`Dockerfile` has been updated so that `apt-get update` is executed before packages are installed by the `apt-get install` command.
