### PR TITLE
TestDebt: To remove excel files after a functional test

### DIFF
--- a/tests/functional/DownloadTemplateFilesCest.php
+++ b/tests/functional/DownloadTemplateFilesCest.php
@@ -6,6 +6,17 @@ class DownloadTemplateFilesCest
     {
     }
 
+    public function _after(FunctionalTester $I)
+    {
+        if (file_exists("GigaDBUploadForm-forWebsite-v22Dec2021.xlsx"))
+            unlink("GigaDBUploadForm-forWebsite-v22Dec2021.xlsx");
+
+        if (file_exists("GigaDBUpload-Example1-forWebsite-v22Dec2021.xlsx"))
+            unlink("GigaDBUpload-Example1-forWebsite-v22Dec2021.xlsx");
+
+        if (file_exists("GigaDBUpload-Example2-forWebsite-v22Dec2021.xlsx"))
+            unlink("GigaDBUpload-Example2-forWebsite-v22Dec2021.xlsx");
+    }
     // tests
     public function tryToDownloadTemplateFile(FunctionalTester $I)
     {
@@ -22,6 +33,6 @@ class DownloadTemplateFilesCest
     public function tryToDownloadExampleFile2(FunctionalTester $I)
     {
         shell_exec('curl --url "http://gigadb.test/files/templates/GigaDBUpload-Example2-forWebsite-v22Dec2021.xlsx" -O');
-        $I->assertFileExists("GigaDBUpload-Example1-forWebsite-v22Dec2021.xlsx");
+        $I->assertFileExists("GigaDBUpload-Example2-forWebsite-v22Dec2021.xlsx");
     }
 }


### PR DESCRIPTION
# Pull request for functional test debt

This is a pull request for the following functionalities:

Before the fix, every time after running

```
% ./tests/unit_functional_runner
OR
% docker-compose run --rm test ./vendor/codeception/codeception/codecept run functional tests/functional/DownloadTemplateFilesCest.php

```
unnecessary excel files will be downloaded to the file systems and they need to be removed manually.

After the fix, an `after` function is added to check for the existence of the excel file and then remove it after each test, so the state of the file systems could remain as before the test.
