### PR TITLE
Update SETUP_CI_CD_PIPELINE.md with staging.gigadb.org deployment

### DIFF
--- a/docs/SETUP_CI_CD_PIPELINE.md
+++ b/docs/SETUP_CI_CD_PIPELINE.md
@@ -701,6 +701,15 @@ $ terraform refresh
 where you replace ``gigascience/forks/rija-gigadb-website`` with the appropriate GitLab project.
 and ``environment`` with ``staging`` or ``live``
 
+>To provision infrastructure for *.gigadb.org, we need to use the `Gigadb` AWS
+> IAM user account which needs to be correctly configured in ~/.aws.credentials
+> and ~/.aws/config. This IAM profile can then be used as follows:
+```
+$ AWS_PROFILE=Gigadb terraform plan
+$ AWS_PROFILE=Gigadb terraform apply
+$ AWS_PROFILE=Gigadb terraform refresh
+```
+
 #### 3. Initialise Ansible
 
 ```

--- a/docs/SETUP_CI_CD_PIPELINE.md
+++ b/docs/SETUP_CI_CD_PIPELINE.md
@@ -601,7 +601,7 @@ The RDS instance is provisioned with a database via the bastion server by a
 separate ansible playbook:
 ```
 $ cd ops/infrastructure/envs/staging
-$ TF_KEY_NAME=private_ip ansible-playbook -i ../../inventories bastion_playbook.yml
+$ ansible-playbook -i ../../inventories bastion_playbook.yml
 ```
 
 The bastion playbook will create a `gigadb` database containing data from


### PR DESCRIPTION
# Pull request for issue: #783

This is a pull request for the following functionalities:

* Updates to SETUP_CI_CD_PIPELINE.md 

## Changes to the documentation

SETUP_CI_CD_PIPELINE.md has been updated with information on deploying to staging.gigadb.org using the `Gigadb` AWS IAM user account.

Also corrected command for executing bastion playbook as the bastion server is not accessed using its private IP address.
