### PR TITLE
Fix contact us email

### DIFF
--- a/ops/configuration/yii-conf/web.php.dist
+++ b/ops/configuration/yii-conf/web.php.dist
@@ -11,7 +11,7 @@ return [
     'components' => [
         'mailer' => [
             'class' => 'yii\swiftmailer\Mailer',
-            'useFileTransport' => true,
+            'useFileTransport' => false,
             'fileTransportPath'=>'/var/www/protected/runtime/mail',
             'transport' => [
                 'class' => 'Swift_SmtpTransport',

--- a/protected/controllers/SiteController.php
+++ b/protected/controllers/SiteController.php
@@ -1,6 +1,10 @@
 <?php
 
 use Ramsey\Uuid\Uuid;
+
+use yii\swiftmailer\mailer;
+use yii\swiftmailer\Message;
+
 class SiteController extends Controller {
     /**
  	 * Declares class-based actions.
@@ -273,24 +277,23 @@ class SiteController extends Controller {
         $this->render('guidesoftware');
     }
 
-	/**
-	 * Displays the contact page
-	 */
-	public function actionContact() {
-
-            $this->layout='new_main';
-		$model = new ContactForm;
-		if (isset($_POST['ContactForm'])) {
-			$model->attributes=$_POST['ContactForm'];
-			if ($model->validate()) {
-				$headers = "From: {$model->name}<{$model->email}>\r\nReply-To: {$model->email}";
-				mail(Yii::app()->params['adminEmail'],$model->subject,$model->body,$headers);
-        Yii::app()->user->setFlash('contact','Thank you for contacting us. We will respond to you as soon as possible.');
-				$this->refresh();
-			}
-		}
-		$this->render('contact',array('model'=>$model));
-	}
+    /**
+     * Display /site/contact page
+     */
+    public function actionContact()
+    {
+        $this->layout = 'new_main';
+        $model = new ContactForm;
+        if (isset($_POST['ContactForm'])) {
+            $model->attributes = $_POST['ContactForm'];
+            if ($model->validate()) {
+                Yii::app()->mailService->sendEmail(Yii::app()->params['adminEmail'], Yii::app()->params['adminEmail'], Yii::app()->params['email_prefix'] . $model->subject, "Message from: " . $model->name . " <" . $model->email . ">\n\n" . $model->body);
+                Yii::app()->user->setFlash('contact', 'Thank you for contacting us. We will respond to you as soon as possible.');
+                $this->refresh();
+            }
+        }
+        $this->render('contact', array('model' => $model));
+    }
 	/**
 	*This method returns all dataset locations
 	*/

--- a/protected/controllers/SiteController.php
+++ b/protected/controllers/SiteController.php
@@ -287,7 +287,11 @@ class SiteController extends Controller {
         if (isset($_POST['ContactForm'])) {
             $model->attributes = $_POST['ContactForm'];
             if ($model->validate()) {
-                Yii::app()->mailService->sendEmail(Yii::app()->params['adminEmail'], Yii::app()->params['adminEmail'], Yii::app()->params['email_prefix'] . $model->subject, "Message from: " . $model->name . " <" . $model->email . ">\n\n" . $model->body);
+                try {
+                    Yii::app()->mailService->sendEmail(Yii::app()->params['adminEmail'], Yii::app()->params['adminEmail'], Yii::app()->params['email_prefix'] . $model->subject, "Message from: " . $model->name . " <" . $model->email . ">\n\n" . $model->body);
+                } catch (Swift_TransportException $ste) {
+                    Yii::log("Problem sending email from contact page - " . $ste->getMessage(), "error");
+                }
                 Yii::app()->user->setFlash('contact', 'Thank you for contacting us. We will respond to you as soon as possible.');
                 $this->refresh();
             }

--- a/protected/tests/functional_custom_bootstrap.php
+++ b/protected/tests/functional_custom_bootstrap.php
@@ -13,7 +13,7 @@ $yii=dirname(__FILE__).'/../components/Yii.php';
 require_once($yii);
 
 # load Yii 2 (but don't run the web application)
-$yii2Config = require(__DIR__ . '/../config/yii2/web.php');
+$yii2Config = require(__DIR__ . '/../config/yii2/test.php');
 new yii\web\Application($yii2Config);
 
 


### PR DESCRIPTION
# Pull request for issue: #863

This is a pull request for the following functionalities:

* A fix for the sending email bug on Contact `/site/contact` web page

## Changes to the controller classes

The `actionContact()` function in `SiteController.php` has been updated to use the mailService component which is the standard way for sending emails in GigaDB website.

## Changes to the provisioning

This was the cause of the email sending bug. `ops/configuration/yii-conf/web.php.dist` has been updated with `'useFileTransport' => false` to enable emails to be sent using the configured SMTP server. Previously, `'useFileTransport' => true` which caused email messages to be saved as `eml` files in `/var/www/protected/runtime/mail` so this explains why emails from the contact page were never received. You can either save the messages to `eml` files or send them to the actual recipients, but can not do both simultaneously - see [here](https://www.yiiframework.com/doc/guide/2.0/en/tutorial-mailing).

>N.B. You must have the following Gitlab variables in your project: SERVER_EMAIL, SERVER_EMAIL_PASSWORD, SERVER_EMAIL_SMTP_PORT=465. You can use test@gigasciencejournal.com credentials.

>To improve the security of email sending, see #888.

## Changes to the tests

`protected/tests/functional_custom_bootstrap.php` has now been configured so that `$yii2Config` uses `config/yii2/test.php`. The configuration in this `test.php` file allows email messages to be saved as `eml` files which need to be parsed as part of the functional tests in `MailServiceTest.php`.