### PR TITLE
Fix CSort syntax for sorting dataset samples by DOI in admin pages

### DIFF
--- a/protected/models/DatasetSample.php
+++ b/protected/models/DatasetSample.php
@@ -112,8 +112,8 @@ class DatasetSample extends CActiveRecord
 		$sort = new CSort();
 		$sort->attributes = array(
 			'doi_search' => array(
-				'asc' => '(SELECT identifier from dataset d WHERE dataset.id = t.dataset_id) ASC',
-				'desc' => '(SELECT identifier from dataset d WHERE dataset.id = t.dataset_id) DESC',
+				'asc' => 'identifier ASC',
+				'desc' => 'identifier DESC',
 			),
 		);
 

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -227,4 +227,13 @@ class AcceptanceTester extends \Codeception\Actor
         $actualUrl = $this->grabAttributeFrom("//img[@src='$image']/parent::*", "href");
         $this->assertEquals($expectedUrl, $actualUrl);
     }
+
+    /**
+     * @Then I should be on :path
+     */
+    public function iShouldBeOn($path)
+    {
+        $this->seeCurrentUrlEquals($path);
+    }
+
 }

--- a/tests/acceptance/AdminDatasetSample.feature
+++ b/tests/acceptance/AdminDatasetSample.feature
@@ -22,3 +22,18 @@ Feature: admin page for samples
     And I should see "Geographic location (country and/or sea,region):Antarctica, Inexpressible Island, Ross Sea"
     And I should see "Alternative names:PYGAD"
     And I should not see "... +"
+
+   @ok
+  Scenario: Sorting on DOI column in ascending order
+     Given I am on "/adminDatasetSample/admin"
+     When I follow "DOI"
+     Then I should be on "/adminDatasetSample/admin/sort/doi_search"
+     And I should see "100006"
+
+  @ok
+  Scenario: Sorting on DOI column in descending order
+    Given I am on "/adminDatasetSample/admin"
+    When I follow "DOI"
+    And I follow "DOI"
+    Then I should be on "/adminDatasetSample/admin/sort/doi_search.desc"
+    And I should see "100006"


### PR DESCRIPTION
# Pull request for issue: #943

This is a pull request for the following functionalities:

The syntax for using CSort for configuring ascending and descending sort order
on the identifier table column was incorrect, causing server error.

## Changes to the model classes

* ``protected/models/DatasetSample.php``

Correct the syntax for specifying how to sort on the identifier column, ascending and descending respectively

## Changes to the tests

* ``tests/acceptance/AdminDatasetSample.feature``
*  ``tests/_support/AcceptanceTester.php``


Added two scenarios that check there is no more server error when using the web UI to sort out using "DOI" label column in ascencing and descending order repectively. 

Added a generic step implementation to help with checking current url changes match expected behaviours for the Yii's CGridView widget and CSort algorithm.