### PR TITLE
Fix missing node module problem when running database setup scripts

### DIFF
--- a/ops/scripts/setup_devdb.sh
+++ b/ops/scripts/setup_devdb.sh
@@ -22,7 +22,7 @@ fi
 $DOCKER_COMPOSE run --rm test bash -c "psql -h database -U gigadb -c 'create database gigadb'" || true
 
 # generate migrations
-$DOCKER_COMPOSE run --rm csv-to-migrations bash -c "node /var/www/ops/scripts/csv_yii_migration.js dev"
+$DOCKER_COMPOSE run --rm csv-to-migrations bash -c "npm install /var/www/ops/scripts && node /var/www/ops/scripts/csv_yii_migration.js dev"
 
 # and run them
 $DOCKER_COMPOSE run --rm  application ./protected/yiic migrate to 300000_000000 --connectionID=db --migrationPath=application.migrations.admin --interactive=0

--- a/ops/scripts/setup_prod_likedb.sh
+++ b/ops/scripts/setup_prod_likedb.sh
@@ -22,7 +22,7 @@ fi
 $DOCKER_COMPOSE run --rm test bash -c "psql -h database -U gigadb -c 'create database gigadb'" || true
 
 # generate migrations
-$DOCKER_COMPOSE run --rm csv-to-migrations bash -c "node /var/www/ops/scripts/csv_yii_migration.js prod_like"
+$DOCKER_COMPOSE run --rm csv-to-migrations bash -c "npm install /var/www/ops/scripts && node /var/www/ops/scripts/csv_yii_migration.js prod_like"
 
 # and run them
 $DOCKER_COMPOSE run --rm  application ./protected/yiic migrate to 300000_000000 --connectionID=db --migrationPath=application.migrations.admin --interactive=0


### PR DESCRIPTION
# Pull request for issue: #562

This is a pull request for the following functionalities:

* A fix for missing `node_modules` directory when running `setup_devdb.sh` and `setup_prod_likedb.sh` scripts.

## Changes to provisioning

A fix involving the execution of `npm install /var/www/ops/scripts` has been added into `set_devdb.sh` and `setup_prod_likedb.sh` scripts before `csv_yii_migration.js` is run. The `npm install` command creates a `ops/scripts/node_modules` directory and downloads the required node packages into it before running the database migration scripts:
```
$ ops/scripts/setup_devdb.sh
ERROR:  database "gigadb" already exists

> jsonpath@1.0.2 postinstall /var/www/ops/scripts/node_modules/jsonpath
> node lib/aesprim.js > generated/aesprim-browser.js

npm WARN csv-to-migrations@1.0.0 No repository field.

added 25 packages from 57 contributors and audited 25 packages in 4.171s
found 1 high severity vulnerability
  run `npm audit fix` to fix them, or `npm audit` for details

Yii Migration Tool v1.0 (based on Yii v1.1.20)

Total 1 new migration to be applied:
    m300000_000000_drop_tables
```

If the `node_modules` directory already exists then the packages in it are just audited:
```
$ ops/scripts/setup_devdb.sh
ERROR:  database "gigadb" already exists
npm WARN csv-to-migrations@1.0.0 No repository field.

audited 25 packages in 0.985s
found 1 high severity vulnerability
  run `npm audit fix` to fix them, or `npm audit` for details

Yii Migration Tool v1.0 (based on Yii v1.1.20)

Total 1 new migration to be applied:
    m300000_000000_drop_tables
```

