### PR TITLE
Assign bug reports to IT team when created

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,9 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a report of a defect on the live service, so we can investigate.
 title: ''
 labels: bug
-assignees: ''
+assignees: pli888, rija, kencho51
 
 ---
 


### PR DESCRIPTION
This way, when a bug is reported, someone in the IT team  can triage it (do something immediately and/or create a 'backlog:Bug' labelled item in the Product Backlog Item)

This is an implementation of  previous discussion on how to handle bugs in  a SCRUM context, when we said IT Team monitors bug report creation and will triage them appropriately.