### PR TITLE
Fix problem where search could not find genome

### DIFF
--- a/protected/components/DatabaseSearch.php
+++ b/protected/components/DatabaseSearch.php
@@ -69,6 +69,14 @@ class DatabaseSearch extends CApplicationComponent {
 		    return $command->join("dataset_type dt","d.id = dt.dataset_id")
                 ->join("type t", "dt.type_id=t.id")
                 ->where(array('in', 't.name', $types))
+                ->andWhere("d.upload_status = 'Published'")
+                ->queryAll();
+        }
+
+		if($author_id) {
+		    return $command->join("dataset_author da","d.id = da.dataset_id")
+                ->where('da.author_id=:id', array(':id'=>$author_id))
+                ->andWhere("d.upload_status = 'Published'")
                 ->queryAll();
         }
 

--- a/protected/components/DatabaseSearch.php
+++ b/protected/components/DatabaseSearch.php
@@ -65,6 +65,13 @@ class DatabaseSearch extends CApplicationComponent {
 		$command->selectDistinct("d.id, d.shorturl, d.identifier, d.authornames, d.title, d.description");
 		$command->from = "dataset_finder d";
 
+		if (count($types)>0) {
+		    return $command->join("dataset_type dt","d.id = dt.dataset_id")
+                ->join("type t", "dt.type_id=t.id")
+                ->where(array('in', 't.name', $types))
+                ->queryAll();
+        }
+
         $searchQuery = "$keyword";
         if($types) {
             $typesStr = implode(" ", $types);

--- a/protected/migrations/schema/m220127_150844_search_materialized_views_gin_indexes.php
+++ b/protected/migrations/schema/m220127_150844_search_materialized_views_gin_indexes.php
@@ -118,6 +118,7 @@ SELECT f.*, fs.sample_id as sample_id, ff.name as file_format, ft.name as file_t
 	left join dataset_types dt on dt.dataset_id = d.id
 	left join external_links el on el.dataset_id = d.id")->execute();
 
+        Yii::app()->db->createCommand("alter role gigadb in database gigadb SET default_text_search_config TO 'pg_catalog.english'")->execute();
         Yii::app()->db->createCommand("drop index if exists dataset_finder_search_idx")->execute();
         Yii::app()->db->createCommand("create index dataset_finder_search_idx on dataset_finder using GIN (to_tsvector('english',document))")->execute();
 

--- a/protected/migrations/schema/m220127_150844_search_materialized_views_gin_indexes.php
+++ b/protected/migrations/schema/m220127_150844_search_materialized_views_gin_indexes.php
@@ -13,6 +13,9 @@ class m220127_150844_search_materialized_views_gin_indexes extends CDbMigration
 	// Use safeUp/safeDown to do migration with transaction
 	public function safeUp()
 	{
+        //Ensure full-text search uses english dictionary on all environments
+	    Yii::app()->db->createCommand("alter role gigadb in database gigadb SET default_text_search_config TO 'pg_catalog.english'")->execute();
+
 	    //First query
         Yii::app()->db->createCommand("drop materialized view if exists file_finder")->execute();
 	    Yii::app()->db->createCommand("create materialized view file_finder as
@@ -105,7 +108,7 @@ SELECT f.*, fs.sample_id as sample_id, ff.name as file_format, ft.name as file_t
 		dal.authorlinks as authornames,
 		d.title as title,
 		d.description as description,
-		coalesce(d.identifier,'') || coalesce(d.title,'') || coalesce(daf.names,'') || coalesce(dai.names,'') || coalesce(d.description,'') || coalesce(dt.types,'') || coalesce(dk.keywords,'') || coalesce(dp.names,'') || coalesce(m.identifier,'') || coalesce(m.pmid::varchar,'') || coalesce(df.grant_award, '') || coalesce(df.comments,'') || coalesce(fn.primary_name_display,'') || coalesce(el.external_links,'') || 'published:' || to_char(d.publication_date,'YYYY-MM-DD') || ',' || to_char(d.publication_date,'YYYY-MM') || ',' || to_char(d.publication_date,'YYYY')as document
+		coalesce(d.identifier,'') || ' ' || coalesce(d.title,'') || ' ' || coalesce(dt.types,'') || ' ' || coalesce(daf.names,'') || ' ' || coalesce(dai.names,'') || ' ' || coalesce(d.description,'') || ' ' || coalesce(dt.types,'') || ' ' || coalesce(dk.keywords,'') || ' ' || coalesce(dp.names,'') || ' ' || coalesce(m.identifier,'') || ' '  || coalesce(m.pmid::varchar,'') || ' ' || coalesce(df.grant_award, '') || ' ' || coalesce(df.comments,'') || ' ' || coalesce(fn.primary_name_display,'') || ' ' || coalesce(el.external_links,'') || ' ' || 'published:' || to_char(d.publication_date,'YYYY-MM-DD') || ',' || to_char(d.publication_date,'YYYY-MM') || ',' || to_char(d.publication_date,'YYYY') as document
 	from dataset d
 	left join manuscript m on d.id = m.dataset_id
 	left join dataset_funder df on df.dataset_id = d.id
@@ -118,7 +121,7 @@ SELECT f.*, fs.sample_id as sample_id, ff.name as file_format, ft.name as file_t
 	left join dataset_types dt on dt.dataset_id = d.id
 	left join external_links el on el.dataset_id = d.id")->execute();
 
-        Yii::app()->db->createCommand("alter role gigadb in database gigadb SET default_text_search_config TO 'pg_catalog.english'")->execute();
+
         Yii::app()->db->createCommand("drop index if exists dataset_finder_search_idx")->execute();
         Yii::app()->db->createCommand("create index dataset_finder_search_idx on dataset_finder using GIN (to_tsvector('english',document))")->execute();
 

--- a/protected/views/site/index.php
+++ b/protected/views/site/index.php
@@ -26,73 +26,73 @@
                         </div>
                         <ul class="list-inline home-text-icon-list">
                             <li>
-                                <a href="/search/new?keyword=Genomic&type%5B%5D=dataset&dataset_type%5B%5D=2">
+                                <a href="/search/new?keyword=Genomic&type%5B%5D=dataset&dataset_type%5B%5D=Genomic">
                                     <div class="text-icon text-icon-green">
                                         <img src="/images/new_interface_image/Genomic.svg" alt="Link to Genomic datasets">
                                     </div>Genomic (<span><? echo $number_genomic ?></span>)</a>
                             </li>
                             <li>
-                                <a href="/search/new?keyword=Software&type%5B%5D=dataset&dataset_type%5B%5D=6">
+                                <a href="/search/new?keyword=Software&type%5B%5D=dataset&dataset_type%5B%5D=Software">
                                     <div class="text-icon text-icon-blue">
                                         <img src="/images/new_interface_image/Software.svg" alt="Link to Software datasets">
                                     </div>Software (<span><? echo $number_software ?></span>)</a>
                             </li>
                             <li>
-                                <a href="/search/new?keyword=Transcriptomic&type%5B%5D=dataset&dataset_type%5B%5D=4">
+                                <a href="/search/new?keyword=Transcriptomic&type%5B%5D=dataset&dataset_type%5B%5D=Transcriptomic">
                                     <div class="text-icon text-icon-blue">
                                         <img src="/images/new_interface_image/Transcriptomic.svg" alt="Link to Transcriptomic datasets">
                                     </div>Transcriptomic (<span><? echo $number_ts ?></span>)</a>
                             </li>
                             <li>
-                                <a href="/search/new?keyword=Imaging&type%5B%5D=dataset&dataset_type%5B%5D=7">
+                                <a href="/search/new?keyword=Imaging&type%5B%5D=dataset&dataset_type%5B%5D=Imaging">
                                     <div class="text-icon text-icon-blue">
                                         <img src="/images/new_interface_image/Imaging.svg" alt="Link to Imaging datasets">
                                     </div>Imaging (<span><? echo $number_imaging ?></span>)</a>
                             </li>
                             <li>
-                                <a href="/search/new?keyword=Neuroscience&type%5B%5D=dataset&dataset_type%5B%5D=11">
+                                <a href="/search/new?keyword=Neuroscience&type%5B%5D=dataset&dataset_type%5B%5D=Neuroscience">
                                     <div class="text-icon text-icon-yellow">
                                         <img src="/images/new_interface_image/Neuroscience.svg" alt="Link to Neuroscience datasets">
                                     </div>Neuroscience (<span><? echo $number_ns ?></span>)</a>
                             </li>
                             <li>
-                                <a href="/search/new?keyword=Epigenomic&type%5B%5D=dataset&dataset_type%5B%5D=1">
+                                <a href="/search/new?keyword=Epigenomic&type%5B%5D=dataset&dataset_type%5B%5D=Epigenomic">
                                     <div class="text-icon text-icon-red">
                                         <img src="/images/new_interface_image/Epigenomic.svg" alt="Link to Epigenomic datasets">
                                     </div>Epigenomic (<span><? echo $number_epi ?></span>)</a>
                             </li>
                             <li>
-                                <a href="/search/new?keyword=Metagenomic&type%5B%5D=dataset&dataset_type%5B%5D=3">
+                                <a href="/search/new?keyword=Metagenomic&type%5B%5D=dataset&dataset_type%5B%5D=Metagenomic">
                                     <div class="text-icon text-icon-green">
                                         <img src="/images/new_interface_image/Metagenomic.svg" alt="Link to Metagenomic datasets">
                                     </div>Metagenomic (<span><? echo $number_metagenomic ?></span>)</a>
                             </li>
                             <li>
-                                <a href="/search/new?keyword=Genome-Mapping&type%5B%5D=dataset&dataset_type%5B%5D=13">
+                                <a href="/search/new?keyword=Genome-Mapping&type%5B%5D=dataset&dataset_type%5B%5D=Genome-Mapping">
                                     <div class="text-icon text-icon-yellow">
                                         <img src="/images/new_interface_image/Genome-Mapping.svg" alt="Link to Genome mapping datasets">
                                     </div>Genome mapping (<span><? echo $number_genome_mapping ?></span>)</a>
                             </li>
                             <li>
-                                <a href="/search/new?keyword=Workflow&type%5B%5D=dataset&dataset_type%5B%5D=5">
+                                <a href="/search/new?keyword=Workflow&type%5B%5D=dataset&dataset_type%5B%5D=Workflow">
                                     <div class="text-icon text-icon-red">
                                         <img src="/images/new_interface_image/Workflow.svg" alt="Link to Workflow datasets">
                                     </div>Workflow (<span><? echo $number_wf ?></span>)</a>
                             </li>
                             <li>
-                                <a href="/search/new?keyword=Proteomic&type%5B%5D=dataset&dataset_type%5B%5D=10">
+                                <a href="/search/new?keyword=Proteomic&type%5B%5D=dataset&dataset_type%5B%5D=Proteomic">
                                     <div class="text-icon text-icon-yellow">
                                         <img src="/images/new_interface_image/Proteomic.svg" alt="Link to Proteomic datasets">
                                     </div>Proteomic (<span><? echo $number_proteomic ?></span>)</a>
                             </li>
                             <li>
-                                <a href="/search/new?keyword=Metabarcoding&type%5B%5D=dataset&dataset_type%5B%5D=17">
+                                <a href="/search/new?keyword=Metabarcoding&type%5B%5D=dataset&dataset_type%5B%5D=Metabarcoding">
                                     <div class="text-icon text-icon-yellow">
                                         <img src="/images/new_interface_image/Metabarcoding.svg" alt="Link to Metabarcoding datasets">
                                     </div>Metabarcoding (<span><? echo $number_metabarcoding ?></span>)</a>
                             </li>
                             <li>
-                                <a href="/search/new?keyword=Metadata&type%5B%5D=dataset&dataset_type%5B%5D=16">
+                                <a href="/search/new?keyword=Metadata&type%5B%5D=dataset&dataset_type%5B%5D=Metadata">
                                     <div class="text-icon text-icon-red">
                                         <img src="/images/new_interface_image/Metadata.svg" alt="Link to Metadata datasets">
                                     </div>Metadata (<span><? echo $number_metadata ?></span>)</a>
@@ -100,7 +100,7 @@
                         </ul>
                         <ul class="list-inline home-text-icon-list" style="display: none;">
                             <li>
-                                <a href="/search/new?keyword=climate&type%5B%5D=dataset&dataset_type%5B%5D=18">
+                                <a href="/search/new?keyword=climate&type%5B%5D=dataset&dataset_type%5B%5D=climate">
                                     <div class="text-icon text-icon-green">
                                         <img src="/images/new_interface_image/Climate.svg"  alt="Link to Climate datasets">
                                     </div>Climate (<span><? echo $number_climate ?></span>)</a>

--- a/sql/dataset_finder.sql
+++ b/sql/dataset_finder.sql
@@ -59,7 +59,7 @@ select d.id as id,
        dal.authorlinks as authornames,
        d.title as title,
        d.description as description,
-       coalesce(d.identifier,'') || coalesce(d.title,'') || coalesce(daf.names,'') || coalesce(dai.names,'') || coalesce(d.description,'') || coalesce(dt.types,'') || coalesce(dk.keywords,'') || coalesce(dp.names,'') || coalesce(m.identifier,'') || coalesce(m.pmid::varchar,'') || coalesce(df.grant_award, '') || coalesce(df.comments,'') || coalesce(fn.primary_name_display,'') || coalesce(el.external_links,'') || 'published:' || to_char(d.publication_date,'YYYY-MM-DD') || ',' || to_char(d.publication_date,'YYYY-MM') || ',' || to_char(d.publication_date,'YYYY')as document
+       coalesce(d.identifier,'') || ' ' || coalesce(d.title,'') || ' ' || coalesce(dt.types,'') || ' ' || coalesce(daf.names,'') || ' ' || coalesce(dai.names,'') || ' ' || coalesce(d.description,'') || ' ' || coalesce(dt.types,'') || ' ' || coalesce(dk.keywords,'') || ' ' || coalesce(dp.names,'') || ' ' || coalesce(m.identifier,'') || ' '  || coalesce(m.pmid::varchar,'') || ' ' || coalesce(df.grant_award, '') || ' ' || coalesce(df.comments,'') || ' ' || coalesce(fn.primary_name_display,'') || ' ' || coalesce(el.external_links,'') || ' ' || 'published:' || to_char(d.publication_date,'YYYY-MM-DD') || ',' || to_char(d.publication_date,'YYYY-MM') || ',' || to_char(d.publication_date,'YYYY') as document
 from dataset d
          left join manuscript m on d.id = m.dataset_id
          left join dataset_funder df on df.dataset_id = d.id

--- a/tests/acceptance/Search.feature
+++ b/tests/acceptance/Search.feature
@@ -175,3 +175,10 @@ Feature: main search function
     And I press the button "Search"
     And I wait "1" seconds
     Then I should see a link "Genome data from foxtail millet (<em>Setaria italica</em>)." to "/dataset/100020"
+
+  @ok
+  Scenario: Query for specific author id
+    Given I am on "/dataset/100006"
+    When I follow "Lambert DM"
+    And I wait "1" seconds
+    Then I should see a link "Genomic data from Adelie penguin (<em>Pygoscelis adeliae</em>)." to "/dataset/100006"

--- a/tests/acceptance/Search.feature
+++ b/tests/acceptance/Search.feature
@@ -160,3 +160,18 @@ Feature: main search function
     And I press the button "Search"
     And I wait "1" seconds
     Then I should see "No results found for 'teletubbies'"
+
+  @ok
+  Scenario: Query for specific dataset type
+    Given I am on "/"
+    When I follow "Software"
+    And I wait "1" seconds
+    Then I should see a link "Data and software to accompany the paper: Applying compressed sensing to genome-wide association studies." to "/dataset/100094"
+
+  @ok
+  Scenario: Search for a term that is only in dataset types
+    Given I am on "/"
+    And I fill in the field of "id" "keyword" with "epigenomic"
+    And I press the button "Search"
+    And I wait "1" seconds
+    Then I should see a link "Genome data from foxtail millet (<em>Setaria italica</em>)." to "/dataset/100020"


### PR DESCRIPTION
# Pull request for issue: #966 

This is a pull request for the following functionalities:

There were words (like genome or machine learning) that the GigaDB search returns no results for even though there should be a lot of matching datasets.

This problem manifests itself on staging environment.
However, on local dev environment the same search returns the expected results.
This shows that the crux of the problem lies with AWS RDS.

Strong clue surfaces when running the following query on both environments: 
```
SHOW default_text_search_config ;
```

results on local dev: 
```
gigadb=# SHOW default_text_search_config ;
 default_text_search_config 
----------------------------
 pg_catalog.english
(1 row)
```

results on RDS AWS:
```
gigadb=> SHOW default_text_search_config ;
 default_text_search_config 
----------------------------
 pg_catalog.simple
(1 row)
```

It shows that AWS RDS is using a "simple" dictionary instead of the "english" with which the GIN indexes were created with and the search queries were made with.

RDS AWS doesn't allow changing the default value system wide, but we can change the default for a specific  role/database combination with this query: 
```
alter role gigadb in database gigadb SET default_text_search_config TO 'pg_catalog.english';
```

and this can be made into a Yii migration.


## Changes to the database schema

* protected/migrations/schema/m220127_150844_search_materialized_views_gin_indexes.php


