### PR TITLE
Fix problems with dataset spreadsheet upload

### DIFF
--- a/protected/components/MailService.php
+++ b/protected/components/MailService.php
@@ -70,9 +70,10 @@ class MailService extends CApplicationComponent
      * @param string $subject email's subject
      * @param string $content content to send
      * @param string $filepath path to file attachment
+     * @param string $attachmentFileName name for the file attachment
      * @return bool whether sending the email is successful or not
      */
-    public function sendHTMLEmailWithAttachment(string $from, string $to, string $subject, string $content, string $filepath)
+    public function sendHTMLEmailWithAttachment(string $from, string $to, string $subject, string $content, string $filepath, string $attachmentFileName)
     {
         return $this->mailer->compose('template',
             ['top_img' => '/var/www/images/email/top.png',
@@ -82,7 +83,7 @@ class MailService extends CApplicationComponent
             ->setFrom($from)
             ->setTo($to)
             ->setSubject($subject)
-            ->attach($filepath)
+            ->attach($filepath, array("fileName" => $attachmentFileName))
             ->send();
     }
 }

--- a/protected/controllers/DatasetSubmissionController.php
+++ b/protected/controllers/DatasetSubmissionController.php
@@ -60,7 +60,8 @@ class DatasetSubmissionController extends Controller
         if (isset($_POST['userId'])) {
             $user = User::model()->findByPk(Yii::app()->user->id);
             $excelFile = CUploadedFile::getInstanceByName('xls');
-            $excelTempFileName = $excelFile->tempName;
+            $uploadedFilePath = $excelFile->tempName;
+            $filename = $excelFile->name;
             $subject = "New dataset uploaded by user ".$user->id." - ".$user->first_name.' '.$user->last_name;
             $receiveNewsletter = $user->newsletter ? 'Yes' : 'No';
             $message = <<<EO_MAIL
@@ -81,7 +82,7 @@ Receiving Newsletter:  <b>{$receiveNewsletter}</b>
 <br/><br/>
 EO_MAIL;
 
-            $email_status = Yii::app()->mailService->sendHTMLEmailWithAttachment(Yii::app()->params['app_email'], Yii::app()->params['adminEmail'], Yii::app()->params['email_prefix'] . $subject, $message, $excelTempFileName);
+            $email_status = Yii::app()->mailService->sendHTMLEmailWithAttachment(Yii::app()->params['app_email'], Yii::app()->params['adminEmail'], Yii::app()->params['email_prefix'] . $subject, $message, $uploadedFilePath, $filename);
             if ($email_status) {
                 $this->redirect('/datasetSubmission/upload/status/successful');
                 return;

--- a/protected/tests/functional/MailServiceTest.php
+++ b/protected/tests/functional/MailServiceTest.php
@@ -129,8 +129,9 @@ class MailServiceTest extends FunctionalTesting
             $subject = "Test HTML message";
             $body = "<h1>Hello World</h1>";
             $filepath = "/var/www/images/new_interface_image/frog.jpg";
-            $result = Yii::app()->mailService->sendHTMLEmailWithAttachment($from, $to, $subject, $body, $filepath);
-            $this->assertTrue($result, "Problem sending email using MailService sendHTMLEmail function");
+            $filename = "frog.jpg";
+            $result = Yii::app()->mailService->sendHTMLEmailWithAttachment($from, $to, $subject, $body, $filepath, $filename);
+            $this->assertTrue($result, "Problem sending email using MailService sendHTMLEmailWithAttachment function");
             $msg = $this->getLastMessage();
 
             $parser = new PhpMimeMailParser\Parser();

--- a/protected/views/datasetSubmission/upload.php
+++ b/protected/views/datasetSubmission/upload.php
@@ -94,11 +94,11 @@ if (isset($_GET['status'])) {
                             <br/>
                             <div class="clear"></div>
                             <div class="pull-right">
-                                <?php echo CHtml::submitButton('Upload New Dataset', array('class' => 'btn-green upload-control', 'disabled' => 'disabled', 'title' => 'You must agree to the terms and conditions before continuing.')); ?>
+                                <?php echo CHtml::submitButton('Upload New Dataset', array('class' => 'btn-green submit-button-control', 'disabled' => 'disabled', 'title' => 'You must agree to the terms and conditions before continuing.')); ?>
                             </div>
                             <?php echo CHtml::hiddenField('userId', Yii::app()->user->id); ?>
                             <?php echo CHtml::label('Excel File', 'xls'); ?>
-                            <?php echo CHtml::fileField('xls', null, array('disabled' => 'disabled', 'class' => 'upload-control', 'title' => 'You must agree to the terms and conditions before continuing.')); ?>
+                            <?php echo CHtml::fileField('xls', null, array('disabled' => 'disabled', 'class' => 'file-upload-control', 'title' => 'You must agree to the terms and conditions before continuing.')); ?>
                             <?php echo CHtml::endForm(); ?>
 
                         </div>
@@ -137,7 +137,7 @@ if (isset($_GET['status'])) {
                         <div class="clear"></div>
                         <?php echo CHtml::form(Yii::app()->createUrl('datasetSubmission/create1'), 'post', array('enctype' => 'multipart/form-data')); ?>
                         <div class="pull-right">
-                            <?php echo CHtml::submitButton('Submission wizard', array('id' => 'online', 'class' => 'btn-green', 'disabled' => 'disabled', 'title' => 'You must agree to the terms and conditions before continuing.')); ?>
+                            <?php echo CHtml::submitButton('Submission wizard', array('id' => 'online', 'class' => 'btn-green', 'disabled' => 'disabled', 'title' => 'You must agree to the terms and conditions before continuing.', 'onclick' => 'GFG_Fun()')); ?>
                         </div>
                         <br/>
                     </div>
@@ -152,10 +152,13 @@ if (isset($_GET['status'])) {
         $(function() {
             $('#agree-checkbox').click(function() {
                 if ($(this).is(':checked')) {
-                    $('.upload-control').attr('disabled', false);
+                    $('.file-upload-control').attr('disabled', false);
                 } else {
-                    $('.upload-control').attr('disabled', true);
+                    $('.file-upload-control').attr('disabled', true);
                 }
+            });
+            $('#xls').change(function (){
+                $('.submit-button-control').attr('disabled', false);
             });
             $('#agree-checkbox1').click(function() {
                 if ($(this).is(':checked')) {
@@ -165,5 +168,16 @@ if (isset($_GET['status'])) {
                 }
             });
         });
+    </script>
+    
+    <script>
+        function GFG_Fun() {
+            if ($('#xls')[0].files.length === 0) ) {
+                $('.submit-button-control').attr('disabled', true);
+            }
+            else {
+                $('.submit-button-control').attr('disabled', false);
+            }
+        }
     </script>
 <? } ?>

--- a/protected/views/datasetSubmission/upload.php
+++ b/protected/views/datasetSubmission/upload.php
@@ -155,6 +155,7 @@ if (isset($_GET['status'])) {
                     $('.file-upload-control').attr('disabled', false);
                 } else {
                     $('.file-upload-control').attr('disabled', true);
+                    $('.submit-button-control').attr('disabled', true);
                 }
             });
             $('#xls').change(function (){

--- a/protected/views/datasetSubmission/upload.php
+++ b/protected/views/datasetSubmission/upload.php
@@ -137,7 +137,7 @@ if (isset($_GET['status'])) {
                         <div class="clear"></div>
                         <?php echo CHtml::form(Yii::app()->createUrl('datasetSubmission/create1'), 'post', array('enctype' => 'multipart/form-data')); ?>
                         <div class="pull-right">
-                            <?php echo CHtml::submitButton('Submission wizard', array('id' => 'online', 'class' => 'btn-green', 'disabled' => 'disabled', 'title' => 'You must agree to the terms and conditions before continuing.', 'onclick' => 'GFG_Fun()')); ?>
+                            <?php echo CHtml::submitButton('Submission wizard', array('id' => 'online', 'class' => 'btn-green', 'disabled' => 'disabled', 'title' => 'You must agree to the terms and conditions before continuing.')); ?>
                         </div>
                         <br/>
                     </div>
@@ -169,16 +169,5 @@ if (isset($_GET['status'])) {
                 }
             });
         });
-    </script>
-    
-    <script>
-        function GFG_Fun() {
-            if ($('#xls')[0].files.length === 0) ) {
-                $('.submit-button-control').attr('disabled', true);
-            }
-            else {
-                $('.submit-button-control').attr('disabled', false);
-            }
-        }
     </script>
 <? } ?>

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -137,6 +137,14 @@ class AcceptanceTester extends \Codeception\Actor
     }
 
     /**
+     * @Then I should see a disabled submit button :value
+     */
+    public function iShouldSeeADisabledSubmitButton($value)
+    {
+        $this->seeElement(Locator::find('input', ['type' => 'submit', 'value' => $value, 'disabled' =>'disabled']));
+    }
+
+    /**
      * @When I fill in the field of :attribute :fieldName with :value
      */
     public function iFillInTheFieldOfWith($attribute, $fieldName, $value)

--- a/tests/acceptance/DatasetUpload.feature
+++ b/tests/acceptance/DatasetUpload.feature
@@ -22,3 +22,10 @@ Scenario: Upload dataset metadata with an Excel spreadsheet
   And I press the button "Upload New Dataset"
   Then I should see "Your GigaDB submission has been received and is currently under review."
   And I should see a link "Back to upload new dataset" to "/datasetSubmission/upload"
+
+@ok
+Scenario: Ensure submit button is disabled after checking terms checkbox
+  Given I sign in as a user
+  And I am on "/datasetSubmission/upload"
+  When I check "agree-checkbox" checkbox
+  Then I should see a disabled submit button "Upload New Dataset"


### PR DESCRIPTION
# Pull request for issue: #862 Error when attempting to submit dataset spreadsheet via webpage

This is a pull request for the following functionalities:

* Correct behaviour between Terms & Conditions checkbox, input file selector for choosing spreadsheet to upload and Upload New Dataset button on the `/datasetSubmission/upload` page
* The filename of the spreadsheet attachment in the email now has the original spreadsheet filename that has been uploaded by the user

## Changes to the Component classes

The `sendHTMLEmailWithAttachment()` function in `MailService.php` now requires a new argument `$attachmentFileName` which provides the filename that the attachment should have instead of a randomly generated name.

## Changes to the controller classes

The `actionUpload()` function in `DatasetSubmissionController.php` has been updated so that it can provide the `sendHTMLEmailWithAttachment()` function in `MailService.php` with a filename for the attachment in the email.

## Changes to the view template files

The `protected/views/datasetSubmission/upload.php` file has been updated to correct the behaviour between Terms & Conditions checkbox, input file selector for choosing spreadsheet to upload and `Upload New Dataset` button. Checking the Terms & Conditions checkbox will now enable the input file selector but keep the `Upload New Dataset` button disabled. This button will only be enabled when the user selects a file to upload. This has been implemented by separating the control of the input file selector and the Upload New Dataset button.

## Changes to the tests

The functional test `MailServiceTest.php` has been updated so that it can provide the `sendHTMLEmailWithAttachment()` function in `MailService.php` with a filename for the attachment.

A new acceptance test has been added to `DatasetUpload.feature` to ensure that the `Upload New Dataset` button remains disabled even when the Terms & Conditions checkbox has been checked.

