### PR TITLE
To remove tickbox in lost password page

### DIFF
--- a/features/bootstrap/DatasetViewContext.php
+++ b/features/bootstrap/DatasetViewContext.php
@@ -480,4 +480,14 @@ class DatasetViewContext implements Context
         $metaNode = $this->minkContext->getSession()->getPage()->find('xpath', "//meta[@name='$arg1' and @content='$arg2']");
         PHPUnit_Framework_Assert::assertNotNull($metaNode);
     }
+
+    /**
+     * @Then I should not see a checkbox for the :arg1
+     * To assert the existence of a checkbox
+     */
+    public function iShouldNotSeeACheckbox($arg1)
+    {
+        $element = $this->minkContext->getSession()->getPage()->find('xpath', "//input[@id='$arg1' and @type='checkbox']");
+        PHPUnit_Framework_Assert::assertNull($element);
+    }
 }

--- a/features/lost-password-page.feature
+++ b/features/lost-password-page.feature
@@ -1,0 +1,35 @@
+@issue-876
+Feature:
+  As a gigadb user
+  I want to click lost password link
+  So that there is no mail list or terms and condition tick boxes
+
+  Background:
+    Given Gigadb web site is loaded with production-like data
+
+    @ok
+    Scenario: Go to log in page and lost password link is there
+      Given I am not logged in to Gigadb web site
+      When I am on "/site/login"
+      Then I should see "Lost Password"
+
+    @ok
+    Scenario: Click lost password link and will be on reset password page
+      Given I am not logged in to Gigadb web site
+      When I am on "/site/login"
+      And I click on the "Lost Password" button
+      Then I should be on "/user/reset/username//style/float%3Aright"
+      And I should see "If you have lost your password, enter your email and we will send a new password to the email address associated with your account."
+      And I should see "Email *"
+      And I should see a button input "Reset"
+
+    @ok
+    Scenario: Click lost password and tick box is not found
+      Given I am not logged in to Gigadb web site
+      When I am on "/site/login"
+      And I click on the "Lost Password" button
+      Then I should be on "/user/reset/username//style/float%3Aright"
+      And I should not see "Mailing list"
+      And I should not see "Please tick here to join the GigaDB mailing list to receive news, updates and quarterly newsletters about GigaDB"
+      And I should not see "Terms and Conditions *"
+      And I should not see "Please tick here to confirm you have read and understood our Terms of use and Privacy Policy"

--- a/features/lost-password-page.feature
+++ b/features/lost-password-page.feature
@@ -1,8 +1,8 @@
 @issue-876
 Feature:
-  As a gigadb user
-  I want to click lost password link
-  So that there is no mail list or terms and condition tick boxes
+  As a website user
+  I want to reset my password
+  So that I can sign in to GigaDB website again
 
   Background:
     Given Gigadb web site is loaded with production-like data

--- a/features/lost-password-page.feature
+++ b/features/lost-password-page.feature
@@ -30,6 +30,8 @@ Feature:
       And I click on the "Lost Password" button
       Then I should be on "/user/reset/username//style/float%3Aright"
       And I should not see "Mailing list"
+      And I should not see a checkbox for the "User_newsletter"
       And I should not see "Please tick here to join the GigaDB mailing list to receive news, updates and quarterly newsletters about GigaDB"
       And I should not see "Terms and Conditions *"
+      And I should not see a checkbox for the "User_terms"
       And I should not see "Please tick here to confirm you have read and understood our Terms of use and Privacy Policy"

--- a/less/current/pages/usercreate.less
+++ b/less/current/pages/usercreate.less
@@ -16,9 +16,6 @@
   line-height: initial;
   padding-right: 3px;
 }
-.create-div hr {
-  margin: 30px 0 30px 0;
-}
 .create-div .button-div {
   text-align: center;
 }
@@ -83,4 +80,13 @@
 }
 .notlogged {
   background-image: -webkit-linear-gradient(top,#cccccc,@color-dark-gray) !important;
+}
+.reset-message-div {
+  padding: 1px;
+  width: 650px;
+  margin: 1px auto;
+}
+.reset-message-div p {
+  text-align: left;
+  position: relative;
 }

--- a/less/current/pages/usercreate.less
+++ b/less/current/pages/usercreate.less
@@ -1,23 +1,21 @@
 /* usercreate */
 .create-div {
   background-color: @color-lighter-gray;
-  padding: 50px;
+  padding-top: 20px;
+  padding-bottom: 1px;
   width: 650px;
-  margin: 10px auto;
+  margin: 5px auto;
 }
 .create-div .form-control {
   height: 36px;
 }
-.create-div .col-xs-3.control-label {
-  padding-right: 12px;
+.create-div .col-xs-2.control-label {
+  text-align: right;
 }
 .create-div label::before{
   color: red;
   line-height: initial;
   padding-right: 3px;
-}
-.create-div .button-div {
-  text-align: center;
 }
 .create-div button {
   width: 236px;

--- a/protected/views/user/reset.php
+++ b/protected/views/user/reset.php
@@ -1,14 +1,14 @@
  <div class="content">
-        <div class="container">
-              <section class="page-title-section">
-                <div class="page-title">
-                    <ol class="breadcrumb pull-right">
-                        <li><a href="/">Home</a></li>
-                        <li class="active">Reset</li>
-                    </ol>
-                    <h4>Reset Password</h4>
-                </div>
-            </section>
+     <div class="container">
+         <section class="page-title-section">
+            <div class="page-title">
+                <ol class="breadcrumb pull-right">
+                    <li><a href="/">Home</a></li>
+                    <li class="active">Reset</li>
+                </ol>
+                <h4>Reset Password</h4>
+            </div>
+         </section>
         <div class="subsection" style="margin-bottom: 130px;">
 		<p>Fields with <span class="symbol">*</span> are required.</p>
             <div class="reset-message-div">
@@ -31,7 +31,6 @@
                         <?= CHtml::submitButton(Yii::t('app' , 'Reset') , array('class'=>'btn background-btn')) ?>
                     </div>
                 </div>
-
                 <? $this->endWidget() ?>
             </div>
 	    </div>

--- a/protected/views/user/reset.php
+++ b/protected/views/user/reset.php
@@ -10,60 +10,31 @@
                 </div>
             </section>
         <div class="subsection" style="margin-bottom: 130px;">
-	
-		<div class="clear"></div>
-		
 		<p>Fields with <span class="symbol">*</span> are required.</p>
-		<div class="create-div">
-			<? $form=$this->beginWidget('CActiveForm', array(
-				'id'=>'user-form',
-				'enableAjaxValidation'=>false,
-				'htmlOptions'=>array('class'=>'form-horizontal')
-			)) ?>
-				 <div class="form-group">
-					<?= $form->labelEx($model,'email', array('class'=>'col-xs-3 control-label')) ?>
-					<div class="col-xs-9">
-						<?= $form->textField($model,'email',array('class'=>'form-control')) ?>
-						<font color="red"><?= $form->error($model,'email') ?></font>
-					</div>
-				</div>
-
-                                <div class="form-group">
-                                    <label class="col-xs-3 control-label"><?=Yii::t('app' , 'Mailing list')?></label>
-                                   
-				    <div class="col-xs-9">				    	
-                                         <?php echo $form->checkbox($model,'newsletter'); ?>
-				    </div>
-                                    <div class="col-xs-9">
-                                        <p>Please tick here to join the GigaDB mailing list to receive news, updates and quarterly newsletters about GigaDB</p>   
-                                    </div>
-                                 </div>
-                                <div class="form-group">
-                                    <?= $form->labelEx($model,'terms', array('class'=>'col-xs-3 control-label')) ?>              
-				    <div class="col-xs-9">				    	
-                                         <?php echo $form->checkbox($model,'terms'); ?>
-                                         <font color="red"><?= $form->error($model,'terms') ?></font>
-				    </div>
-                                    <div class="col-xs-9">
-                                     <p>Please tick here to confirm you have read and understood our <a href="/site/term#policies">Terms of use</a> and <a href="/site/term#privacy">Privacy Policy</a></p>
-                                    </div>
-                                 </div>
-                                
-
-
-			
-                        <hr>
-                            <div class="button-div">
-                                <?= CHtml::submitButton(Yii::t('app' , 'Reset') , array('class'=>'btn background-btn')) ?>
-                            </div>
-                        <? $this->endWidget() ?>
-		</div><!--well-->
-		
-
-
-	
-	</div><!--span8-->
-    </div><!-- user-form -->
+            <div class="reset-message-div">
+                <p>
+                    If you have lost your password, enter your email and we will send a new password to the email address associated with your account.
+                </p>
+            </div>
+            <div class="create-div">
+                <? $form=$this->beginWidget('CActiveForm', array(
+                    'id'=>'user-form',
+                    'enableAjaxValidation'=>false,
+                    'htmlOptions'=>array('class'=>'form-horizontal')
+                )) ?>
+                     <div class="form-group">
+                        <?= $form->labelEx($model,'email', array('class'=>'col-xs-3 control-label')) ?>
+                        <div class="col-xs-9">
+                            <?= $form->textField($model,'email',array('class'=>'form-control')) ?>
+                        </div>
+                    </div>
+                    <div class="button-div">
+                        <?= CHtml::submitButton(Yii::t('app' , 'Reset') , array('class'=>'btn background-btn')) ?>
+                    </div>
+                <? $this->endWidget() ?>
+            </div>
+	    </div>
+    </div>
 </div>
 
 <script type="text/javascript">

--- a/protected/views/user/reset.php
+++ b/protected/views/user/reset.php
@@ -22,15 +22,16 @@
                     'enableAjaxValidation'=>false,
                     'htmlOptions'=>array('class'=>'form-horizontal')
                 )) ?>
-                     <div class="form-group">
-                        <?= $form->labelEx($model,'email', array('class'=>'col-xs-3 control-label')) ?>
-                        <div class="col-xs-9">
-                            <?= $form->textField($model,'email',array('class'=>'form-control')) ?>
-                        </div>
+                <div class="form-group">
+                    <?= $form->labelEx($model,'email', array('class'=>'col-xs-2 control-label')) ?>
+                    <div class="col-xs-8">
+                        <?= $form->textField($model,'email',array('class'=>'form-control')) ?>
                     </div>
-                    <div class="button-div">
+                    <div class="col-xs-2">
                         <?= CHtml::submitButton(Yii::t('app' , 'Reset') , array('class'=>'btn background-btn')) ?>
                     </div>
+                </div>
+
                 <? $this->endWidget() ?>
             </div>
 	    </div>


### PR DESCRIPTION
# Pull request for issue: #876 

This is a pull request for the following functionalities:

## Changes to the view template files
1. Removed checkbox from the reset page
2. Added description to the reset page
3. Changed the style

## Changes to the tests
1. Created `lost-password-page.feature` file to test that there are no mailing list, T&C and checkbox. 

## The page before fix
![image](https://user-images.githubusercontent.com/64770635/144998836-56c2fafe-ec2f-4a9c-9428-f01543c8c07a.png)


## The page after fix
![image](https://user-images.githubusercontent.com/64770635/144998733-170f32da-82ba-412e-90d9-f68a7764692d.png)
 
