### PR TITLE
Fix test image build

### DIFF
--- a/ops/packaging/Dockerfile
+++ b/ops/packaging/Dockerfile
@@ -195,6 +195,8 @@ RUN if [ ${INSTALL_MAILPARSE} = true ]; then \
 
 ARG INSTALL_CSSLINT_JSHINT=false
 RUN if [ ${INSTALL_CSSLINT_JSHINT} = true ]; then \
+    # To fix public key not found error when running nodesource_setup.sh
+    curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
     curl -sL https://deb.nodesource.com/setup_10.x -o nodesource_setup.sh && \
     bash nodesource_setup.sh && \
     apt-get install -y nodejs && \


### PR DESCRIPTION
# Pull request for issue: #602

This is a pull request for the following functionalities:

A fix for building `test` image. This was broken due to a missing package key 
for node.js which is required to authenticate the package in `Dockerfile`.

## Changes to the provisioning

A step to download and add the nodejs package key has been added into 
`Dockerfile`. This is required for installing nodejs in the `test` image. 

