### PR TITLE
Fix to out of shared memory/disk space errors when running Yii migrations for large database

### DIFF
--- a/ops/deployment/docker-compose.yml
+++ b/ops/deployment/docker-compose.yml
@@ -127,7 +127,7 @@ services:
       - ${DATA_SAVE_PATH}/postgres/${POSTGRES_VERSION}/data:/var/lib/postgresql/data
       - ${APPLICATION}/fuw/app/common/config/bootstrap.sql:/docker-entrypoint-initdb.d/3-fuw.sql
       - ${APPLICATION}/ops/configuration/postgresql-conf/pg_hba.conf:/etc/postgresql/pg_hba.conf
-    command: postgres -c 'hba_file=/etc/postgresql/pg_hba.conf' -c 'stats_temp_directory=/tmp' -c 'log_statement=none' -c 'log_min_duration_statement=1000ms' -c 'max_locks_per_transaction=1024'
+    command: postgres -c 'hba_file=/etc/postgresql/pg_hba.conf' -c 'stats_temp_directory=/tmp' -c 'log_statement=none' -c 'log_min_duration_statement=1000ms'
     networks:
       - db-tier
 

--- a/ops/deployment/docker-compose.yml
+++ b/ops/deployment/docker-compose.yml
@@ -127,7 +127,7 @@ services:
       - ${DATA_SAVE_PATH}/postgres/${POSTGRES_VERSION}/data:/var/lib/postgresql/data
       - ${APPLICATION}/fuw/app/common/config/bootstrap.sql:/docker-entrypoint-initdb.d/3-fuw.sql
       - ${APPLICATION}/ops/configuration/postgresql-conf/pg_hba.conf:/etc/postgresql/pg_hba.conf
-    command: postgres -c 'hba_file=/etc/postgresql/pg_hba.conf' -c 'stats_temp_directory=/tmp' -c 'log_statement=none' -c 'log_min_duration_statement=1000ms'
+    command: postgres -c 'hba_file=/etc/postgresql/pg_hba.conf' -c 'stats_temp_directory=/tmp' -c 'log_statement=none' -c 'log_min_duration_statement=1000ms' -c 'max_locks_per_transaction=1024'
     networks:
       - db-tier
 

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -58,6 +58,7 @@
     - echo "$MIGRATION_STATUS"
     - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints'
     - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes'
+    - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations droptriggers'
     - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0'
     - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.fix_import --interactive=0'
     # post-install script to run

--- a/ops/scripts/setup_devdb.sh
+++ b/ops/scripts/setup_devdb.sh
@@ -29,6 +29,7 @@ $DOCKER_COMPOSE run --rm test bash -c "psql -h database -U gigadb -c 'create dat
 $DOCKER_COMPOSE run --rm js bash -c "node /var/www/ops/scripts/csv_yii_migration.js $dbSet"
 
 # and run them
+$DOCKER_COMPOSE run --rm test ./protected/yiic custommigrations droptriggers
 $DOCKER_COMPOSE run --rm  application ./protected/yiic migrate to 300000_000000 --connectionID=db --migrationPath=application.migrations.admin --interactive=0
 $DOCKER_COMPOSE run --rm  application ./protected/yiic migrate mark 000000_000000 --connectionID=db --interactive=0
 $DOCKER_COMPOSE run --rm  application ./protected/yiic migrate --connectionID=db --migrationPath=application.migrations.schema --interactive=0

--- a/protected/commands/CustomMigrationsCommand.php
+++ b/protected/commands/CustomMigrationsCommand.php
@@ -15,6 +15,7 @@ class CustomMigrationsCommand extends CConsoleCommand
         $helpText .= "Usage: ./protected/yiic custommigration dropindexes" . PHP_EOL;
         $helpText .= "Usage: ./protected/yiic custommigration droptriggers" . PHP_EOL;
         $helpText .= "Usage: ./protected/yiic custommigration refreshmaterializedviews" . PHP_EOL;
+        $helpText .= "Usage: ./protected/yiic custommigration preparedropcreateconstraints" . PHP_EOL;
         return $helpText;
     }
 
@@ -64,7 +65,8 @@ END;
 SELECT nspname, relname 
 FROM pg_index 
 INNER JOIN pg_class ON indexrelid=pg_class.oid 
-INNER JOIN pg_namespace ON pg_namespace.oid=pg_class.relnamespace WHERE indisprimary=FALSE and indisvalid=TRUE AND nspname='public' ORDER BY nspname,relname;
+INNER JOIN pg_namespace ON pg_namespace.oid=pg_class.relnamespace WHERE indisprimary=FALSE and indisvalid=TRUE AND nspname='public' 
+ORDER BY nspname,relname;
 END;
 
         $dropCommands = [];
@@ -131,6 +133,70 @@ END;
         Yii::app()->db->createCommand("refresh materialized view file_finder")->execute();
         Yii::app()->db->createCommand("refresh materialized view sample_finder")->execute();
         Yii::app()->db->createCommand("refresh materialized view dataset_finder")->execute();
+    }
+
+    public function actionPrepareDropCreateConstraints()
+    {
+        $dropConstraintsQuery = "";
+        $addConstraintsQuery = "";
+        $dropIndexQuery = "";
+        $addIndexQuery = "";
+        $dropTriggerQuery = "";
+        $addTriggerQuery = "";
+
+        $rows = Yii::app()->db->createCommand("SELECT 'ALTER TABLE '||nspname||'.\"'||relname||'\" DROP CONSTRAINT \"'||conname||'\";' as q
+FROM pg_constraint
+INNER JOIN pg_class ON conrelid=pg_class.oid
+INNER JOIN pg_namespace ON pg_namespace.oid=pg_class.relnamespace
+ORDER BY CASE WHEN contype='f' THEN 0 ELSE 1 END,contype,nspname,relname,conname;")->queryAll();
+
+        foreach ($rows as $row) {
+           $dropConstraintsQuery .= $row["q"].PHP_EOL;
+        }
+        file_put_contents("/var/www/protected/runtime/dropConstraintsQuery.sql", $dropConstraintsQuery);
+
+        $rows = Yii::app()->db->createCommand("SELECT 'ALTER TABLE '||nspname||'.\"'||relname||'\" ADD CONSTRAINT \"'||conname||'\" '|| pg_get_constraintdef(pg_constraint.oid)||';' as q
+FROM pg_constraint
+INNER JOIN pg_class ON conrelid=pg_class.oid
+INNER JOIN pg_namespace ON pg_namespace.oid=pg_class.relnamespace
+ORDER BY CASE WHEN contype='f' THEN 0 ELSE 1 END DESC,contype DESC,nspname DESC,relname DESC,conname DESC;")->queryAll();
+
+        foreach ($rows as $row) {
+            $addConstraintsQuery .= $row["q"].PHP_EOL;
+        }
+        file_put_contents("/var/www/protected/runtime/addConstraintsQuery.sql", $addConstraintsQuery);
+
+        $rows = Yii::app()->db->createCommand("SELECT 'DROP INDEX ' || indexname || ';' as q FROM pg_indexes WHERE schemaname = 'public'")->queryAll();
+        foreach ($rows as $row) {
+            $dropIndexQuery .= $row["q"].PHP_EOL;
+        }
+        file_put_contents("/var/www/protected/runtime/dropIndexQuery.sql", $dropIndexQuery);
+
+        $rows = Yii::app()->db->createCommand("SELECT indexdef || ';' as q FROM pg_indexes WHERE schemaname = 'public'")->queryAll();
+        foreach ($rows as $row) {
+            $addIndexQuery .= $row["q"].PHP_EOL;
+        }
+        file_put_contents("/var/www/protected/runtime/addIndexQuery.sql", $addIndexQuery);
+
+        $dropTriggerQuery = "drop trigger if exists file_finder_trigger on file RESTRICT;".PHP_EOL;
+        $dropTriggerQuery .=  "drop trigger if exists sample_finder_trigger on sample RESTRICT;".PHP_EOL;
+        $dropTriggerQuery .=  "drop trigger if exists dataset_finder_trigger on dataset RESTRICT;".PHP_EOL;
+
+        $addTriggerQuery = "create trigger file_finder_trigger
+after insert or update or delete or truncate
+on file for each statement 
+execute procedure refresh_file_finder();".PHP_EOL;
+        $addTriggerQuery .= "create trigger sample_finder_trigger
+after insert or update or delete or truncate
+on sample for each statement 
+execute procedure refresh_sample_finder();".PHP_EOL;
+        $addTriggerQuery .= "create trigger dataset_finder_trigger
+after insert or update or delete or truncate
+on dataset for each statement 
+execute procedure refresh_dataset_finder();".PHP_EOL;
+
+        file_put_contents("/var/www/protected/runtime/dropTriggerQuery.sql", $dropTriggerQuery);
+        file_put_contents("/var/www/protected/runtime/addTriggerQuery.sql", $addTriggerQuery);
     }
 
 }


### PR DESCRIPTION
This PR is to fix issues with running database migrations on large database (like the ``production_like`` test data or the CNGB database import).
The problem manifested in two situations:

(1) On my local development environment, when running ``setup_devdb.sh`` against ``production_like`` test data

(2) On staging environment, after triggering "sd_reset_migration" manual gitlab job and then triggering a new deployment


In both cases, the symptom are that the process will take forever, won't finish and if we wait, will crash due to exhausted resources (no more memory, or no more disk space).

The root cause are the database triggers, they need to be disabled before running migrations, as every insert from the migration script will trigger them, and to make it worse, the operation they perform is an expensive one.

Database constraints and indexes also need to be disabled, it was already the case in the gitlab production deployment job, but not in the local/CI environment that uses ``setup_devdb.sh``.


One challenge to overcome on local development environment is that because we have to run the data migrations after the schema migrations have run 
and the disabling need to happen before running the data migrations, we cannot rely on schema migrations to restore the disabled structure like we do 
on gitlab production deployment job.

The solution is to pre-build a list of drop queries and add queries before starting migrations.
Then run the drop queries just before running the data migrations.
and run the add queries after running the data migrations.

Why you cannot just dynamically re-add the constraints, indexes and triggers after the data migrations have run (instead of pre-building the queries)
is because once they are dropped, they don't exist anymore, and we wouldn't have an easy way to know what structure to re-create.
That's why both the list of drop queries and add queries are created beforehand while we still have information about them.


>Aside: While investigating, I've stumbled on something that can be a suggestion for future improvement (it's not in scope with this PR):
>In the ``csv_yii_migration.js`` and its ``ops/configuration/yii-conf/migration.php.dist`` template, 
replacing individual ``INSERT`` statements  with  a bulk ``COPY ... FROM '.../myfile.csv' DELIMITERS ','`` 
will improve import performance by **orders of magnitude** (the challenge there would be ensuring that the test data CSV files are visible to the database engine)


## Changes to the provisioning

* ops/deployment/docker-compose.yml
