### PR TITLE
Fix misalignment in admin dataset, admin file and dataset funder pages

### DIFF
--- a/features/dataset-admin.feature
+++ b/features/dataset-admin.feature
@@ -7,39 +7,6 @@ Background:
 	Given Gigadb web site is loaded with "gigadb_testdata.pgdmp" data
 	And default admin user exists
 
-@ok @issue-381
-Scenario: form loading with all necessary fields
-	Given I sign in as an admin
-	When I go to "/adminDataset/update/id/210"
-	Then I should see a form element labelled "Submitter *"
-	And I should see a form element labelled "Curator Id"
-	And I should see a form element labelled "Manuscript Id"
-	And I should see a form element labelled "Upload Status"
-	And I should see a form element labelled "Epigenomic"
-	And I should see a form element labelled "Software"
-	And I should see a form element labelled "Genomic"
-	And I should see a form element labelled "Metadata"
-	And I should see a form element labelled "Dataset Size *"
-	And I should see a form element labelled "datasetImage"
-	And I should see a form element labelled "Image URL"
-	And I should see a form element labelled "Image Source *"
-	And I should see a form element labelled "Image Tag"
-	And I should see a form element labelled "Image License *"
-	And I should see a form element labelled "Image Photographer *"
-	And I should see a form element labelled "DOI *"
-	And I should see a form element labelled "Ftp Site *"
-	And I should see a form element labelled "Fair Use Policy"
-	And I should see a form element labelled "Publication Date"
-	And I should see a form element labelled "Modification Date"
-	And I should see a form element labelled "Dataset Size *"
-	And I should see a form element labelled "Title *"
-	And I should see a form element labelled "Description"
-	And I should see a form element labelled "Keywords"
-	And I should see a form element labelled "URL to redirect"
-	And I should see a button input "Save"
-	And I should see a button "Create New Log"
-	And I should not see a form element labelled "Publisher"
-
 @ok @javascript
 Scenario: Mint A DOI
 	Given I sign in as an admin

--- a/less/current/modules/forms.less
+++ b/less/current/modules/forms.less
@@ -125,5 +125,5 @@ label {
   display: inline-block;
   *display: inline;
   *zoom: 1;
-  margin-bottom: 0;
+  margin-top: -30px;
 }

--- a/less/current/modules/tables.less
+++ b/less/current/modules/tables.less
@@ -14,6 +14,12 @@ table.table a {
   text-decoration: none;
 }
 
+.table {
+  table-layout: fixed;
+  width: 100%;
+  margin-bottom: 18px;
+}
+
 .table > thead > tr > th {
   text-align: center;
   font-weight: normal;

--- a/less/current/modules/tables.less
+++ b/less/current/modules/tables.less
@@ -19,10 +19,13 @@ table.table a {
   width: 100%;
   margin-bottom: 18px;
 }
+.table .attr-form {
+  margin-top: auto;
+}
 
 .table > thead > tr > th {
   text-align: center;
-  font-weight: normal;
+  font-weight: bold;
   border-bottom: 0px;
   background-color: @color-lighter-gray;
 }

--- a/less/current/modules/tables.less
+++ b/less/current/modules/tables.less
@@ -17,19 +17,21 @@ table.table a {
 .table {
   table-layout: fixed;
   width: 100%;
-  margin-bottom: 18px;
+  margin: auto;
 }
 .table .attr-form {
-  margin-top: auto;
+  margin: auto;
+  width: 100%;
 }
-
 .table > thead > tr > th {
   text-align: center;
   font-weight: bold;
   border-bottom: 0px;
   background-color: @color-lighter-gray;
 }
-
+.table > tbody > tr > td {
+  padding: 5px;
+}
 .new-upload-table {
   margin: 0px;
 }

--- a/less/current/modules/tables.less
+++ b/less/current/modules/tables.less
@@ -31,6 +31,7 @@ table.table a {
 }
 .table > tbody > tr > td {
   padding: 5px;
+  word-break: break-all;
 }
 .new-upload-table {
   margin: 0px;

--- a/less/current/modules/tables.less
+++ b/less/current/modules/tables.less
@@ -13,28 +13,12 @@ table.table td {
 table.table a {
   text-decoration: none;
 }
-.table {
-  table-layout: fixed;
-  width: 100%;
-  margin: auto;
-  td {
-    border-top: none;
-    text-align: left;
-  }
-}
-.table .attr-form {
-  margin: auto;
-  width: 100%;
-}
+
 .table > thead > tr > th {
   text-align: center;
-  font-weight: bold;
+  font-weight: normal;
   border-bottom: 0px;
   background-color: @color-lighter-gray;
-}
-.table > tbody > tr > td {
-  padding: 5px;
-  word-break: break-all;
 }
 
 .new-upload-table {

--- a/less/current/modules/tables.less
+++ b/less/current/modules/tables.less
@@ -13,11 +13,14 @@ table.table td {
 table.table a {
   text-decoration: none;
 }
-
 .table {
   table-layout: fixed;
   width: 100%;
   margin: auto;
+  td {
+    border-top: none;
+    text-align: left;
+  }
 }
 .table .attr-form {
   margin: auto;
@@ -33,6 +36,7 @@ table.table a {
   padding: 5px;
   word-break: break-all;
 }
+
 .new-upload-table {
   margin: 0px;
 }

--- a/protected/views/adminDataset/_form.php
+++ b/protected/views/adminDataset/_form.php
@@ -17,12 +17,6 @@ $cs->registerCssFile('/css/jquery.tag-editor.css');
 <? } ?>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/caret/1.0.0/jquery.caret.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/tag-editor/1.0.20/jquery.tag-editor.min.js"></script>
-<? if (Yii::app()->params['less_dev_mode']) { ?>
-    <link rel="stylesheet/less" type="text/css" href="/less/current.less?time=<?= time() ?>">
-    <? Yii::app()->clientScript->registerScriptFile('/js/less-1.3.0.min.js'); ?>
-<? } else { ?>
-    <link rel="stylesheet" type="text/css" href="/css/current.css"/>
-<? } ?>
 
 <?php $form=$this->beginWidget('CActiveForm', array(
     'id'=>'dataset-form',
@@ -48,7 +42,7 @@ echo $form->hiddenField($model, "image_id");
                     <div class="control-group">
                         <?php echo $form->labelEx($model,'submitter_id',array('class'=>'control-label')); ?>
                         <div class="controls">
-                            <?php echo $form->dropDownList($model,'submitter_id',CHtml::listData(User::model()->findAll(array('order'=>'email ASC')),'id','email')); ?>
+                            <?php echo $form->dropDownList($model,'submitter_id',CHtml::listData(User::model()->findAll(array('order'=>'email ASC')),'id','email'),array('style'=>'margin-top:-40px')); ?>
                             <?php echo $form->error($model,'submitter_id'); ?>
                         </div>
                     </div>
@@ -59,14 +53,14 @@ echo $form->hiddenField($model, "image_id");
                             $criteria = new CDbCriteria;
                             $criteria->condition='role=\'admin\' and email like \'%gigasciencejournal.com\''; 
                             ?>
-                            <?php echo $form->dropDownList($model,'curator_id',CHtml::listData(User::model()->findAll($criteria),'id','email'),array('prompt'=>'')); ?>
+                            <?php echo $form->dropDownList($model,'curator_id',CHtml::listData(User::model()->findAll($criteria),'id','email'),array('prompt'=>'','style'=>'margin-top:-40px')); ?>
                             <?php echo $form->error($model,'curator_id'); ?>
                         </div>
                     </div>
                      <div class="control-group">
                         <?php echo $form->labelEx($model,'manuscript_id',array('class'=>'control-label')); ?>
                         <div class="controls">
-                            <?php echo $form->textField($model,'manuscript_id',array('size'=>60,'maxlength'=>200)); ?>
+                            <?php echo $form->textField($model,'manuscript_id',array('size'=>60,'maxlength'=>200,'style'=>'margin-top:-40px')); ?>
                             <?php echo $form->error($model,'manuscript_id'); ?>
                         </div>
                     </div>
@@ -74,7 +68,7 @@ echo $form->hiddenField($model, "image_id");
                         <?php echo $form->labelEx($model,'upload_status',array('class'=>'control-label')); ?>
                         <div class="controls">
                             <?php echo $form->dropDownList($model,'upload_status',Dataset::$availableStatusList,
-                                array('class'=>'js-pub', 'disabled'=>$model->upload_status == 'Published')); ?>
+                                array('class'=>'js-pub', 'disabled'=>$model->upload_status == 'Published','style'=>'margin-top:-40px')); ?>
                             <?php echo $form->error($model,'upload_status'); ?>
                         </div>
                     </div>
@@ -91,7 +85,7 @@ echo $form->hiddenField($model, "image_id");
                                         $checkedHtml = in_array($id,$checkedTypes,true) ? 'checked="checked"' : '';
                                         $checkboxId="Dataset_$datasetType";
                                         echo '<div class="controls">';
-                                        echo '<input id="'.$checkboxId.'" type="checkbox" name="datasettypes['.$id.']" value="1"'.$checkedHtml.'/>';
+                                        echo '<input id="'.$checkboxId.'" type="checkbox" name="datasettypes['.$id.']" value="1"'.$checkedHtml.' style="margin-top:-25px"/>';
                                         echo '</div>';
 //                                        echo '</div>';
 
@@ -105,7 +99,7 @@ echo $form->hiddenField($model, "image_id");
                     <div class="control-group">
                         <?php echo $form->labelEx($model,'dataset_size',array('class'=>'control-label')); ?>
                         <div class="controls">
-                            <?php echo $form->textField($model,'dataset_size',array('size'=>60,'maxlength'=>200)); ?> (bytes)
+                            <?php echo $form->textField($model,'dataset_size',array('size'=>60,'maxlength'=>200,'style'=>'margin-top:-40px')); ?> (bytes)
                             <?php echo $form->error($model,'dataset_size'); ?>
                         </div>
                     </div>
@@ -120,11 +114,11 @@ echo $form->hiddenField($model, "image_id");
                         $img_location = $model->image->location;
                         $no_img_url = 'https://assets.gigadb-cdn.net/images/datasets/no_image.png';
                         if($img_url){
-                            echo CHtml::image($img_url, $img_url, array('id'=>'showImage','style'=>'width:100px; display:block; margin-left:auto;'));
-                            echo CHtml::image("", "", array('id' => 'imagePreview', 'style' => 'width:100px; display:block; margin-left:auto;'));
+                            echo CHtml::image($img_url, $img_url, array('id'=>'showImage','style'=>'width:100px; display:block; margin-left:auto; margin-top:-40px'));
+                            echo CHtml::image("", "", array('id' => 'imagePreview', 'style' => 'width:100px; display:block; margin-left:auto; margin-top:-40px'));
                         } else {
-                            echo CHtml::image($no_img_url, $no_img_url, array('id'=>'showImage','style'=>'width:100px; display:block; margin-left:auto;'));
-                            echo CHtml::image("", "", array('id' => 'imagePreview', 'style' => 'width:100px; display:block; margin-left:auto;'));
+                            echo CHtml::image($no_img_url, $no_img_url, array('id'=>'showImage','style'=>'width:100px; display:block; margin-left:auto; margin-top:-40px'));
+                            echo CHtml::image("", "", array('id' => 'imagePreview', 'style' => 'width:100px; display:block; margin-left:auto; margin-top:-40px'));
 
                         }
                     ?>
@@ -133,7 +127,7 @@ echo $form->hiddenField($model, "image_id");
                         <?php if($img_url && $img_location !== "no_image.png" ){ ?>
                         <div class="controls">
                             <ul>
-                                <li style="list-style: none;"><?php echo CHtml::fileField('datasetImage'); ?></li>
+                                <li style="list-style: none;"><?php echo CHtml::fileField('datasetImage',); ?></li>
                                 <li style="list-style: none;"><?php echo CHtml::htmlButton('Remove image', ['id' => 'removeButton', 'class' => 'btn btn-sm']); ?></li>
                             </ul>
                         </div>
@@ -146,7 +140,7 @@ echo $form->hiddenField($model, "image_id");
                     <div class="control-group">
                         <?php echo $form->labelEx($model->image,'url',array('class'=>'control-label meta-fields','style'=>'display:none')); ?>
                         <div class="controls">
-                            <?php echo $form->textField($model->image,'url',array('class'=>'span4 meta-fields','style'=>'display:none')); ?>
+                            <?php echo $form->textField($model->image,'url',array('class'=>'span4 meta-fields','style'=>'display:none;margin-top:-40px')); ?>
                             <?php echo $form->error($model->image,'url'); ?>
                         </div>
                     </div>
@@ -154,7 +148,7 @@ echo $form->hiddenField($model, "image_id");
                     <div class="control-group">
                         <?php echo $form->labelEx($model->image,'source',array('class'=>'control-label meta-fields','style'=>'display:none')); ?>
                         <div class="controls">
-                            <?php echo $form->textField($model->image,'source',array('class'=>'span4 meta-fields','style'=>'display:none')); ?>
+                            <?php echo $form->textField($model->image,'source',array('class'=>'span4 meta-fields','style'=>'display:none;margin-top:-40px')); ?>
                             <?php echo $form->error($model->image,'source'); ?>
                         </div>
                     </div>
@@ -162,7 +156,7 @@ echo $form->hiddenField($model, "image_id");
                     <div class="control-group">
                         <?php echo $form->labelEx($model->image,'tag',array('class'=>'control-label meta-fields','style'=>'display:none')); ?>
                         <div class="controls">
-                            <?php echo $form->textField($model->image,'tag',array('class'=>'span4 meta-fields','style'=>'display:none')); ?>
+                            <?php echo $form->textField($model->image,'tag',array('class'=>'span4 meta-fields','style'=>'display:none;margin-top:-40px')); ?>
                             <?php echo $form->error($model->image,'tag'); ?>
                         </div>
                     </div>
@@ -170,7 +164,7 @@ echo $form->hiddenField($model, "image_id");
                     <div class="control-group">
                         <?php echo $form->labelEx($model->image,'license',array('class'=>'control-label meta-fields','style'=>'display:none')); ?>
                         <div class="controls">
-                            <?php echo $form->textField($model->image,'license',array('class'=>'span4 meta-fields','style'=>'display:none')); ?>
+                            <?php echo $form->textField($model->image,'license',array('class'=>'span4 meta-fields','style'=>'display:none;margin-top:-40px')); ?>
                             <?php echo $form->error($model->image,'license'); ?>
                         </div>
                     </div>
@@ -178,7 +172,7 @@ echo $form->hiddenField($model, "image_id");
                     <div class="control-group">
                         <?php echo $form->labelEx($model->image,'photographer',array('class'=>'control-label meta-fields','style'=>'display:none')); ?>
                         <div class="controls">
-                            <?php echo $form->textField($model->image,'photographer',array('class'=>'span4 meta-fields','style'=>'display:none')); ?>
+                            <?php echo $form->textField($model->image,'photographer',array('class'=>'span4 meta-fields','style'=>'display:none;margin-top:-40px')); ?>
                             <?php echo $form->error($model->image,'photographer'); ?>
                         </div>
                     </div>
@@ -196,6 +190,7 @@ echo $form->hiddenField($model, "image_id");
                                                 'maxlength'=>32,
                                                 'disabled'=>$model->upload_status == 'Published',
                                                 'class' => "input-mini",
+                                                'style' => "margin-top:-30px",
                                                 'ajax' => array(
                                                     'type' => 'POST',
                                                     'url' => array('adminDataset/checkDOIExist'),
@@ -210,7 +205,7 @@ echo $form->hiddenField($model, "image_id");
                                                         }
                                                     }',
                                                 ),
-                                            )
+                                            ),
                                         ); ?>
                                         <?php echo $form->error($model,'identifier'); ?>
                                     </div>
@@ -263,7 +258,7 @@ echo $form->hiddenField($model, "image_id");
                     <div class="control-group">
                         <?php echo $form->labelEx($model,'ftp_site',array('class'=>'control-label')); ?>
                         <div class="controls">
-                            <?php echo $form->textField($model,'ftp_site',array('class'=>'span4','size'=>60,'maxlength'=>200, 'disabled'=>$model->upload_status == 'Published')); ?>
+                            <?php echo $form->textField($model,'ftp_site',array('class'=>'span4','size'=>60,'maxlength'=>200, 'disabled'=>$model->upload_status == 'Published', 'style'=>'margin-top:-40px')); ?>
                             <?php echo $form->error($model,'ftp_site'); ?>
                         </div>
                     </div>
@@ -271,7 +266,7 @@ echo $form->hiddenField($model, "image_id");
                     <div class="control-group">
                         <?php echo $form->labelEx($model,'fairnuse',array('class'=>'control-label')); ?>
                         <div class="controls">
-                        <?php echo $form->textField($model,'fairnuse',array('class'=>'span4 date')); ?>
+                        <?php echo $form->textField($model,'fairnuse',array('class'=>'span4 date', 'style'=>'margin-top:-40px')); ?>
                         <?php echo $form->error($model,'fairnuse'); ?>
                         </div>
                     </div>
@@ -279,7 +274,7 @@ echo $form->hiddenField($model, "image_id");
                     <div class="control-group">
                         <?php echo $form->labelEx($model,'publication_date',array('class'=>'control-label')); ?>
                         <div class="controls">
-                        <?php echo $form->textField($model,'publication_date',array('class'=>'span4 date js-date-pub', 'disabled'=>$model->upload_status == 'Published')); ?>
+                        <?php echo $form->textField($model,'publication_date',array('class'=>'span4 date js-date-pub', 'disabled'=>$model->upload_status == 'Published', 'style'=>'margin-top:-40px')); ?>
                         <?php echo $form->error($model,'publication_date'); ?>
                         </div>
                     </div>
@@ -287,7 +282,7 @@ echo $form->hiddenField($model, "image_id");
                     <div class="control-group">
                         <?php echo $form->labelEx($model,'modification_date',array('class'=>'control-label')); ?>
                         <div class="controls">
-                        <?php echo $form->textField($model,'modification_date',array('class'=>'span4 date')); ?>
+                        <?php echo $form->textField($model,'modification_date',array('class'=>'span4 date', 'style'=>'margin-top:-40px')); ?>
                         <?php echo $form->error($model,'modification_date'); ?>
                         </div>
                     </div>
@@ -303,7 +298,7 @@ echo $form->hiddenField($model, "image_id");
                     <div class="control-group">
                         <?php echo $form->labelEx($model,'title',array('class'=>'control-label')); ?>
                         <div class="controls">
-                            <?php echo $form->textField($model,'title',array('class'=>'span10', 'size'=>60,'maxlength'=>300)); ?>
+                            <?php echo $form->textField($model,'title',array('class'=>'span10', 'size'=>60,'maxlength'=>300, 'style'=>'margin-top:-40px')); ?>
                             <?php echo $form->error($model,'title'); ?>
                         </div>
                     </div>
@@ -311,7 +306,7 @@ echo $form->hiddenField($model, "image_id");
                     <div class="control-group">
                         <?php echo $form->labelEx($model,'description',array('class'=>'control-label')); ?>
                         <div class="controls">
-                            <?php echo $form->textArea($model,'description',array('class'=>'span10','rows'=>8, 'cols'=>50)); ?>
+                            <?php echo $form->textArea($model,'description',array('class'=>'span10','rows'=>8, 'cols'=>50, 'style'=>'margin-top:-40px')); ?>
                             <?php echo $form->error($model,'description'); ?>
                         </div>
                     </div>
@@ -326,7 +321,7 @@ echo $form->hiddenField($model, "image_id");
                     <div class="control-group">
                         <?php echo CHtml::label('URL to redirect','urltoredirect', array('class'=>'control-label')); ?>
                         <div class="controls">
-                            <?php echo CHtml::textField('urltoredirect', $model->getUrlToRedirectAttribute(), array('class'=>'span10', 'size'=>60,'maxlength'=>300)); ?>
+                            <?php echo CHtml::textField('urltoredirect', $model->getUrlToRedirectAttribute(), array('class'=>'span10', 'size'=>60,'maxlength'=>300, 'style'=>'margin-top:-40px')); ?>
                         </div>
                     </div>
                 </div>
@@ -346,7 +341,7 @@ echo $form->hiddenField($model, "image_id");
 
 <div class="span12" style="text-align:center">
     <a href="<?=Yii::app()->createUrl('/adminDataset/admin')?>" class="btn"/>Cancel</a>
-    <?= CHtml::submitButton($model->isNewRecord ? 'Create' : 'Save', array('class' => 'btn-green', 'style'=>'margin-top:auto;')); ?>
+    <?= CHtml::submitButton($model->isNewRecord ? 'Create' : 'Save', array('class' => 'btn-green')); ?>
         <?php if( "hidden" === $datasetPageSettings->getPageType() ) { ?>
     <a href="<?=Yii::app()->createUrl('/adminDataset/private/identifier/'.$model->identifier)?>" class="btn-green"/>Create/Reset Private URL</a>
             <?php if($model->token){?>

--- a/protected/views/adminDataset/_form.php
+++ b/protected/views/adminDataset/_form.php
@@ -97,9 +97,9 @@ echo $form->hiddenField($model, "image_id");
 
 
                     <div class="control-group">
-                        <?php echo $form->labelEx($model,'dataset_size',array('class'=>'control-label')); ?>
+                        <?php echo $form->labelEx($model,'dataset_size',array('label'=>'Dataset Size in Bytes','class'=>'control-label')); ?>
                         <div class="controls">
-                            <?php echo $form->textField($model,'dataset_size',array('size'=>60,'maxlength'=>200,'style'=>'margin-top:-40px')); ?> (bytes)
+                            <?php echo $form->textField($model,'dataset_size',array('size'=>60,'maxlength'=>200,'style'=>'margin-top:-40px')); ?>
                             <?php echo $form->error($model,'dataset_size'); ?>
                         </div>
                     </div>

--- a/protected/views/adminDataset/_form.php
+++ b/protected/views/adminDataset/_form.php
@@ -35,6 +35,8 @@ echo $form->hiddenField($model, "image_id");
         <div class="clear"></div>
         <?php echo $form->errorSummary($model); ?>
 
+        <!--TODO: Adding 'style'=>'margin-top:*' to each div is just a temp styling fix, need further investigation on how to implement CSS styling properly.-->
+
         <div class="container">
 
             <div class="row">

--- a/protected/views/adminDataset/_form.php
+++ b/protected/views/adminDataset/_form.php
@@ -98,13 +98,13 @@ echo $form->hiddenField($model, "image_id");
 
 
 
-                    <div class="control-group">
-                        <?php echo $form->labelEx($model,'dataset_size',array('label'=>'Dataset Size in Bytes','class'=>'control-label')); ?>
-                        <div class="controls">
-                            <?php echo $form->textField($model,'dataset_size',array('size'=>60,'maxlength'=>200,'style'=>'margin-top:-40px')); ?>
-                            <?php echo $form->error($model,'dataset_size'); ?>
-                        </div>
-                    </div>
+<!--                    <div class="control-group">-->
+<!--                        --><?php //echo $form->labelEx($model,'dataset_size',array('label'=>'Dataset Size in Bytes','class'=>'control-label')); ?>
+<!--                        <div class="controls">-->
+<!--                            --><?php //echo $form->textField($model,'dataset_size',array('size'=>60,'maxlength'=>200,'style'=>'margin-top:-40px')); ?>
+<!--                            --><?php //echo $form->error($model,'dataset_size'); ?>
+<!--                        </div>-->
+<!--                    </div>-->
 
                 </div>
                 <div class="span1">
@@ -296,7 +296,13 @@ echo $form->hiddenField($model, "image_id");
             <div class="row">
 
                 <div class="span9">
-
+                    <div class="control-group">
+                        <?php echo $form->labelEx($model,'dataset_size',array('label'=>'Dataset Size in Bytes','class'=>'control-label')); ?>
+                        <div class="controls">
+                            <?php echo $form->textField($model,'dataset_size',array('class'=>'span10', 'size'=>60,'maxlength'=>300,'style'=>'margin-top:-40px')); ?>
+                            <?php echo $form->error($model,'dataset_size'); ?>
+                        </div>
+                    </div>
                     <div class="control-group">
                         <?php echo $form->labelEx($model,'title',array('class'=>'control-label')); ?>
                         <div class="controls">

--- a/protected/views/adminFile/_attr.php
+++ b/protected/views/adminFile/_attr.php
@@ -10,6 +10,6 @@
 </td>
 <td>
     <div>
-	<input type="submit" class="btn" name="edit_attr" style="margin: auto auto auto 150px;" value="Save"/>
+	<input type="submit" class="btn" name="edit_attr" style="margin: auto;" value="Save"/>
     </div>
 </td>

--- a/protected/views/adminFile/_attr.php
+++ b/protected/views/adminFile/_attr.php
@@ -1,3 +1,4 @@
+<!--TODO: Adding 'style'=>'width: 100%;' to each div is just a temp styling fix, need further investigation on how to implement CSS styling properly.-->
 <td>
 	<?php echo CHtml::activeHiddenField($attribute, 'id') ?>
 	<?php echo CHtml::activeDropDownList($attribute, 'attribute_id',CHtml::listData(Attribute::model()->findAll(),'id','attribute_name'), array('class'=>'attr-form', 'style'=>'width: 100%;', 'empty'=>'Select name')); ?>

--- a/protected/views/adminFile/_attr.php
+++ b/protected/views/adminFile/_attr.php
@@ -10,6 +10,6 @@
 </td>
 <td>
     <div>
-	<input type="submit" class="btn" name="edit_attr" value="Save"/>
+	<input type="submit" class="btn" name="edit_attr" style="margin: auto auto auto 150px;" value="Save"/>
     </div>
 </td>

--- a/protected/views/adminFile/_attr.php
+++ b/protected/views/adminFile/_attr.php
@@ -1,12 +1,12 @@
 <td>
 	<?php echo CHtml::activeHiddenField($attribute, 'id') ?>
-	<?php echo CHtml::activeDropDownList($attribute, 'attribute_id',CHtml::listData(Attribute::model()->findAll(),'id','attribute_name'), array('class'=>'attr-form', 'empty'=>'Select name')); ?>
+	<?php echo CHtml::activeDropDownList($attribute, 'attribute_id',CHtml::listData(Attribute::model()->findAll(),'id','attribute_name'), array('class'=>'attr-form', 'style'=>'width: 100%;', 'empty'=>'Select name')); ?>
 </td>
 <td>
-	<?php echo CHtml::activeTextField($attribute, 'value',array('class'=>'attr-form'));?> 
+	<?php echo CHtml::activeTextField($attribute, 'value',array('class'=>'attr-form', 'style'=>'width: 100%;'));?>
 </td>
 <td>
-	<?php echo CHtml::activeDropDownList($attribute, 'unit_id',CHtml::listData(Unit::model()->findAll(),'id','name'), array('class'=>'attr-form', 'empty'=>'Select unit')); ?>
+	<?php echo CHtml::activeDropDownList($attribute, 'unit_id',CHtml::listData(Unit::model()->findAll(),'id','name'), array('class'=>'attr-form', 'style'=>'width: 100%;', 'empty'=>'Select unit')); ?>
 </td>
 <td>
     <div>

--- a/protected/views/adminFile/_attr.php
+++ b/protected/views/adminFile/_attr.php
@@ -10,6 +10,6 @@
 </td>
 <td>
     <div>
-	<input type="submit" class="btn" name="edit_attr" style="margin: auto;" value="Save"/>
+	<input type="submit" class="btn" name="edit_attr" value="Save"/>
     </div>
 </td>

--- a/protected/views/adminFile/_form.php
+++ b/protected/views/adminFile/_form.php
@@ -122,7 +122,7 @@
         <?php } ?>
         <div class="pull-right">
             <a href="/adminFile/admin" class="btn">Cancel</a>
-            <?php echo CHtml::submitButton($model->isNewRecord ? 'Create' : 'Save',array('class'=>'btn', 'style'=>'margin-top: auto;')); ?>
+            <?php echo CHtml::submitButton($model->isNewRecord ? 'Create' : 'Save',array('class'=>'btn')); ?>
         </div>
         <?php $this->endWidget(); ?>
     </div>

--- a/protected/views/adminFile/_form.php
+++ b/protected/views/adminFile/_form.php
@@ -129,7 +129,7 @@
         <?php } ?>
         <div class="pull-right">
             <a href="/adminFile/admin" class="btn">Cancel</a>
-            <?php echo CHtml::submitButton($model->isNewRecord ? 'Create' : 'Save',array('class'=>'btn')); ?>
+            <?php echo CHtml::submitButton($model->isNewRecord ? 'Create' : 'Save',array('class'=>'btn', 'style'=>'margin-top: auto;')); ?>
         </div>
         <?php $this->endWidget(); ?>
     </div>

--- a/protected/views/adminFile/_form.php
+++ b/protected/views/adminFile/_form.php
@@ -88,7 +88,7 @@
         <div class="control-group">
             <a href="#" role="button" class="btn btn-attr">New Attribute </a>
             <br/>
-            <div class="js-new-attr" style="display:none;">
+            <div class="js-new-attr" style="display:none;margin-top: 10px">
                 <?php echo CHtml::activeDropDownList($attribute, 'attribute_id',CHtml::listData(Attribute::model()->findAll(),'id','attribute_name'), array('class'=>'attr-form', 'empty'=>'Select name')); ?>
                 <?php echo $form->textField($attribute, 'value',array('class'=>'attr-form'));?>
                 <?php echo CHtml::activeDropDownList($attribute, 'unit_id',CHtml::listData(Unit::model()->findAll(),'id','name'), array('class'=>'attr-form', 'empty'=>'Select unit')); ?>

--- a/protected/views/adminFile/_form.php
+++ b/protected/views/adminFile/_form.php
@@ -1,3 +1,10 @@
+<? if (Yii::app()->params['less_dev_mode']) { ?>
+    <link rel="stylesheet/less" type="text/css" href="/less/current.less?time=<?= time() ?>">
+    <? Yii::app()->clientScript->registerScriptFile('/js/less-1.3.0.min.js'); ?>
+<? } else { ?>
+    <link rel="stylesheet" type="text/css" href="/css/current.css"/>
+<? } ?>
+
 <div class="row">
     <div class="span10 offset1 form well">
         <?php $form=$this->beginWidget('CActiveForm', array(

--- a/protected/views/adminFile/_form.php
+++ b/protected/views/adminFile/_form.php
@@ -1,4 +1,7 @@
 <div class="row">
+
+    <!--TODO: Adding 'style'=>'margin-top:*' to each div is just a temp styling fix, need further investigation on how to implement CSS styling properly.-->
+
     <div class="span10 offset1 form well">
         <?php $form=$this->beginWidget('CActiveForm', array(
 		'id'=>'file-form',

--- a/protected/views/adminFile/_form.php
+++ b/protected/views/adminFile/_form.php
@@ -89,10 +89,10 @@
             <a href="#" role="button" class="btn btn-attr">New Attribute </a>
             <br/>
             <div class="js-new-attr" style="display:none;">
-                <?php echo CHtml::activeDropDownList($attribute, 'attribute_id',CHtml::listData(Attribute::model()->findAll(),'id','attribute_name'), array('class'=>'attr-form','style'=>'margin-top: 10px;','empty'=>'Select name')); ?>
-                <?php echo $form->textField($attribute, 'value',array('class'=>'attr-form','style'=>'margin-top: 10px;'));?>
-                <?php echo CHtml::activeDropDownList($attribute, 'unit_id',CHtml::listData(Unit::model()->findAll(),'id','name'), array('class'=>'attr-form','style'=>'margin-top: 10px;','empty'=>'Select unit')); ?>
-                <input type="submit" class="btn" style="margin-top: 10px" "submit_attr" value="Add" />
+                <?php echo CHtml::activeDropDownList($attribute, 'attribute_id',CHtml::listData(Attribute::model()->findAll(),'id','attribute_name'), array('class'=>'attr-form', 'empty'=>'Select name')); ?>
+                <?php echo $form->textField($attribute, 'value',array('class'=>'attr-form'));?>
+                <?php echo CHtml::activeDropDownList($attribute, 'unit_id',CHtml::listData(Unit::model()->findAll(),'id','name'), array('class'=>'attr-form', 'empty'=>'Select unit')); ?>
+                <input type="submit" class="btn" name="submit_attr" value="Add" />
             </div>
             <br/>
             <?php if($model->fileAttributes) { ?>

--- a/protected/views/adminFile/_form.php
+++ b/protected/views/adminFile/_form.php
@@ -89,10 +89,10 @@
             <a href="#" role="button" class="btn btn-attr">New Attribute </a>
             <br/>
             <div class="js-new-attr" style="display:none;">
-                <?php echo CHtml::activeDropDownList($attribute, 'attribute_id',CHtml::listData(Attribute::model()->findAll(),'id','attribute_name'), array('class'=>'attr-form', 'empty'=>'Select name')); ?>
-                <?php echo $form->textField($attribute, 'value',array('class'=>'attr-form'));?>
-                <?php echo CHtml::activeDropDownList($attribute, 'unit_id',CHtml::listData(Unit::model()->findAll(),'id','name'), array('class'=>'attr-form', 'empty'=>'Select unit')); ?>
-                <input type="submit" class="btn" name="submit_attr" value="Add" />
+                <?php echo CHtml::activeDropDownList($attribute, 'attribute_id',CHtml::listData(Attribute::model()->findAll(),'id','attribute_name'), array('class'=>'attr-form','style'=>'margin-top: 10px;','empty'=>'Select name')); ?>
+                <?php echo $form->textField($attribute, 'value',array('class'=>'attr-form','style'=>'margin-top: 10px;'));?>
+                <?php echo CHtml::activeDropDownList($attribute, 'unit_id',CHtml::listData(Unit::model()->findAll(),'id','name'), array('class'=>'attr-form','style'=>'margin-top: 10px;','empty'=>'Select unit')); ?>
+                <input type="submit" class="btn" style="margin-top: 10px" "submit_attr" value="Add" />
             </div>
             <br/>
             <?php if($model->fileAttributes) { ?>

--- a/protected/views/adminFile/_form.php
+++ b/protected/views/adminFile/_form.php
@@ -10,70 +10,70 @@
         <div class="control-group">
             <?php echo $form->labelEx($model,'dataset_id',array('class'=>'control-label')); ?>
             <div class="controls">
-                <?= CHtml::activeDropDownList($model,'dataset_id',CHtml::listData(Util::getDois(),'id','identifier')); ?>
+                <?= CHtml::activeDropDownList($model,'dataset_id',CHtml::listData(Util::getDois(),'id','identifier'), array('style'=>'margin-top:-40px')); ?>
                     <?php echo $form->error($model,'dataset_id'); ?>
             </div>
         </div>
         <div class="control-group">
             <?php echo $form->labelEx($model,'name',array('class'=>'control-label')); ?>
             <div class="controls">
-                <?php echo $form->textField($model,'name',array('size'=>60,'maxlength'=>100)); ?>
+                <?php echo $form->textField($model,'name',array('size'=>60,'maxlength'=>100,'style'=>'margin-top:-40px')); ?>
                 <?php echo $form->error($model,'name'); ?>
             </div>
         </div>
         <div class="control-group">
             <?php echo $form->labelEx($model,'location',array('class'=>'control-label')); ?>
             <div class="controls">
-                <?php echo $form->textField($model,'location',array('size'=>60,'maxlength'=>200)); ?>
+                <?php echo $form->textField($model,'location',array('size'=>60,'maxlength'=>200,'style'=>'margin-top:-40px')); ?>
                 <?php echo $form->error($model,'location'); ?>
             </div>
         </div>
         <div class="control-group">
             <?php echo $form->labelEx($model,'extension',array('class'=>'control-label')); ?>
             <div class="controls">
-                <?php echo $form->textField($model,'extension',array('size'=>30,'maxlength'=>30)); ?>
+                <?php echo $form->textField($model,'extension',array('size'=>30,'maxlength'=>30,'style'=>'margin-top:-40px')); ?>
                 <?php echo $form->error($model,'extension'); ?>
             </div>
         </div>
         <div class="control-group">
             <?php echo $form->labelEx($model,'size',array('class'=>'control-label')); ?>
             <div class="controls">
-                <?php echo $form->textField($model,'size'); ?>
+                <?php echo $form->textField($model,'size',array('style'=>'margin-top:-40px')); ?>
                 <?php echo $form->error($model,'size'); ?>
             </div>
         </div>
         <div class="control-group">
             <?php echo $form->labelEx($model,'description',array('class'=>'control-label')); ?>
             <div class="controls">
-                <?php echo $form->textArea($model,'description',array('rows'=>6, 'cols'=>50)); ?>
+                <?php echo $form->textArea($model,'description',array('rows'=>6,'cols'=>50,'style'=>'margin-top:-40px')); ?>
                 <?php echo $form->error($model,'description'); ?>
             </div>
         </div>
         <div class="control-group">
             <?php echo $form->labelEx($model,'date_stamp',array('class'=>'control-label')); ?>
             <div class="controls">
-                <?php echo $form->textField($model,'date_stamp' , array('class' => 'date')); ?>
+                <?php echo $form->textField($model,'date_stamp' ,array('class'=>'date','style'=>'margin-top:-40px')); ?>
                 <?php echo $form->error($model,'date_stamp'); ?>
             </div>
         </div>
         <div class="control-group">
             <?php echo $form->labelEx($model,'format_id',array('class'=>'control-label')); ?>
             <div class="controls">
-                <?= CHtml::activeDropDownList($model,'format_id',CHtml::listData(FileFormat::model()->findAll(),'id','name')); ?>
+                <?= CHtml::activeDropDownList($model,'format_id',CHtml::listData(FileFormat::model()->findAll(),'id','name'),array('style'=>'margin-top:-40px')); ?>
                     <?php echo $form->error($model,'format_id'); ?>
             </div>
         </div>
         <div class="control-group">
             <?php echo $form->labelEx($model,'type_id',array('class'=>'control-label')); ?>
             <div class="controls">
-                <?= CHtml::activeDropDownList($model,'type_id',CHtml::listData(FileType::model()->findAll(),'id','name')); ?>
+                <?= CHtml::activeDropDownList($model,'type_id',CHtml::listData(FileType::model()->findAll(),'id','name'),array('style'=>'margin-top:-40px')); ?>
                     <?php echo $form->error($model,'type_id'); ?>
             </div>
         </div>
         <div class="control-group">
             <?php echo $form->labelEx($model,'sample_name',array('class'=>'control-label')); ?>
             <div class="controls">
-                <?php echo $form->textField($model,'sample_name'); ?>
+                <?php echo $form->textField($model,'sample_name',array('style'=>'margin-top:-40px')); ?>
                 <?php echo $form->error($model,'sample_name'); ?>
             </div>
         </div>

--- a/protected/views/adminFile/_form.php
+++ b/protected/views/adminFile/_form.php
@@ -1,10 +1,3 @@
-<? if (Yii::app()->params['less_dev_mode']) { ?>
-    <link rel="stylesheet/less" type="text/css" href="/less/current.less?time=<?= time() ?>">
-    <? Yii::app()->clientScript->registerScriptFile('/js/less-1.3.0.min.js'); ?>
-<? } else { ?>
-    <link rel="stylesheet" type="text/css" href="/css/current.css"/>
-<? } ?>
-
 <div class="row">
     <div class="span10 offset1 form well">
         <?php $form=$this->beginWidget('CActiveForm', array(

--- a/protected/views/datasetFunder/_form.php
+++ b/protected/views/datasetFunder/_form.php
@@ -10,6 +10,8 @@
 
 	<?php //echo $form->errorSummary($model); ?>
 
+    <!--TODO: Adding style="flex-direction: column;" to each div is just a temp styling fix, need further investigation on how to implement CSS styling properly.-->
+
 	<div class="control-group">
 		<?php echo $form->labelEx($model,'dataset_id', array('class'=>'control-label')); ?>
 		<div class="controls" style="flex-direction: column;">

--- a/protected/views/datasetFunder/_form.php
+++ b/protected/views/datasetFunder/_form.php
@@ -12,7 +12,7 @@
 
 	<div class="control-group">
 		<?php echo $form->labelEx($model,'dataset_id', array('class'=>'control-label')); ?>
-		<div class="controls">
+		<div class="controls" style="flex-direction: column;">
 			<?php echo CHtml::activeDropDownList($model,'dataset_id', $datasets); ?>
 			<?php echo $form->error($model,'dataset_id'); ?>
 		</div>
@@ -20,7 +20,7 @@
 
 	<div class="control-group">
 		<?php echo $form->labelEx($model,'funder_id', array('class'=>'control-label')); ?>
-		<div class="controls">
+		<div class="controls" style="flex-direction: column;">
 			<?php echo CHtml::activeDropDownList($model,'funder_id', $funders); ?>
 			<?php echo $form->error($model,'funder_id'); ?>
 		</div>
@@ -28,7 +28,7 @@
 
 	<div class="control-group">
 		<?php echo $form->labelEx($model,'grant_award', array('class'=>'control-label')); ?>
-		<div class="controls">
+		<div class="controls" style="flex-direction: column;">
 			<?php echo $form->textArea($model,'grant_award',array('rows'=>6, 'cols'=>50)); ?>
 			<?php echo $form->error($model,'grant_award'); ?>
 		</div>
@@ -36,7 +36,7 @@
         
         <div class="control-group">
 		<?php echo $form->labelEx($model,'awardee', array('class'=>'control-label')); ?>
-		<div class="controls">
+		<div class="controls" style="flex-direction: column;">
 			<?php echo $form->textArea($model,'awardee',array('rows'=>6, 'cols'=>50)); ?>
 			<?php echo $form->error($model,'awardee'); ?>
 		</div>
@@ -44,7 +44,7 @@
 
 	<div class="control-group">
 		<?php echo $form->labelEx($model,'comments', array('class'=>'control-label')); ?>
-		<div class="control">
+		<div class="controls" style="flex-direction: column;">
 			<?php echo $form->textArea($model,'comments',array('rows'=>6, 'cols'=>50)); ?>
 			<?php echo $form->error($model,'comments'); ?>
 		</div>

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -47,7 +47,7 @@ class AcceptanceTester extends \Codeception\Actor
     }
 
     /**
-     * @Then I should see :text
+     * @Then /^I should see "([^"]*)"$/
      */
     public function iShouldSee($text)
     {
@@ -142,6 +142,15 @@ class AcceptanceTester extends \Codeception\Actor
     public function iShouldSeeADisabledSubmitButton($value)
     {
         $this->seeElement(Locator::find('input', ['type' => 'submit', 'value' => $value, 'disabled' =>'disabled']));
+    }
+
+    /**
+     * @Then I should see a button :button with creation log link
+     */
+    public function iShouldSeeAButtonWithLink($expectButton)
+    {
+        $actualButton = $this->grabTextFrom("//a[contains(@href, '/curationlog/create/id/')]");
+        $this->assertEquals($actualButton, $expectButton);
     }
 
     /**

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -47,7 +47,7 @@ class AcceptanceTester extends \Codeception\Actor
     }
 
     /**
-     * @Then /^I should see "([^"]*)"$/
+     * @Then I should see :text
      */
     public function iShouldSee($text)
     {

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -6,7 +6,7 @@ Feature: form to update dataset details
   Background:
     Given I have signed in as admin
 
-  @wip
+  @ok @issue-381 @issue-926
   Scenario: Form loading with all necessary fields
     When I am on "/adminDataset/update/id/8"
     Then I should see "Submitter *"
@@ -17,7 +17,7 @@ Feature: form to update dataset details
     And I should see "Software"
     And I should see "Genomic"
     And I should see "Metadata"
-    And I should see "Dataset Size!!!"
+    And I should see "Dataset Size in Bytes *"
     And I should see "Image Status"
     And I should see "Image URL"
     And I should see "Image Source *"
@@ -29,7 +29,6 @@ Feature: form to update dataset details
     And I should see "Fair Use Policy"
     And I should see "Publication Date"
     And I should see "Modification Date"
-    And I should see "Dataset Size *"
     And I should see "Title *"
     And I should see "Description"
     And I should see "Keywords"

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -6,6 +6,38 @@ Feature: form to update dataset details
   Background:
     Given I have signed in as admin
 
+  @wip
+  Scenario: Form loading with all necessary fields
+    When I am on "/adminDataset/update/id/8"
+    Then I should see "Submitter *"
+    And I should see "Curator Id"
+    And I should see "Manuscript Id"
+    And I should see "Upload Status"
+    And I should see "Epigenomic"
+    And I should see "Software"
+    And I should see "Genomic"
+    And I should see "Metadata"
+    And I should see "Dataset Size!!!"
+    And I should see "Image Status"
+    And I should see "Image URL"
+    And I should see "Image Source *"
+    And I should see "Image Tag"
+    And I should see "Image License *"
+    And I should see "Image Photographer *"
+    And I should see "DOI *"
+    And I should see "Ftp Site *"
+    And I should see "Fair Use Policy"
+    And I should see "Publication Date"
+    And I should see "Modification Date"
+    And I should see "Dataset Size *"
+    And I should see "Title *"
+    And I should see "Description"
+    And I should see "Keywords"
+    And I should see "URL to redirect"
+    And I should see a submit button "Save"
+    And I should see a button "Create New Log" with creation log link
+    And I should not see "Publisher"
+
   @ok
   Scenario: Can display generic image, but no image meta data fields for no image dataset in update page
     When I am on "/adminDataset/update/id/144"


### PR DESCRIPTION
# Pull request for issue: #926, #927, #933

This is a pull request for the following functionalities:

This PR does not make any update of the files in the less folder, so the changes are only effective specifically to the admin dataset page,  admin file page and admin sample page as described in the reported issues.

For issue #926, since the `forms.less` has been reverted as the whole less folder needs further investigation, so it is re-opened and fixed in this PR.

<img width="744" alt="image" src="https://user-images.githubusercontent.com/64770635/165231092-cdf0a95f-cb3c-464f-8824-1aec49832584.png">



When edit attribute on admin file page, the table size would exceed the page size after clicking the edit button #927,  after updating the style in the files `/views/adminFile/_attr.php` and `/view/adminFile/_form`, this issue could then be fixed.

<img width="868" alt="image" src="https://user-images.githubusercontent.com/64770635/160049655-7ddbc0e1-c674-47c7-8c09-22695c97c8fd.png">

For the text boxes are found not under the title in admin dataset funder page #933, this issue is fixed by adding `flex-direction: column;` to the class `controls`. 

<img width="657" alt="image" src="https://user-images.githubusercontent.com/64770635/159623314-33eab3b7-740d-4d16-8f46-3fc8ca3ea9d3.png">


