### PR TITLE
TLS Audit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,7 @@ before_script:
   - '[[ $CI_JOB_NAME != *sast* ]] && env | grep "^CI_" > $APPLICATION/.ci_env'
   - '[[ $CI_JOB_NAME != *sast* ]] && env | grep -v "SAST" | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tls)" > $APPLICATION/.env'
   - '[[ $CI_JOB_NAME != *sast* ]] && env | grep -v "SAST" | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -v "ANALYTICS_PRIVATE_KEY" | grep -viE "tls" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" > $APPLICATION/.secrets'
-  - '[[ $CI_JOB_NAME != *sast* ]] && apk add --no-cache py-pip bash'
+  - '[[ $CI_JOB_NAME != *sast* ]] && apk add --no-cache py-pip bash curl jq'
   # Pin docker-compose version to stop installation error
   - '[[ $CI_JOB_NAME != *sast* ]] && pip install docker-compose~=1.23.0'
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -59,8 +59,38 @@ is to ssh into the target host and run the system command ``ss`` [3]
 $ ss -tunlp
 ```
 
+## TLS vulnerabilities and mitigations
+
+Our project use TLS certificate infrastructure for encrypting user requests to our web site.
+
+We used the Mozilla SSL configuration tool [4] to help us generate a safe nginx configuration instructions for a TLS termination proxy.
+That tool can be configured using a choice of three profiles
+
+| profile | description | security level |
+| --- | --- | --- | 
+| Modern | "Services with clients that support TLS 1.3 and don't need backward compatibility" | highest |
+| Intermediate | "General-purpose servers with a variety of clients, recommended for almost all systems" | high |
+| Old | "Compatible with a number of very old clients, and should be used only as a last resort" | low |
+
+We chose the intermediate configuration as it provides good security and doesn't have too strong requirements on website visitor's up-to-date-ness of their browser.
+I think the Modern profile would prevent the visitors not using the most recent version of web browsers to visit our website.
+
+We have also used Qualys' SSL Labs [5] to audit our TLS termination setup from a security perspective.
+Their automated audit checks if our setup is vulnerable to the common TLS attacks and exploits.
+
+After three attempts and making the corresponding corrections to our configuration, we got the highest grade A+. The report also lists
+the common vulnerabilities and whether we are vulnerable to them or not [6].
+
+
+
 [1] https://nmap.org/book/man-port-specification.html
 
 [2] http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml
 
 [3] https://www.linux.com/topic/networking/introduction-ss-command/
+
+[4] https://ssl-config.mozilla.org
+
+[5] https://www.ssllabs.com/ssltest/index.html (make sure to tick "Do not show the results on the boards")
+
+[6] https://drive.google.com/file/d/1NAcZvUNvnxhiM4g5KPNeAmqdk5v8KZvy/view?usp=sharing

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -72,14 +72,19 @@ That tool can be configured using a choice of three profiles
 | Intermediate | "General-purpose servers with a variety of clients, recommended for almost all systems" | high |
 | Old | "Compatible with a number of very old clients, and should be used only as a last resort" | low |
 
-We chose the intermediate configuration as it provides good security and doesn't have too strong requirements on website visitor's up-to-date-ness of their browser.
-I think the Modern profile would prevent the visitors not using the most recent version of web browsers to visit our website.
+We chose the intermediate configuration for now as it provides good security while allowing most of web audience to access our site.
+I think (we will need to confirm this by analysing our web analytics) the modern profile would prevent some of our visitors not using the most recent version of web browsers/OS combo to visit our website.
 
 We have also used Qualys' SSL Labs [5] to audit our TLS termination setup from a security perspective.
 Their automated audit checks if our setup is vulnerable to the common TLS attacks and exploits.
 
 After three attempts and making the corresponding corrections to our configuration, we got the highest grade A+. The report also lists
 the common vulnerabilities and whether we are vulnerable to them or not [6].
+
+### OpenSSL
+
+Docker, certbot, Nginx and most tools on Linux rely on the open source library OpenSSL to work with TLS certificates.
+We've upgraded it to a recent version (1.1.1) to ensure vulnerabilities associated with older versions are not problem.
 
 
 

--- a/docs/TLS.md
+++ b/docs/TLS.md
@@ -1,0 +1,145 @@
+# TLS
+
+TLS (transport layer security) is the communication encryption protocol used in a couple of places in our projects: communication to the website and communication to the Docker daemon
+
+
+## TLS to encrypt connections to the web site
+
+TLS is a mean to encrypt the communication between web browsers and our web site, 
+in order to avoid interception, eavesdropping and leaking of PII (personally identifiable information) data.
+It also reduces the risks of website and links hijacking into larger distributed nefarious activities. 
+
+### How to set it up
+
+1. The required input is a GitLab variable REMOTE_HOSTNAME that need to be defined in GitLab Variables for each production environment (staging and live).
+2. Ensure that in the DNS server managing the REMOTE_HOSTNAME domain, there is a A record associating it with the public IP address of the target environment's dockerhost instance
+3. The script ``ops/scripts/setup_cert.sh`` (executed during deployment from GitLab pipeline) will request  a TLS certificate signed and delivered by Let's Encrypt that will be written to the dockerhost's filesystem at a path accessible to Nginx container. The script will also save the certificate in GitLab variables.
+
+When the infrastructure for the website has to be rebuilt, the ``ops/scripts/setup_cert.sh`` script will download the certificate from GitLab during the deployment to the newly rebuilt environment.
+
+>If the IP address changes, the variables in GitLab that hold the certificate need to be deleted, and the certificate files on the filesystem need to be removed.
+
+### How it works
+
+That certificate cryptographically associates the fully qualified domain names (FQDN) REMOTE\_HOSTNAME and portainer.REMOTE\_HOSTNAME with the public IP address for the infrastructure that has been provisioned for the target environment with Terraform/Ansible tools.
+In our case, the public IP address is an AWS Elastic IP.
+
+It is then used by the web server/reverse proxy Nginx to encrypt communication from a web browser and API clients.
+
+Certificates have limited lifetime, 3 months for Let's Encrypt emitted certificates.
+Whenever a deployment is performed on staging or live, a renewal request will be performed by ``ops/scripts/setup_cert.sh``. Most of the time this request will be denied and that's expected behaviour as it's only when the expiration date is close that Let's Encrypt will accept the request for renewal.
+Additionally, there is an automated check that run as part of the automated test suite that will fail if we are close (10 days or less) to 
+the expiration date. 
+
+Additionally, LetsEncrypt have a rate limit that limit the number of certificate that can be created for a domain.
+That's the main reason we save them to GitLab variables, so that we can reuse them whenever we need to destroy and rebuild the dockerhost instance.
+
+The interaction with Let's Encrypt is handled by Let's Encrypt command line tool ``cerbot`` which is run as a container service of the same name.
+
+In our infrastructure, Nginx is called a TLS termination proxy and as such it needs to be configured 
+in a certain way in order to accept TLS encrypted requests. 
+
+The Nginx configuration follows the recommendation generated with the tool: https://ssl-config.mozilla.org (intermediate level)
+which is the configuration tool associated with doc: https://wiki.mozilla.org/Security/Server_Side_TLS.
+The nginx configuration is defined in template ``ops/configuration/nginx-conf/sites/nginx.target_deployment.https.conf.dist``
+
+#### Certificate files
+
+| Name on filesystem | Name in GitLab variables | role | nginx directive |
+| --- | --- | --- | --- |
+| fullchain.pem |tls_fullchain_pem| Signed certificate and intermediates | ``ssl_certificate``|
+| chain.pem |tls_chain_pem| Root CA certificate plus intermediates| ``ssl_trusted_certificate``|
+| privkey.pem |tls_privkey_pem|Private key for the certificate|``ssl_certificate_key``|
+
+#### File structure on dockerhost for certificate files
+
+A docker volume ``le_config`` is used to store LetsEncrypt files, so that it can be mounted
+to both the web container and the certbot container. The mount point in both case is ``/etc/letsencrypt``
+
+
+```
+$ docker exec rija-gigadb-website_web_1 ls -1l /etc/letsencrypt
+total 4
+drwxr-xr-x    3 root     root            41 Nov 16 10:04 archive
+-rw-r--r--    1 root     root          1006 Nov 16 10:04 cli.ini
+drwxr-xr-x    3 root     root            41 Nov 16 10:04 live
+```
+
+``cli.ini`` is the configuraiton for ``certbot`` and copied from ``ops/configuration/nginx-conf/le.(staging|live).ini``
+in two stages:
+1. ``Config-Dockerfile`` will copy those two files at the root of the Config container image
+2. The ``config`` container service defined in ``ops/deployment/docker-compose-production-envs.yml`` has a command that copy one specific to current environment into final location as ``cli.ini``
+
+``certbot`` will create the files in ``/etc/letsencrypt/archive/REMOTE_HOSTNAME`` and will create a symbolic link for each file in ``/etc/letsencrypt/live/REMOTE_HOSTNAME``
+
+```
+$ docker exec rija-gigadb-website_web_1 ls -1l /etc/letsencrypt/live/gigadb-staging.pommetab.com
+total 0
+lrwxrwxrwx    1 root     root            63 Nov 16 10:04 chain.pem -> /etc/letsencrypt/archive/gigadb-staging.pommetab.com/chain1.pem
+lrwxrwxrwx    1 root     root            67 Nov 16 10:04 fullchain.pem -> /etc/letsencrypt/archive/gigadb-staging.pommetab.com/fullchain1.pem
+lrwxrwxrwx    1 root     root            65 Nov 16 10:04 privkey.pem -> /etc/letsencrypt/archive/gigadb-staging.pommetab.com/privkey1.pem
+```
+
+Any application which needs access to the certificates (in our case Nginx) needs to reference the ``/etc/letsencrypt/live/REMOTE_HOSTNAME`` path.
+
+Upon restoring them from GitLab variables,  ``ops/scripts/setup_cert.sh`` needs to write them in the   ``/etc/letsencrypt/archive/REMOTE_HOSTNAME`` path **AND** create the symlinks in ``/etc/letsencrypt/live/REMOTE_HOSTNAME`` path.
+
+
+## TLS to encrypt connections between GitLab pipeline and the docker daemon
+
+This is a mean to authenticate and encrypt communication from the GitLab pipeline to the docker daemon deployed on staging or live environment
+for the purpose of configuring, starting and operating the application that is being deployed.
+A secondary purpose is to remote control the docker demon deployed on staging and live from a local developer environment
+for debugging purpose.
+
+This usage requires the generation of a client certificate and of a server certificate.
+
+### how to set it up
+
+The certificates are created automatically as part of the provisioning of Docker with Ansible.
+The client certificates are also saved to GitLab variables and to the operator's machine.
+
+
+### how it works
+
+The TLS certificate's files are generated by Ansible role [role-secure-docker-daemon](https://github.com/ansible/role-secure-docker-daemon)
+which is executed when the ``ops/infrastructure/dockerhost_playbook.yml`` playbook is run.
+
+Upon creation, the server certificates will be placed in ``etc/docker`` on the dockerhost,
+while the client certificates will be placed in ``~/.docker``.
+
+The ``ops/infrastructure/roles/docker-postinstall`` Ansible role is in charge of saving the client certificate files to GitLab variables
+and to the local environment fo the Ansible's operator in ``ops/infrastructure/envs/(staging|live)/output-(dockerhost ip address)``.
+
+These certificates don't have expiration date nor do they have rate limits as they are self-signed certificates created by the deployed instance of Docker.
+
+#### Certificate files
+
+| Name on filesystem | Name in GitLab variables | role | docker client/daemon argument |
+| --- | --- | --- | --- |
+| ca.pem | docker_tlsauth_ca|The self-generated CA (Certificate Authority) that will sign the server and client certificates | ``--tlscacert=``|
+| server-cert.pem | n/a| server certificate| ``--tlscert=`` |
+| server-key.pem |n/a| private key to server certificate| ``--tlskey`` | 
+| cert.pem |docker_tlsauth_cert| client certificate | ``--tlscert`` |
+| key.pem |docker_tlsauth_key| private key to client certificate| ``--tlskey`` |
+
+Server example:
+
+```
+> dockerd \
+    --tlsverify \
+    --tlscacert=ca.pem \
+    --tlscert=server-cert.pem \
+    --tlskey=server-key.pem \
+    -H=0.0.0.0:2376
+```
+
+Client example:
+
+```
+> docker --tlsverify \
+    --tlscacert=ca.pem \
+    --tlscert=cert.pem \
+    --tlskey=key.pem \
+    -H=$HOST:2376 ps
+```

--- a/ops/configuration/nginx-conf/sites/nginx.target_deployment.https.conf.dist
+++ b/ops/configuration/nginx-conf/sites/nginx.target_deployment.https.conf.dist
@@ -73,16 +73,13 @@ server {
     # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
     ssl_dhparam /etc/ssl/nginx/dhparam.pem;
 
-    # below section is from: generated 2021-11-09, Mozilla Guideline v5.6, nginx 1.17.7, OpenSSL 1.1.1k, intermediate configuration, no HSTS, no OCSP
+    # below section is based on: generated 2021-11-09, Mozilla Guideline v5.6, nginx 1.17.7, OpenSSL 1.1.1k, intermediate configuration
     # https://ssl-config.mozilla.org/#server=nginx&version=1.17.7&config=intermediate&openssl=1.1.1k&hsts=false&ocsp=false&guideline=5.6
 
     # intermediate configuration. tweak to your needs.
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;
-
-    # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
-    add_header Strict-Transport-Security max-age=15768000;
 
     # OCSP Stapling ---
     # fetch OCSP records from URL in ssl_certificate and cache them

--- a/ops/configuration/nginx-conf/sites/nginx.target_deployment.https.conf.dist
+++ b/ops/configuration/nginx-conf/sites/nginx.target_deployment.https.conf.dist
@@ -73,10 +73,13 @@ server {
     # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
     ssl_dhparam /etc/ssl/nginx/dhparam.pem;
 
+    # below section is from: generated 2021-11-09, Mozilla Guideline v5.6, nginx 1.17.7, OpenSSL 1.1.1k, intermediate configuration, no HSTS, no OCSP
+    # https://ssl-config.mozilla.org/#server=nginx&version=1.17.7&config=intermediate&openssl=1.1.1k&hsts=false&ocsp=false&guideline=5.6
+
     # intermediate configuration. tweak to your needs.
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
-    ssl_prefer_server_ciphers on;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
 
     # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
     add_header Strict-Transport-Security max-age=15768000;

--- a/ops/scripts/cert_age.sh
+++ b/ops/scripts/cert_age.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eu
+
+hostname=${1:-"academic.oup.com"}
+date=$(echo | openssl s_client -connect $hostname:443 2>/dev/null | openssl x509 -noout -enddate | sed "s/.*=\(.*\)/\1/")
+date_s=$(date -d "${date}" +%s)
+now_s=$(date -d now +%s)
+date_diff=$(( (date_s - now_s) / 86400 ))
+
+if [[ "$date_diff" -gt "1" && "$date_diff" -lt "11" ]]; then
+  echo "Certificate expires in: $date_diff days"
+  exit 1
+elif [[ "$date_diff" -gt "10" ]]; then
+  echo "Certificate expires in: $date_diff days"
+  exit 0
+else
+  echo "hostname does not use SSL Certificates"
+  exit 0
+fi

--- a/tests/all_and_coverage
+++ b/tests/all_and_coverage
@@ -12,5 +12,6 @@ set +a
 ./tests/javascript_check
 #./tests/css_check
 ./tests/logging_check
+./tests/cert_check
 ./tests/coverage_runner
 

--- a/tests/cert_check
+++ b/tests/cert_check
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -eu
+
+source .env
+source .secrets
+
+# Checking the staging hostname
+staging_hostname=$(curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "$PROJECT_VARIABLES_URL/REMOTE_HOSTNAME?filter%5benvironment_scope%5d=staging" | jq -r .value)
+echo $staging_hostname
+
+if [[ ! -z $staging_hostname ]];then
+  docker-compose run --rm test ./ops/scripts/cert_age.sh $staging_hostname
+fi
+
+# checking the live hostname
+live_hostname=$(curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "$PROJECT_VARIABLES_URL/REMOTE_HOSTNAME?filter%5benvironment_scope%5d=live" | jq -r .value)
+echo $live_hostname
+
+if [[ ! -z $live_hostname ]];then
+  docker-compose run --rm test ./ops/scripts/cert_age.sh $live_hostname
+fi

--- a/tests/cert_check
+++ b/tests/cert_check
@@ -5,8 +5,10 @@ set -eu
 source .env
 source .secrets
 
+encoded_gitlab_project=$(echo $CI_PROJECT_PATH | sed -e 's/\//%2F/g')
+
 # Checking the staging hostname
-staging_hostname=$(curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "$PROJECT_VARIABLES_URL/REMOTE_HOSTNAME?filter%5benvironment_scope%5d=staging" | jq -r .value)
+staging_hostname=$(curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "$CI_API_V4_URL/projects/$encoded_gitlab_project/variables/REMOTE_HOSTNAME?filter%5benvironment_scope%5d=staging" | jq -r .value)
 echo $staging_hostname
 
 if [[ ! -z $staging_hostname ]];then
@@ -14,7 +16,7 @@ if [[ ! -z $staging_hostname ]];then
 fi
 
 # checking the live hostname
-live_hostname=$(curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "$PROJECT_VARIABLES_URL/REMOTE_HOSTNAME?filter%5benvironment_scope%5d=live" | jq -r .value)
+live_hostname=$(curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "$CI_API_V4_URL/projects/$encoded_gitlab_project/variables/REMOTE_HOSTNAME?filter%5benvironment_scope%5d=live" | jq -r .value)
 echo $live_hostname
 
 if [[ ! -z $live_hostname ]];then


### PR DESCRIPTION
This PR used to be rija/gigadb-website#210 which was closed as the target branch has been merged to gigascience/gigadb-website:develop

This PR implements the changes that comes out from auditing our TLS setup for issue #818:

* [x] Run deployed web site through Qualys SSL Labs certificate check
* [x] Verify connection upgrade, that "http://" redirect to "https://" and that [HSTS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) is enabled and set up correctly
* [x] Disable old versions of TLS and enable TLS  v1.3
* [x] Create an automated smoke test that fails if expiration of a certificate is less than 10 days
* [x] Update docs, add a ``docs/TLS.md`` to document TLS  usage, setup and security considerations in GigaDB 

# Changes

* Added an operations script ``ops/scripts/cert_age.sh`` that return how old the certificate is
* Added an automated test ``tests/check_cert.sh`` set to fail if the Let's Encrypt certificate for staging and live are close to their expiration date and added it to ``tests/all_and_coverage``
* Updated Nginx configuration to pass the Qualys SSL Labs automated audit with a A+ grade
* Add documentation to explain how TLS certificates are set up and used in our project
* Updated the security documentation with a section about our TLS setup
* Updated the ``before_script`` section of ``.gitlab-ci.yml`` to make useful tools ``jq`` and ``curl`` available to docker dind's shell (and used in ``check_cert.sh``) in gitlab jobs scripts' steps
