### PR TITLE
Add scripts to back up data onto Tencent cloud

### DIFF
--- a/backup/dataset_backup.sh
+++ b/backup/dataset_backup.sh
@@ -1,0 +1,5 @@
+export backup_date=`date "+%Y%m%d"`
+
+/usr/bin/coscmd -l /home/gigadb/test/giga_cosbackup.log$backup_date upload -H '{"x-cos-storage-class":"DEEP_ARCHIVE"}' -rs /data/gigadb/pub/10.5524/100001_101000/100905 /cngbdb/
+giga/gigadb/pub/10.5524/100001_101000/
+

--- a/backup/giga_backup.sh
+++ b/backup/giga_backup.sh
@@ -1,0 +1,4 @@
+export backup_date=`date "+%Y%m%d"`
+
+/usr/bin/coscmd -l /home/gigadb/giga_cosbackup.log$backup_date upload -H '{"x-cos-storage-class":"DEEP_ARCHIVE"}' -rs /data/gigadb/pub /cngbdb/giga/gigadb/
+

--- a/backup/giga_backup_fullbackup.sh
+++ b/backup/giga_backup_fullbackup.sh
@@ -1,0 +1,4 @@
+export backup_date=`date "+%Y%m%d"`
+
+/usr/bin/coscmd -l /home/gigadb/giga_cosbackup.log$backup_date upload -H '{"x-cos-storage-class":"DEEP_ARCHIVE"}'  --skipmd5 -rs /data/gigadb/pub /cngbdb/giga/gigadb/
+


### PR DESCRIPTION
This is a pull request for the following functionalities:

* Deposit scripts used to back up GigaDB dataset files into cold storage on Tencent cloud  into `gigadb-website` repo.

## Changes to the backup scripts

This is an initial commit of the shell scripts that have been used to back up dataset files into cold storage on Tencent cloud.