### PR TITLE
Log all PostgreSQL statements in dev and staging deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,11 @@ $ docker-compose run --rm test bin/behat --profile local --stop-on-failure featu
 When working on your local dev environment, navigate to ``http://localhost:9009``.
 Portainer will give you quick access to all the details about all running container
 as well as controls to **start/stop/kill/restart/pause/resume** them.
-More importantly, you can easily acces the logs or drop into console mode by
-clicking the relevant icon next to the container.f
+More importantly, you can easily access the logs or drop into console mode by
+clicking the relevant icon next to the container.
+
+The database container now logs all SQL statements executed on the PostgreSQL
+database by the GigaDB website.
 
 The only pre-requisite is that a PORTAINER_BCRYPT variable is defined in the ``.env`` file.
 Look at the ``env-sample`` file for inline instructions on how to generate a correct value for 

--- a/docs/SETUP_CI_CD_PIPELINE.md
+++ b/docs/SETUP_CI_CD_PIPELINE.md
@@ -796,3 +796,7 @@ Then running the following command to create a default subnet will fix it:
  ```
  aws ec2 --profile UserNameOfAdminUser create-default-subnet --region ap-east-1 --availability-zone ap-east-1a
  ```
+
+All SQL statements executed on the PostgreSQL RDS instance are logged in staging
+deployments of GigaDB. These `postgres.log` files are available from the AWS
+console for the RDS service in the `Log & events` tab.

--- a/docs/awsdocs/policy-rds.md
+++ b/docs/awsdocs/policy-rds.md
@@ -90,20 +90,35 @@ Policy Name: GigadbRDSAccess
         {
             "Sid": "CreateRDSInstancesWithRegionAndInstanceTypeRestriction",
             "Effect": "Allow",
-            "Action": "rds:CreateDBInstance",
+            "Action": [
+                "rds:CreateDBInstance",
+                "rds:CreateDBParameterGroup",
+                "rds:DeleteDBParameterGroup",
+                "rds:DownloadCompleteDBLogFile"
+            ],
             "Resource": "*",
             "Condition": {
                 "StringEquals": {
                     "rds:DatabaseEngine": "postgres",
                     "rds:DatabaseClass": "db.t3.micro",
-                    "aws:RequestedRegion": "ap-east-1"
+                    "aws:RequestedRegion": [
+                        "ap-east-1",
+                        "ap-northeast-1"
+                    ]
                 }
             }
         },
         {
             "Sid": "CreateRDSInstancesWithOwnerTagRestriction",
             "Effect": "Allow",
-            "Action": "rds:CreateDBInstance",
+            "Action": [
+                "rds:CreateDBInstance",
+                "rds:CreateDBParameterGroup",
+                "rds:ModifyDBParameterGroup",
+                "rds:ResetDBParameterGroup",
+                "rds:DeleteDBParameterGroup",
+                "rds:DownloadCompleteDBLogFile"
+            ],
             "Resource": "*",
             "Condition": {
                 "StringEqualsIgnoreCase": {
@@ -170,7 +185,9 @@ Policy Name: GigadbRDSAccess
                 "rds:DeleteDBInstance",
                 "rds:RebootDBInstance",
                 "rds:ModifyDBInstance",
-                "rds:CreateDBSnapshot"
+                "rds:CreateDBSnapshot",
+                "rds:DownloadDBLogFilePortion",
+                "rds:DownloadCompleteDBLogFile"
             ],
             "Effect": "Allow",
             "Resource": "*",
@@ -197,14 +214,20 @@ Policy Name: GigadbRDSAccess
         {
             "Sid": "ManageDBParameterGroupWithOwnerTagRestriction",
             "Action": [
+                "rds:CreateDBParameterGroup",
                 "rds:ModifyDBParameterGroup",
-                "rds:ResetDBParameterGroup"
+                "rds:ResetDBParameterGroup",
+                "rds:DeleteDBParameterGroup"
             ],
             "Effect": "Allow",
             "Resource": "*",
             "Condition": {
                 "StringEqualsIgnoreCase": {
-                    "rds:pg-tag/Owner": "${aws:username}"
+                    "rds:pg-tag/Owner": "${aws:username}",
+                    "aws:RequestedRegion": [
+                        "ap-east-1",
+                        "ap-northeast-1"
+                    ]
                 }
             }
         },
@@ -230,12 +253,7 @@ Policy Name: GigadbRDSAccess
                 "rds:RestoreDBInstanceFromDBSnapshot"
             ],
             "Effect": "Allow",
-            "Resource": "*",
-            "Condition": {
-                "StringEqualsIgnoreCase": {
-                    "rds:snapshot-tag/Owner": "${aws:username}"
-                }
-            }
+            "Resource": "*"
         },
         {
             "Sid": "ManageEventSubscriptionsWithOwnerTagRestriction",

--- a/ops/deployment/docker-compose.yml
+++ b/ops/deployment/docker-compose.yml
@@ -127,7 +127,7 @@ services:
       - ${DATA_SAVE_PATH}/postgres/${POSTGRES_VERSION}/data:/var/lib/postgresql/data
       - ${APPLICATION}/fuw/app/common/config/bootstrap.sql:/docker-entrypoint-initdb.d/3-fuw.sql
       - ${APPLICATION}/ops/configuration/postgresql-conf/pg_hba.conf:/etc/postgresql/pg_hba.conf
-    command: postgres -c 'hba_file=/etc/postgresql/pg_hba.conf'
+    command: postgres -c 'hba_file=/etc/postgresql/pg_hba.conf' -c 'log_statement=all'
     networks:
       - db-tier
 

--- a/ops/infrastructure/modules/rds-instance/rds-instance.tf
+++ b/ops/infrastructure/modules/rds-instance/rds-instance.tf
@@ -38,6 +38,8 @@ module "db" {
 
   create_db_option_group    = false
   create_db_parameter_group = false
+
+  parameter_group_name      = (var.deployment_target == "staging" ? "gigadb-db-param-group" : null)
   engine                    = "postgres"
   engine_version            = "11.13"
   family                    = "postgres11"  # DB parameter group
@@ -55,15 +57,21 @@ module "db" {
   apply_immediately         = true
 }
 
-resource "aws_db_parameter_group" "log-statement" {
+resource "aws_db_parameter_group" "gigadb-db-param-group" {
   count = var.deployment_target == "staging" ? 1 : 0
-  name = "log-statement"
+  name = "gigadb-db-param-group"
   family = "postgres11"
 
   parameter {
     apply_method = "immediate"
     name = "log_statement"
     value = "all"
+  }
+
+  parameter {
+    apply_method = "immediate"
+    name = "log_min_duration_statement"
+    value = "0"  # Log all SQL statements
   }
 }
 

--- a/ops/infrastructure/modules/rds-instance/rds-instance.tf
+++ b/ops/infrastructure/modules/rds-instance/rds-instance.tf
@@ -55,6 +55,18 @@ module "db" {
   apply_immediately         = true
 }
 
+resource "aws_db_parameter_group" "log-statement" {
+  count = var.deployment_target == "staging" ? 1 : 0
+  name = "log-statement"
+  family = "postgres11"
+
+  parameter {
+    apply_method = "immediate"
+    name = "log_statement"
+    value = "all"
+  }
+}
+
 output "rds_instance_address" {
   value = module.db.db_instance_address
 }


### PR DESCRIPTION
# Pull request for issue: #837 

This is a pull request for the following functionalities:

* Logging of all SQL statements executed on PostgreSQL database by GigaDB application on dev and staging deployments

## Changes to the provisioning

`docker-compose.yml` has been updated so that for local dev deployments, the `postgres` command is executed with the log_statement=all parameter which configures the PostgreSQL database to log all SQL statements.

`rds-instance.tf` now contains a database parameter group resource which is conditionally associated to the RDS instance for staging deployments of GigaDB. Live GigaDB deployments will not log SQL statements. This database parameter group resource provides configuration for the PostgreSQL RDS instance to log all SQL statements. These SQL statements are contained within `postgres.log` files available from the AWS console for the RDS service in the `Log & events` tab. Here is an example [postgres.log](https://drive.google.com/file/d/1-IYLLSrOYYegmsvObi1E01q56cOecnzH/view?usp=sharing) file which was saved after a keyword search for `vulcan` was executed from the GigaDB website on the staging server.

`policy-rds.md` has been updated to include permissions for users to view and download database log files.

## Changes to the documentation

`README.md` and `SETUP_CI_CD_PIPELINE.md` have both been updated with information about the SQL statements being logged for local and staging deployments of GigaDB.
