### PR TITLE
Add command to check files url for a dataset

### DIFF
--- a/protected/commands/FilesCommand.php
+++ b/protected/commands/FilesCommand.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Command to check fils url
+ *
+ * @author Rija Menage <rija+git@cinecinetique.com>
+ * @license GPL-3.0
+ */
+
+
+class FilesCommand extends CConsoleCommand
+{
+
+    public function getHelp()
+    {
+        $helpText = "checks files url for a specific dataset in the database" . PHP_EOL;
+        $helpText .= "Usage: ./protected/yiic files checkUrls --doi=<DOI>" . PHP_EOL;
+
+        return $helpText;
+    }
+
+    /**
+     * @return int
+     * @throws CException
+     */
+    public function actionCheckUrls($doi) {
+        $sql =<<<END
+SELECT f.location
+FROM file f, dataset d
+WHERE f.dataset_id = d.id and d.identifier = '$doi';
+END;
+
+        try {
+            $rows = Yii::app()->db->createCommand($sql)->queryAll();
+            foreach ($rows as $row) {
+                $parts = parse_url($row['location']);
+                if ( "ftp" === $parts['scheme']) {
+                    echo $row['location'].PHP_EOL;
+                    continue;
+                }
+                $headers = get_headers($row['location'], 1, stream_context_create(array('http' => array('method' => 'HEAD'))));
+                if ($headers[0] !== 200)
+                    echo $row['location'].PHP_EOL;
+
+            }
+
+        } catch (CDbException $e) {
+            Yii::log($e->getMessage(),"error");
+            return 1;
+        }
+
+
+    }
+
+
+
+}

--- a/protected/commands/FilesCommand.php
+++ b/protected/commands/FilesCommand.php
@@ -6,10 +6,16 @@
  * @license GPL-3.0
  */
 
+use \yii\console\ExitCode;
+use \Codeception\Util\HttpCode;
 
 class FilesCommand extends CConsoleCommand
 {
+    const RETURN_ASSOCIATIVE_ARRAY = 1 ;
 
+    /**
+     * @return string
+     */
     public function getHelp()
     {
         $helpText = "checks files url for a specific dataset in the database" . PHP_EOL;
@@ -19,6 +25,11 @@ class FilesCommand extends CConsoleCommand
     }
 
     /**
+     *
+     * Query databse for files url associated to dataset passed as parameter and check that they resolve ok
+     * otherwise output the url
+     *
+     * @param $doi string identifier of the dataset for which to check url
      * @return int
      * @throws CException
      */
@@ -37,17 +48,18 @@ END;
                     echo $row['location'].PHP_EOL;
                     continue;
                 }
-                $headers = get_headers($row['location'], 1, stream_context_create(array('http' => array('method' => 'HEAD'))));
-                if ($headers[0] !== 200)
+                $headers = get_headers($row['location'], self::RETURN_ASSOCIATIVE_ARRAY, stream_context_create(array('http' => array('method' => 'HEAD'))));
+                if ($headers[0] !== HttpCode::OK)
                     echo $row['location'].PHP_EOL;
 
             }
 
         } catch (CDbException $e) {
             Yii::log($e->getMessage(),"error");
-            return 1;
+            return ExitCode::IOERR;
         }
 
+        return ExitCode::OK;
 
     }
 

--- a/protected/commands/FilesCommand.php
+++ b/protected/commands/FilesCommand.php
@@ -49,9 +49,8 @@ END;
                     continue;
                 }
                 $headers = get_headers($row['location'], self::RETURN_ASSOCIATIVE_ARRAY, stream_context_create(array('http' => array('method' => 'HEAD'))));
-                if ($headers[0] !== HttpCode::OK)
+                if (!CompatibilityHelper::str_contains($headers[0],HttpCode::OK))
                     echo $row['location'].PHP_EOL;
-
             }
 
         } catch (CDbException $e) {

--- a/tests/functional/FilesCommandCest.php
+++ b/tests/functional/FilesCommandCest.php
@@ -14,7 +14,7 @@ class FilesCommandCest
         $I->assertNull($output);
     }
 
-    public function tryToOutputNonResolvableLinks(FunctionalTester $I)
+    public function tryToOutputNonResolvableHTTPLinks(FunctionalTester $I)
     {
 
         $I->haveInDatabase("file", [
@@ -29,5 +29,23 @@ class FilesCommandCest
 
         $output = shell_exec("./protected/yiic files checkUrls --doi=100020");
         $I->assertContains("https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020/bogus.txt", $output);
+    }
+
+
+    public function tryToOutputNonResolvableFTPLinks(FunctionalTester $I)
+    {
+
+        $I->haveInDatabase("file", [
+            "dataset_id" => 22,
+            "name" => "bogus.txt",
+            "location" => "ftp://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020/bogus.txt",
+            "extension" => "txt",
+            "size" => "999",
+            "format_id" => 1,
+            "type_id" => 1,
+        ]);
+
+        $output = shell_exec("./protected/yiic files checkUrls --doi=100020");
+        $I->assertContains("ftp://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020/bogus.txt", $output);
     }
 }

--- a/tests/functional/FilesCommandCest.php
+++ b/tests/functional/FilesCommandCest.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Functional tests for the file URLs checker command
+ *
+ */
+class FilesCommandCest
+{
+
+
+    public function tryNotToOutputResolvableLinks(FunctionalTester $I)
+    {
+        $output = shell_exec("./protected/yiic files checkUrls --doi=100020");
+        $I->assertNull($output);
+    }
+
+    public function tryToOutputNonResolvableLinks(FunctionalTester $I)
+    {
+
+        $I->haveInDatabase("file", [
+            "dataset_id" => 22,
+            "name" => "bogus.txt",
+            "location" => "https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020/bogus.txt",
+            "extension" => "txt",
+            "size" => "999",
+            "format_id" => 1,
+            "type_id" => 1,
+        ]);
+
+        $output = shell_exec("./protected/yiic files checkUrls --doi=100020");
+        $I->assertContains("https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020/bogus.txt", $output);
+    }
+}


### PR DESCRIPTION
# Pull request for issue: #1031

This is a pull request for the following functionalities:

The command will make a HEAD request to the urls of files associated to a dataset and output thoses that
don't have a 200 response code or have an ftp scheme.

To test run the following command:

```
$ docker-compose exec application  ./protected/yiic files checkUrls --doi=<DOI>
```

where <DOI> is replaced by a DOI for which to test the files' url.



