### PR TITLE
Server error occurs when updating file as an admin with no set release date

### DIFF
--- a/protected/models/File.php
+++ b/protected/models/File.php
@@ -303,7 +303,23 @@ class File extends CActiveRecord
 
     /**
      * Before save file
+     *
+     * ensure the release date can be unset
+     *
+     * @see https://www.yiiframework.com/doc/api/1.1/CActiveRecord#beforeSave-detail
+     * @return boolean
      */
+    public function beforeSave()
+    {
+        if (parent::beforeSave()) {
+            $this->date_stamp = ('' === $this->attributes['date_stamp']) ? null :  $this->attributes['date_stamp'] ;
+            return true;
+        }
+        else
+            return false;
+
+    }
+
     public function setSizeValue()
     {
         // Save the size from file if not set by user

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -43,3 +43,4 @@ gherkin:
         - AuthorSteps
       "website user":
         - WebsiteUserSteps
+bootstrap: initdb.php

--- a/tests/acceptance/AdminFileForm.feature
+++ b/tests/acceptance/AdminFileForm.feature
@@ -1,0 +1,22 @@
+Feature: form to manage file metadata
+  As a curator
+  I want to access a form to update file metadata
+  So that the metadata always reflects changes to the file or file workflow
+
+
+  Background:
+    Given I have signed in as admin
+
+  @ok
+  Scenario: Can unset release date
+    Given I am on "/adminFile/update/id/17679"
+    When I fill in the field of "id" "File_date_stamp" with ""
+    And I press the button "Save"
+    Then I should see "Not set"
+
+  @ok
+  Scenario: Can change release date
+    Given I am on "/adminFile/update/id/17679"
+    When I fill in the field of "id" "File_date_stamp" with "2022-01-01"
+    And I press the button "Save"
+    Then I should see "2022-01-01"

--- a/tests/acceptance/initdb.php
+++ b/tests/acceptance/initdb.php
@@ -1,0 +1,7 @@
+<?php
+
+shell_exec("./protected/yiic migrate to 300000_000000 --connectionID=db --migrationPath=application.migrations.admin --interactive=0");
+shell_exec("./protected/yiic migrate mark 000000_000000 --connectionID=db --interactive=0");
+shell_exec("./protected/yiic migrate --connectionID=db --migrationPath=application.migrations.schema --interactive=0");
+shell_exec("./protected/yiic migrate --connectionID=db --migrationPath=application.migrations.data.dev --interactive=0");
+shell_exec("./protected/yiic sequencefixer fixAll");

--- a/tests/acceptance_runner
+++ b/tests/acceptance_runner
@@ -7,5 +7,4 @@ profile=${1:-"local"}
 
 docker-compose run --rm application ./protected/yiic migrate --interactive=0
 docker-compose run --rm test ./vendor/behat/behat/bin/behat --profile $profile -v --stop-on-failure
-./ops/scripts/setup_devdb.sh dev
 docker-compose run --rm test ./vendor/codeception/codeception/codecept run -g ok acceptance


### PR DESCRIPTION
# Pull request for issue: #886

This is a pull request for the following functionalities:

server error occurs when updating file metadata with an unset release date.
The root cause is that unsetting the date in the UI cause an empty string to be passed in the SQL to update the record, which is considered (rightfully) as an invalid date format by PostgreSQL.

## Changes to the database schema

n/a

## Changes to the model classes

* ``protected/models/File.php``

File is a subclass of CActiveRecord.
We've added a  ``beforeSave()`` hook that overrides Yii CActiveRecord's default ``beforeSave()`` in which 
we intercept changes to the release date field (``date_stamp``) and if it's an empty string
we set it to null.

## Changes to the controller classes

n/a

## Changes to the view template files

n/a

## Changes to the style

n/a

## Changes to the tests

* ``tests/acceptance/AdminFileForm.feature``
*  ``tests/acceptance.suite.yml``
*  ``tests/acceptance/initdb.php``
*  ``tests/acceptance_runner``

Added acceptance tests scenarios to test that release date can be unset and can be changed.
Also added a boostrap script to the acceptance tests suite so that it can be run manually and independently as it can reset the database state independently.

## Changes to the provisioning

n/a
