### PR TITLE
Detect directories in files url and fix SSL handshake error

### DIFF
--- a/ops/scripts/setup_devdb.sh
+++ b/ops/scripts/setup_devdb.sh
@@ -37,9 +37,9 @@ $DOCKER_COMPOSE run --rm  application ./protected/yiic migrate mark 000000_00000
 $DOCKER_COMPOSE run --rm  application ./protected/yiic migrate --connectionID=db --migrationPath=application.migrations.schema --interactive=0
 
 # Drop constraints, indexes and triggers to allow data migrations
-docker-compose run --rm test psql -h database -U gigadb < protected/runtime/dropConstraintsQuery.sql
-docker-compose run --rm test psql -h database -U gigadb < protected/runtime/dropIndexQuery.sql
-docker-compose run --rm test psql -h database -U gigadb < protected/runtime/dropTriggerQuery.sql
+docker-compose run -T --rm test psql -h database -U gigadb < protected/runtime/dropConstraintsQuery.sql
+docker-compose run -T --rm test psql -h database -U gigadb < protected/runtime/dropIndexQuery.sql
+docker-compose run -T --rm test psql -h database -U gigadb < protected/runtime/dropTriggerQuery.sql
 
 # Perform data migrations
 $DOCKER_COMPOSE run --rm  application ./protected/yiic migrate --connectionID=db --migrationPath=application.migrations.data.$dbSet --interactive=0
@@ -48,9 +48,9 @@ $DOCKER_COMPOSE run --rm  application ./protected/yiic migrate --connectionID=db
 $DOCKER_COMPOSE run --rm  application ./protected/yiic migrate --connectionID=db --migrationPath=application.migrations.fix_import --interactive=0
 
 # Restore constraints, indexes and triggers
-docker-compose run --rm test psql -h database -U gigadb < protected/runtime/addConstraintsQuery.sql
-docker-compose run --rm test psql -h database -U gigadb < protected/runtime/addIndexQuery.sql
-docker-compose run --rm test psql -h database -U gigadb < protected/runtime/addTriggerQuery.sql
+docker-compose run -T --rm test psql -h database -U gigadb < protected/runtime/addConstraintsQuery.sql
+docker-compose run -T --rm test psql -h database -U gigadb < protected/runtime/addIndexQuery.sql
+docker-compose run -T --rm test psql -h database -U gigadb < protected/runtime/addTriggerQuery.sql
 
 # run migration for FUW database
 $DOCKER_COMPOSE exec -T console /app/yii migrate/fresh --interactive=0

--- a/protected/commands/FilesCommand.php
+++ b/protected/commands/FilesCommand.php
@@ -54,7 +54,15 @@ END;
                     echo $row['location'].PHP_EOL;
                     continue;
                 }
-                $headers = get_headers($row['location'], self::RETURN_ASSOCIATIVE_ARRAY, stream_context_create(array('http' => array('method' => 'HEAD'))));
+                $headers = get_headers($row['location'], self::RETURN_ASSOCIATIVE_ARRAY, stream_context_create([
+                    'http' => [
+                        'method' => 'HEAD'
+                    ],
+                    'ssl' => [
+                        'verify_peer' => false,
+                        'verify_peer_name' => false,
+                    ],
+                ]));
                 if(!CompatibilityHelper::str_contains($headers[0],HttpCode::OK))
                     echo $row['location'].PHP_EOL;
             }

--- a/protected/commands/FilesCommand.php
+++ b/protected/commands/FilesCommand.php
@@ -44,12 +44,18 @@ END;
             $rows = Yii::app()->db->createCommand($sql)->queryAll();
             foreach ($rows as $row) {
                 $parts = parse_url($row['location']);
-                if ( "ftp" === $parts['scheme']) {
+                $pathComponents = pathinfo($parts['path']);
+
+                if( "ftp" === $parts['scheme']) {
+                    echo $row['location'].PHP_EOL;
+                    continue;
+                }
+                if( !$pathComponents['extension'] ) {
                     echo $row['location'].PHP_EOL;
                     continue;
                 }
                 $headers = get_headers($row['location'], self::RETURN_ASSOCIATIVE_ARRAY, stream_context_create(array('http' => array('method' => 'HEAD'))));
-                if (!CompatibilityHelper::str_contains($headers[0],HttpCode::OK))
+                if(!CompatibilityHelper::str_contains($headers[0],HttpCode::OK))
                     echo $row['location'].PHP_EOL;
             }
 

--- a/tests/functional/FilesCommandCest.php
+++ b/tests/functional/FilesCommandCest.php
@@ -10,7 +10,19 @@ class FilesCommandCest
 
     public function tryNotToOutputResolvableLinks(FunctionalTester $I)
     {
-        $output = shell_exec("./protected/yiic files checkUrls --doi=100020");
+
+        $I->haveInDatabase("file", [
+            "dataset_id" => 700,
+            "name" => "GigaDBUploadForm-forWebsite-v22Dec2021.xlsx",
+            "location" => "http://gigadb.test/files/templates/GigaDBUploadForm-forWebsite-v22Dec2021.xlsx",
+            "extension" => "txt",
+            "size" => "999",
+            "format_id" => 1,
+            "type_id" => 1,
+        ]);
+
+
+        $output = shell_exec("./protected/yiic files checkUrls --doi=300070");
         $I->assertNull($output);
     }
 
@@ -18,17 +30,17 @@ class FilesCommandCest
     {
 
         $I->haveInDatabase("file", [
-            "dataset_id" => 22,
-            "name" => "bogus.txt",
-            "location" => "https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020/bogus.txt",
+            "dataset_id" => 700,
+            "name" => "bogus.xlsx",
+            "location" => "http://gigadb.test/files/templates/bogus.xlsx",
             "extension" => "txt",
             "size" => "999",
             "format_id" => 1,
             "type_id" => 1,
         ]);
 
-        $output = shell_exec("./protected/yiic files checkUrls --doi=100020");
-        $I->assertContains("https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020/bogus.txt", $output);
+        $output = shell_exec("./protected/yiic files checkUrls --doi=300070");
+        $I->assertContains("http://gigadb.test/files/templates/bogus.xlsx", $output);
     }
 
 
@@ -36,17 +48,17 @@ class FilesCommandCest
     {
 
         $I->haveInDatabase("file", [
-            "dataset_id" => 22,
+            "dataset_id" => 700,
             "name" => "bogus.txt",
-            "location" => "ftp://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020/bogus.txt",
+            "location" => "ftp://example.shiny/bogus.txt",
             "extension" => "txt",
             "size" => "999",
             "format_id" => 1,
             "type_id" => 1,
         ]);
 
-        $output = shell_exec("./protected/yiic files checkUrls --doi=100020");
-        $I->assertContains("ftp://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020/bogus.txt", $output);
+        $output = shell_exec("./protected/yiic files checkUrls --doi=300070");
+        $I->assertContains("ftp://example.shiny/bogus.txt", $output);
     }
 
 
@@ -54,7 +66,7 @@ class FilesCommandCest
     {
 
         $I->haveInDatabase("file", [
-            "dataset_id" => 22,
+            "dataset_id" => 700,
             "name" => "some_stuff",
             "location" => "https://mirror.in2p3.fr/pub/epel/8/Everything/x86_64/Packages/f",
             "extension" => "txt",
@@ -64,7 +76,7 @@ class FilesCommandCest
         ]);
 
         $I->haveInDatabase("file", [
-            "dataset_id" => 22,
+            "dataset_id" => 700,
             "name" => "another_stuff",
             "location" => "https://mirror.in2p3.fr/pub/epel/8/Everything/x86_64/Packages/f/",
             "extension" => "txt",
@@ -75,7 +87,7 @@ class FilesCommandCest
 
 
 
-        $output = shell_exec("./protected/yiic files checkUrls --doi=100020");
+        $output = shell_exec("./protected/yiic files checkUrls --doi=300070");
         $I->assertContains("https://mirror.in2p3.fr/pub/epel/8/Everything/x86_64/Packages/f", $output);
         $I->assertContains("https://mirror.in2p3.fr/pub/epel/8/Everything/x86_64/Packages/f/", $output);
     }

--- a/tests/functional/FilesCommandCest.php
+++ b/tests/functional/FilesCommandCest.php
@@ -68,7 +68,7 @@ class FilesCommandCest
         $I->haveInDatabase("file", [
             "dataset_id" => 700,
             "name" => "some_stuff",
-            "location" => "https://mirror.in2p3.fr/pub/epel/8/Everything/x86_64/Packages/f",
+            "location" => "https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020",
             "extension" => "txt",
             "size" => "999",
             "format_id" => 1,
@@ -78,7 +78,7 @@ class FilesCommandCest
         $I->haveInDatabase("file", [
             "dataset_id" => 700,
             "name" => "another_stuff",
-            "location" => "https://mirror.in2p3.fr/pub/epel/8/Everything/x86_64/Packages/f/",
+            "location" => "https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020/",
             "extension" => "txt",
             "size" => "999",
             "format_id" => 1,
@@ -88,7 +88,7 @@ class FilesCommandCest
 
 
         $output = shell_exec("./protected/yiic files checkUrls --doi=300070");
-        $I->assertContains("https://mirror.in2p3.fr/pub/epel/8/Everything/x86_64/Packages/f", $output);
-        $I->assertContains("https://mirror.in2p3.fr/pub/epel/8/Everything/x86_64/Packages/f/", $output);
+        $I->assertContains("https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020", $output);
+        $I->assertContains("https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020/", $output);
     }
 }

--- a/tests/functional/FilesCommandCest.php
+++ b/tests/functional/FilesCommandCest.php
@@ -56,7 +56,7 @@ class FilesCommandCest
         $I->haveInDatabase("file", [
             "dataset_id" => 22,
             "name" => "some_stuff",
-            "location" => "https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020",
+            "location" => "https://mirror.in2p3.fr/pub/epel/8/Everything/x86_64/Packages/f",
             "extension" => "txt",
             "size" => "999",
             "format_id" => 1,
@@ -66,27 +66,17 @@ class FilesCommandCest
         $I->haveInDatabase("file", [
             "dataset_id" => 22,
             "name" => "another_stuff",
-            "location" => "https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020/",
+            "location" => "https://mirror.in2p3.fr/pub/epel/8/Everything/x86_64/Packages/f/",
             "extension" => "txt",
             "size" => "999",
             "format_id" => 1,
             "type_id" => 1,
         ]);
 
-        $I->haveInDatabase("file", [
-            "dataset_id" => 8,
-            "name" => "another_stuff",
-            "location" => "https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/phylogeny_study_update",
-            "extension" => "txt",
-            "size" => "999",
-            "format_id" => 1,
-            "type_id" => 1,
-        ]);
 
 
         $output = shell_exec("./protected/yiic files checkUrls --doi=100020");
-        $I->assertContains("https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020", $output);
-        $I->assertContains("https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020/", $output);
-        $I->assertContains("https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/phylogeny_study_update", $output);
+        $I->assertContains("https://mirror.in2p3.fr/pub/epel/8/Everything/x86_64/Packages/f", $output);
+        $I->assertContains("https://mirror.in2p3.fr/pub/epel/8/Everything/x86_64/Packages/f/", $output);
     }
 }

--- a/tests/functional/FilesCommandCest.php
+++ b/tests/functional/FilesCommandCest.php
@@ -48,4 +48,45 @@ class FilesCommandCest
         $output = shell_exec("./protected/yiic files checkUrls --doi=100020");
         $I->assertContains("ftp://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020/bogus.txt", $output);
     }
+
+
+    public function tryToOutputNonResolvableDirectoryLinks(FunctionalTester $I)
+    {
+
+        $I->haveInDatabase("file", [
+            "dataset_id" => 22,
+            "name" => "some_stuff",
+            "location" => "https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020",
+            "extension" => "txt",
+            "size" => "999",
+            "format_id" => 1,
+            "type_id" => 1,
+        ]);
+
+        $I->haveInDatabase("file", [
+            "dataset_id" => 22,
+            "name" => "another_stuff",
+            "location" => "https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020/",
+            "extension" => "txt",
+            "size" => "999",
+            "format_id" => 1,
+            "type_id" => 1,
+        ]);
+
+        $I->haveInDatabase("file", [
+            "dataset_id" => 8,
+            "name" => "another_stuff",
+            "location" => "https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/phylogeny_study_update",
+            "extension" => "txt",
+            "size" => "999",
+            "format_id" => 1,
+            "type_id" => 1,
+        ]);
+
+
+        $output = shell_exec("./protected/yiic files checkUrls --doi=100020");
+        $I->assertContains("https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020", $output);
+        $I->assertContains("https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100020/", $output);
+        $I->assertContains("https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/phylogeny_study_update", $output);
+    }
 }


### PR DESCRIPTION
# Pull request for issue: #989

This is a pull request for the following functionalities:

* Show directory url in the report of urls for curators to double check
* Fix SSL handshake when checking urls with PHP's ``get_headers``
* Fix ``setup_dev.sh`` to allow gigadb to build and deploy on Apple Silicon based macs

## Changes to ``protected/commands/FilesCommand.php``:

The first change is to detect if the url is likely to be a directory url by checking if the last component of the path has an extension or not. If not, we add it to the report.

The second change is to fix an intermittent error when running the url checker:

```
get_headers(): SSL: Handshake timed out
```

This is not related to our FTP server on CNGB infrastructure as I met that error with urls to third party web sites too.

I don't know the root cause which is related to how PHP negotiate the SSL connections in ``get_headers``, but since we control the urls we check, we can remove the condition for the error by not peforming SSL verification.
This is done by adding an other option to the stream context parameter of ``get_headers()``

## Changes to ``tests/functional/FilesCommandCest.php``:

When testing checking of HTTP links to files, we use internal URLs to gigadb, initially to avoid the SSL handshake error but we keep them to speed up the tests and avoid potential idiosyncracies of our FTP servers.

When testing FTP links, the ftp link can be dummy as we our just capturing the scheme without actually making  a connection to the url.

Finally, added a test scenario for directory link


## Changes to ``ops/scripts/setup_devdb.sh``

Minor change to the script so it works on Apple Silicon based macs.

Before the change, the script would fail with error "no TTY input device" on those machines.







