### PR TITLE
Fix 1067 filesurlchecker bastionerror

### DIFF
--- a/docs/SETUP_CI_CD_PIPELINE.md
+++ b/docs/SETUP_CI_CD_PIPELINE.md
@@ -671,7 +671,7 @@ The script ``ops/configuration/nginx-conf/enable_sites`` will enable the sites w
 
 Example from ``ops/pipelines/gigadb-deploy-jobs.yml``
 ```
-- docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T web /usr/local/bin/enable_sites gigadb.$GIGADB_ENV.https
+- docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml exec -T web /usr/local/bin/enable_sites gigadb.$GIGADB_ENV.https
 ```
 
 When the container service ``web`` is started, it will also execute that ascript to enable the default http configuration for Gigadb.org,

--- a/ops/infrastructure/bastion_playbook.yml
+++ b/ops/infrastructure/bastion_playbook.yml
@@ -128,6 +128,8 @@
 
 - name: Setup files-url-updater so to load latest DB backup in RDS daily
   hosts: name_bastion_server_staging*:name_bastion_server_live*
+  vars:
+    target_host: _bastion
 
   tasks:
     - name: Create a sql and converted directories if they do not exist
@@ -242,6 +244,7 @@
       dds_server_cert_path: /etc/docker
       dds_restart_docker: no
       dds_client_cert_path: /home/centos/.docker
+    - role: ../../roles/docker-postinstall
     - role: ../../roles/docker-daemon-enable-start
 
 - name: Setup Excel to GigaDB tool

--- a/ops/infrastructure/modules/bastion-aws-instance/bastion-aws-instance.tf
+++ b/ops/infrastructure/modules/bastion-aws-instance/bastion-aws-instance.tf
@@ -13,6 +13,13 @@ resource "aws_security_group" "bastion_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    from_port   = 2376
+    to_port     = 2376
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  
   egress {
     from_port   = 0
     to_port     = 0

--- a/ops/infrastructure/roles/docker-postinstall/tasks/main.yml
+++ b/ops/infrastructure/roles/docker-postinstall/tasks/main.yml
@@ -146,7 +146,7 @@
     body_format: json
     body:
       key: "remote{{ target_host }}_private_ip"
-      value: "{{ ec2_private_ip }}"
+      value: "{{ (target_host == '_bastion') | ternary(ec2_bastion_private_ip,ec2_private_ip) }}"
       environment_scope: "{{ gigadb_environment }}"
     status_code:
       - 201
@@ -161,7 +161,7 @@
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
     body_format: json
     body:
-      value: "{{ ec2_private_ip }}"
+      value: "{{ (target_host == '_bastion') | ternary(ec2_bastion_private_ip,ec2_private_ip) }}"
     status_code: 200
   register: private_ip_put_outcome
   when: private_ip_post_outcome.status == 400
@@ -176,7 +176,7 @@
     body_format: json
     body:
       key: "remote{{ target_host }}_public_ip"
-      value: "{{ ec2_public_ip }}"
+      value: "{{ (target_host == '_bastion') | ternary(ec2_bastion_public_ip,ec2_public_ip) }}"
       environment_scope: "{{ gigadb_environment }}"
     status_code:
       - 201
@@ -191,7 +191,7 @@
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
     body_format: json
     body:
-      value: "{{ ec2_public_ip }}"
+      value: "{{ (target_host == '_bastion') | ternary(ec2_bastion_public_ip,ec2_public_ip) }}"
     status_code: 200
   register: public_ip_put_outcome
   when: public_ip_post_outcome.status == 400

--- a/ops/infrastructure/roles/docker-postinstall/tasks/main.yml
+++ b/ops/infrastructure/roles/docker-postinstall/tasks/main.yml
@@ -55,7 +55,7 @@
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
     body_format: json
     body:
-      key: "docker_tlsauth_ca"
+      key: "docker{{ target_host }}_tlsauth_ca"
       value: "{{ ca_pem['content'] | b64decode }}"
       environment_scope: "{{ gigadb_environment }}"
     status_code:
@@ -65,7 +65,7 @@
 
 - name: Copy the CA pem to GITLAB CI environment variable (subsequently)
   uri:
-    url: "{{ gitlab_url }}/variables/docker_tlsauth_ca?filter%5benvironment_scope%5d={{ gigadb_environment }}"
+    url: "{{ gitlab_url }}/variables/docker{{ target_host }}_tlsauth_ca?filter%5benvironment_scope%5d={{ gigadb_environment }}"
     method: PUT
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
@@ -76,7 +76,7 @@
   register: ca_put_outcome
   when: ca_post_outcome.status == 400
 
-- name: Copy the cert pem to GITLAB CI environment variable
+- name: Copy the cert pem to GITLAB CI environment variable (first time)
   uri:
     url: "{{ gitlab_url }}/variables"
     method: POST
@@ -85,7 +85,7 @@
       # Content-Type: application/x-www-form-urlencoded
     body_format: json
     body:
-      key: "docker_tlsauth_cert"
+      key: "docker{{ target_host }}_tlsauth_cert"
       value: "{{ cert_pem['content'] | b64decode }}"
       environment_scope: "{{ gigadb_environment }}"
     status_code:
@@ -95,7 +95,7 @@
 
 - name: Copy the cert pem to GITLAB CI environment variable (subsequently)
   uri:
-    url: "{{ gitlab_url }}/variables/docker_tlsauth_cert?filter%5benvironment_scope%5d={{ gigadb_environment }}"
+    url: "{{ gitlab_url }}/variables/docker{{ target_host }}_tlsauth_cert?filter%5benvironment_scope%5d={{ gigadb_environment }}"
     method: PUT
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
@@ -115,7 +115,7 @@
       # Content-Type: application/x-www-form-urlencoded
     body_format: json
     body:
-      key: "docker_tlsauth_key"
+      key: "docker{{ target_host }}_tlsauth_key"
       value: "{{ key_pem['content'] | b64decode }}"
       environment_scope: "{{ gigadb_environment }}"
     status_code:
@@ -125,7 +125,7 @@
 
 - name: Copy the key pem to GITLAB CI environment variable (subsequently)
   uri:
-    url: "{{ gitlab_url }}/variables/docker_tlsauth_key?filter%5benvironment_scope%5d={{ gigadb_environment }}"
+    url: "{{ gitlab_url }}/variables/docker{{ target_host }}_tlsauth_key?filter%5benvironment_scope%5d={{ gigadb_environment }}"
     method: PUT
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
@@ -145,7 +145,7 @@
       # Content-Type: application/x-www-form-urlencoded
     body_format: json
     body:
-      key: "remote_private_ip"
+      key: "remote{{ target_host }}__private_ip"
       value: "{{ ec2_private_ip }}"
       environment_scope: "{{ gigadb_environment }}"
     status_code:
@@ -155,7 +155,7 @@
 
 - name: copy the private ip address to GITLAB CI environment variable (subsequently)
   uri:
-    url: "{{ gitlab_url }}/variables/remote_private_ip?filter%5benvironment_scope%5d={{ gigadb_environment }}"
+    url: "{{ gitlab_url }}/variables/remote{{ target_host }}_private_ip?filter%5benvironment_scope%5d={{ gigadb_environment }}"
     method: PUT
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
@@ -175,7 +175,7 @@
       # Content-Type: application/x-www-form-urlencoded
     body_format: json
     body:
-      key: "remote_public_ip"
+      key: "remote{{ target_host }}_public_ip"
       value: "{{ ec2_public_ip }}"
       environment_scope: "{{ gigadb_environment }}"
     status_code:
@@ -185,7 +185,7 @@
 
 - name: copy the public ip address to GITLAB CI environment variable (subsequently)
   uri:
-    url: "{{ gitlab_url }}/variables/remote_public_ip?filter%5benvironment_scope%5d={{ gigadb_environment }}"
+    url: "{{ gitlab_url }}/variables/remote{{ target_host }}_public_ip?filter%5benvironment_scope%5d={{ gigadb_environment }}"
     method: PUT
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"

--- a/ops/infrastructure/roles/docker-postinstall/tasks/main.yml
+++ b/ops/infrastructure/roles/docker-postinstall/tasks/main.yml
@@ -145,7 +145,7 @@
       # Content-Type: application/x-www-form-urlencoded
     body_format: json
     body:
-      key: "remote{{ target_host }}__private_ip"
+      key: "remote{{ target_host }}_private_ip"
       value: "{{ ec2_private_ip }}"
       environment_scope: "{{ gigadb_environment }}"
     status_code:

--- a/ops/infrastructure/webapp_playbook.yml
+++ b/ops/infrastructure/webapp_playbook.yml
@@ -19,6 +19,8 @@
 
 - name: Setup Docker CE
   hosts: name_gigadb_server_staging*:name_gigadb_server_live*
+  vars:
+    target_host: ""
 
 
   roles:

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -124,7 +124,7 @@ b_gigadb:
   variables:
     GIGADB_ENV: $DEPLOYMENT_ENV
     COMPOSE_FILE: "ops/deployment/docker-compose.yml:ops/deployment/docker-compose.ci.yml:ops/deployment/docker-compose.build.yml"
-    REMOTE_DOCKER_HOST: "$remote_public_ip:2376"
+    REMOTE_WEBAPP_DOCKER: "$remote_public_ip:2376"
     DATA_SAVE_PATH: "/home/centos/app_data"
     CSV_DIR: "prod_like"
     PORTAINER_BCRYPT: ""

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -2,7 +2,8 @@
   variables:
     GIGADB_ENV: $DEPLOYMENT_ENV
     COMPOSE_FILE: "ops/deployment/docker-compose.yml:ops/deployment/docker-compose.ci.yml:ops/deployment/docker-compose.build.yml"
-    REMOTE_DOCKER_HOST: "$remote_public_ip:2376"
+    REMOTE_WEBAPP_DOCKER: "$remote_public_ip:2376"
+    REMOTE_BASTION_DOCKER: "$remote_bastion_public_ip:2376"
     DATA_SAVE_PATH: "/home/centos/app_data"
   stage: deployment
   allow_failure: false
@@ -29,61 +30,61 @@
     - bash -c "echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
     - bash -c "echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
     # Pull production container from our private registry
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST info
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_web:$GIGADB_ENV
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_app:$GIGADB_ENV
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_config:$GIGADB_ENV
-#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-console:$GIGADB_ENV
-#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-admin:$GIGADB_ENV
-#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-public:$GIGADB_ENV
-#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-worker:$GIGADB_ENV
-#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_gigadb-worker:$GIGADB_ENV
-#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_watcher:$GIGADB_ENV
-#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_tusd:$GIGADB_ENV
-#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_ftpd:$GIGADB_ENV
-#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_beanstalkd:$GIGADB_ENV
+    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER info
+    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
+    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_web:$GIGADB_ENV
+    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_app:$GIGADB_ENV
+    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_config:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-console:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-admin:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-public:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-worker:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_gigadb-worker:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_watcher:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_tusd:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_ftpd:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_beanstalkd:$GIGADB_ENV
     # shutdown currently running container but NOT its volumes
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml down
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST stop socat || true
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST rm socat || true
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml down
+    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER stop socat || true
+    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER rm socat || true
     # verify config renders correctly after variables interpolation
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml config
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml config
     # Redeploy all containers but the web container
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml up -d application #fuw-admin fuw-public
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml up -d application #fuw-admin fuw-public
     # deploy the web container once the application servers are up
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml up -d web
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml up -d web
     # Run database migrations if any
-    - 'MIGRATION_STATUS="$(docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application bash -c "./protected/yiic migrate new --migrationPath=application.migrations.schema --interactive=0 | tail -1")"'
+    - 'MIGRATION_STATUS="$(docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml run --rm application bash -c "./protected/yiic migrate new --migrationPath=application.migrations.schema --interactive=0 | tail -1")"'
     - echo "$MIGRATION_STATUS"
-    - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints'
-    - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes'
-    - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations droptriggers'
-    - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0'
-    - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.fix_import --interactive=0'
+    - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints'
+    - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes'
+    - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations droptriggers'
+    - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0'
+    - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.fix_import --interactive=0'
     # post-install script to run
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm less
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic generatefiletypes
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic generatefileformats
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic custommigrations refreshmaterializedviews
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml run --rm less
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic generatefiletypes
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic generatefileformats
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic custommigrations refreshmaterializedviews
     # Spin up portainer container
     - ./ops/scripts/start_portainer.sh
     # Generate the web certificate for TLS termination on web container.
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm config bash -c "cp /le.staging.ini /etc/letsencrypt/cli.ini && chmod 777 /var/www/assets"
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml run --rm config bash -c "cp /le.staging.ini /etc/letsencrypt/cli.ini && chmod 777 /var/www/assets"
     - ./ops/scripts/setup_cert.sh
     # Debug steps
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml ps
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml top
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml logs web
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml ps
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml top
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml logs web
     # symlink the https configuration for web container and reload nginx (cannot be done earlier as nginx will crash if it cannot see valid web certificates)
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T web /usr/local/bin/enable_sites gigadb.$GIGADB_ENV.https
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml exec -T web /usr/local/bin/enable_sites gigadb.$GIGADB_ENV.https
     # FUW specific steps
-#    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T console /app/yii migrate --interactive=0
-#    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml up -d fuw-worker gigadb-worker
-#    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T web /usr/local/bin/enable_sites fuw-backend.$GIGADB_ENV.http fuw-frontend.$GIGADB_ENV.http
-#    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T console ./yii identity/add-identity --username localadmin --email local-gigadb-admin@rijam.ml1.net --role admin
+#    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml exec -T console /app/yii migrate --interactive=0
+#    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml up -d fuw-worker gigadb-worker
+#    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml exec -T web /usr/local/bin/enable_sites fuw-backend.$GIGADB_ENV.http fuw-frontend.$GIGADB_ENV.http
+#    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml exec -T console ./yii identity/add-identity --username localadmin --email local-gigadb-admin@rijam.ml1.net --role admin
     # start the port 2375 for docker
-#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST run --name socat -d -v /var/run/docker.sock:/var/run/docker.sock -p $remote_private_ip:2375:2375 bobrik/socat TCP-LISTEN:2375,fork UNIX-CONNECT:/var/run/docker.sock
+#    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER run --name socat -d -v /var/run/docker.sock:/var/run/docker.sock -p $remote_private_ip:2375:2375 bobrik/socat TCP-LISTEN:2375,fork UNIX-CONNECT:/var/run/docker.sock
 #  dependencies:
 #    - build
   environment:

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -91,8 +91,8 @@
     - bash -c "echo '$docker_bastion_tlsauth_ca' >  ~/.docker/ca.pem"
     - bash -c "echo '$docker_bastion_tlsauth_cert' > ~/.docker/cert.pem"
     - bash -c "echo '$docker_bastion_tlsauth_key' > ~/.docker/key.pem"
-    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER info
-    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
+    - docker --tlsverify -H=$REMOTE_BASTION_DOCKER info
+    - docker --tlsverify -H=$REMOTE_BASTION_DOCKER login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     - docker --tlsverify -H=$REMOTE_BASTION_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_app:$GIGADB_ENV
   environment:
     name: $DEPLOYMENT_ENV

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -88,9 +88,11 @@
 #  dependencies:
 #    - build
     # Deployment to bastion server
-    - bash -c "echo '$docker_bastion_tlsauth_ca' >  ~/.docker/ca.pem || true"
-    - bash -c "echo '$docker_bastion_tlsauth_cert' > ~/.docker/cert.pem || true"
-    - bash -c "echo '$docker_bastion_tlsauth_key' > ~/.docker/key.pem || true"
+    - bash -c "echo '$docker_bastion_tlsauth_ca' >  ~/.docker/ca.pem"
+    - bash -c "echo '$docker_bastion_tlsauth_cert' > ~/.docker/cert.pem"
+    - bash -c "echo '$docker_bastion_tlsauth_key' > ~/.docker/key.pem"
+    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER info
+    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     - docker --tlsverify -H=$REMOTE_BASTION_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_app:$GIGADB_ENV
   environment:
     name: $DEPLOYMENT_ENV

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -87,6 +87,11 @@
 #    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER run --name socat -d -v /var/run/docker.sock:/var/run/docker.sock -p $remote_private_ip:2375:2375 bobrik/socat TCP-LISTEN:2375,fork UNIX-CONNECT:/var/run/docker.sock
 #  dependencies:
 #    - build
+    # Deployment to bastion server
+    - bash -c "echo '$docker_bastion_tlsauth_ca' >  ~/.docker/ca.pem || true"
+    - bash -c "echo '$docker_bastion_tlsauth_cert' > ~/.docker/cert.pem || true"
+    - bash -c "echo '$docker_bastion_tlsauth_key' > ~/.docker/key.pem || true"
+    - docker --tlsverify -H=$REMOTE_BASTION_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_app:$GIGADB_ENV
   environment:
     name: $DEPLOYMENT_ENV
     url: $REMOTE_HOME_URL

--- a/ops/pipelines/gigadb-operations-jobs.yml
+++ b/ops/pipelines/gigadb-operations-jobs.yml
@@ -25,7 +25,7 @@ sd_top:
   stage: staging deploy
   script:
     - *configure-docker-compose
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml top
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml top
   environment:
     name: staging
     action: prepare
@@ -38,7 +38,7 @@ ld_top:
   stage: live deploy
   script:
     - *configure-docker-compose
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml top
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml top
   environment:
     name: live
     action: prepare
@@ -51,7 +51,7 @@ sd_reset_migration:
   stage: staging deploy
   script:
     - *configure-docker-compose
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate mark 000000_000000 --interactive=0
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate mark 000000_000000 --interactive=0
   environment:
     name: staging
     action: prepare
@@ -64,7 +64,7 @@ ld_reset_migration:
   stage: live deploy
   script:
     - *configure-docker-compose
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate mark 000000_000000 --interactive=0
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate mark 000000_000000 --interactive=0
   environment:
     name: live
     action: prepare
@@ -76,7 +76,7 @@ ld_reset_migration:
   stage: operations
   script:
     - *configure-docker-compose
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml down -v
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml down -v
   when: manual
   artifacts:
     untracked: true
@@ -88,7 +88,7 @@ ld_reset_migration:
   stage: operations
   script:
     - *configure-docker-compose
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml stop application
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml stop application
   when: manual
   artifacts:
     untracked: true
@@ -100,7 +100,7 @@ ld_reset_migration:
   stage: operations
   script:
     - *configure-docker-compose
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml start application
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml start application
   when: manual
   artifacts:
     untracked: true
@@ -112,7 +112,7 @@ ld_reset_migration:
   stage: operations
   script:
     - *configure-docker-compose
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic custommigrations refreshmaterializedviews
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic custommigrations refreshmaterializedviews
   when: manual
   artifacts:
     untracked: true
@@ -203,8 +203,8 @@ ld_teardown:
     - bash -c "echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
     - bash -c "echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
     # start the port 2375 for docker after ensured it's stopped (SIGKILL (137)) and removed
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST rm -f socat || true
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST run --name socat -d -v /var/run/docker.sock:/var/run/docker.sock -p $remote_private_ip:2375:2375 bobrik/socat TCP-LISTEN:2375,fork UNIX-CONNECT:/var/run/docker.sock
+    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER rm -f socat || true
+    - docker --tlsverify -H=$REMOTE_WEBAPP_DOCKER run --name socat -d -v /var/run/docker.sock:/var/run/docker.sock -p $remote_private_ip:2375:2375 bobrik/socat TCP-LISTEN:2375,fork UNIX-CONNECT:/var/run/docker.sock
   environment:
     name: $DEPLOYMENT_ENV
     url: $REMOTE_HOME_URL
@@ -228,8 +228,8 @@ ld_teardown:
     - bash -c "echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
     - bash -c "echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
     # FUW smoke tests
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T console ./yii smoke-test/check-docker-php
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T console ./yii smoke-test/check-tusd-endpoint
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml exec -T console ./yii smoke-test/check-docker-php
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml exec -T console ./yii smoke-test/check-tusd-endpoint
   when: manual
 
 .check_assets:
@@ -250,8 +250,8 @@ ld_teardown:
     - bash -c "echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
     - bash -c "echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
     # list content of assets directory
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T web ls -alrt /var/www/assets
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T application ls -alrt /var/www/assets
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml exec -T web ls -alrt /var/www/assets
+    - docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml exec -T application ls -alrt /var/www/assets
   environment:
     name: $DEPLOYMENT_ENV
     url: $REMOTE_HOME_URL

--- a/ops/pipelines/gigadb-operations-jobs.yml
+++ b/ops/pipelines/gigadb-operations-jobs.yml
@@ -4,7 +4,7 @@
   variables:
     GIGADB_ENV: $DEPLOYMENT_ENV
     COMPOSE_FILE: "ops/deployment/docker-compose.yml:ops/deployment/docker-compose.ci.yml:ops/deployment/docker-compose.build.yml"
-    REMOTE_DOCKER_HOST: "$remote_public_ip:2376"
+    REMOTE_WEBAPP_DOCKER: "$remote_public_ip:2376"
     DATA_SAVE_PATH: "/home/centos/app_data"
   stage: operations
   script: &configure-docker-compose
@@ -189,7 +189,7 @@ ld_teardown:
   variables:
     GIGADB_ENV: $DEPLOYMENT_ENV
     COMPOSE_FILE: "ops/deployment/docker-compose.yml:ops/deployment/docker-compose.ci.yml:ops/deployment/docker-compose.build.yml"
-    REMOTE_DOCKER_HOST: "$remote_public_ip:2376"
+    REMOTE_WEBAPP_DOCKER: "$remote_public_ip:2376"
     DATA_SAVE_PATH: "/home/centos/app_data"
   stage: operations
   script:
@@ -214,7 +214,7 @@ ld_teardown:
   variables:
     GIGADB_ENV: $DEPLOYMENT_ENV
     COMPOSE_FILE: "ops/deployment/docker-compose.yml:ops/deployment/docker-compose.ci.yml:ops/deployment/docker-compose.build.yml"
-    REMOTE_DOCKER_HOST: "$remote_public_ip:2376"
+    REMOTE_WEBAPP_DOCKER: "$remote_public_ip:2376"
     DATA_SAVE_PATH: "/home/centos/app_data"
   stage: operations
   script:
@@ -236,7 +236,7 @@ ld_teardown:
   variables:
     GIGADB_ENV: $DEPLOYMENT_ENV
     COMPOSE_FILE: "ops/deployment/docker-compose.yml:ops/deployment/docker-compose.ci.yml:ops/deployment/docker-compose.build.yml"
-    REMOTE_DOCKER_HOST: "$remote_public_ip:2376"
+    REMOTE_WEBAPP_DOCKER: "$remote_public_ip:2376"
     DATA_SAVE_PATH: "/home/centos/app_data"
   stage: operations
   script:

--- a/ops/scripts/convert_production_db_to_latest_ver.sh
+++ b/ops/scripts/convert_production_db_to_latest_ver.sh
@@ -10,7 +10,7 @@ thedate=${1:-$latest}
 
 # docker-compose executable
 if [[ $GIGADB_ENV != "dev" && $GIGADB_ENV != "CI" ]];then
-	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml"
+	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml"
 else
 	DOCKER_COMPOSE="docker-compose"
 fi

--- a/ops/scripts/make_pgdmp_gigadb_testdata.sh
+++ b/ops/scripts/make_pgdmp_gigadb_testdata.sh
@@ -13,7 +13,7 @@ set +a
 
 # docker-compose executable
 if [[ $GIGADB_ENV != "dev" && $GIGADB_ENV != "CI" ]];then
-	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml"
+	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml"
 else
 	DOCKER_COMPOSE="docker-compose"
 fi

--- a/ops/scripts/make_pgdmp_production_like.sh
+++ b/ops/scripts/make_pgdmp_production_like.sh
@@ -13,7 +13,7 @@ set +a
 
 # docker-compose executable
 if [[ $GIGADB_ENV != "dev" && $GIGADB_ENV != "CI" ]];then
-	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml"
+	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml"
 else
 	DOCKER_COMPOSE="docker-compose"
 fi

--- a/ops/scripts/setup_cert.sh
+++ b/ops/scripts/setup_cert.sh
@@ -21,7 +21,7 @@ CHAIN_LINK=/etc/letsencrypt/live/$REMOTE_HOSTNAME/chain.pem
 
 # docker-compose executable
 if [[ $GIGADB_ENV != "dev" && $GIGADB_ENV != "CI" ]];then
-	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml"
+	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml"
 else
 	DOCKER_COMPOSE="docker-compose"
 fi

--- a/ops/scripts/setup_devdb.sh
+++ b/ops/scripts/setup_devdb.sh
@@ -16,7 +16,7 @@ dbSet=${1:-"gigadb_testdata"}
 
 # docker-compose executable
 if [[ $GIGADB_ENV != "dev" && $GIGADB_ENV != "CI" ]];then
-	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml"
+	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml"
 else
 	DOCKER_COMPOSE="docker-compose"
 fi

--- a/ops/scripts/setup_prod_likedb.sh
+++ b/ops/scripts/setup_prod_likedb.sh
@@ -13,7 +13,7 @@ set +a
 
 # docker-compose executable
 if [[ $GIGADB_ENV != "dev" && $GIGADB_ENV != "CI" ]];then
-	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml"
+	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml"
 else
 	DOCKER_COMPOSE="docker-compose"
 fi

--- a/ops/scripts/setup_testdb.sh
+++ b/ops/scripts/setup_testdb.sh
@@ -16,7 +16,7 @@ dbSet=${1:-"gigadb_testdata"}
 
 # docker-compose executable
 if [[ $GIGADB_ENV != "dev" && $GIGADB_ENV != "CI" ]];then
-	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml"
+	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml"
 else
 	DOCKER_COMPOSE="docker-compose"
 fi

--- a/ops/scripts/start_portainer.sh
+++ b/ops/scripts/start_portainer.sh
@@ -10,7 +10,7 @@ source "./.secrets"
 
 # docker-compose executable
 if [[ $GIGADB_ENV != "dev" && $GIGADB_ENV != "CI" ]];then
-	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml"
+	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_WEBAPP_DOCKER -f ops/deployment/docker-compose.production-envs.yml"
 else
 	DOCKER_COMPOSE="docker-compose"
 fi

--- a/protected/commands/FilesCommand.php
+++ b/protected/commands/FilesCommand.php
@@ -7,11 +7,14 @@
  */
 
 use \yii\console\ExitCode;
-use \Codeception\Util\HttpCode;
 
 class FilesCommand extends CConsoleCommand
 {
+    /** @const int RETURN_ASSOCIATIVE_ARRAY set to 1 it is passed to get_headers() second parameters so output is a list of key/value pairs */
     const RETURN_ASSOCIATIVE_ARRAY = 1 ;
+
+    /** @const int  HTTP_STATUS_OK HTTP status code from HTTP response indicating successful GET */
+    const HTTP_STATUS_OK = 200 ;
 
     /**
      * @return string
@@ -63,7 +66,7 @@ END;
                         'verify_peer_name' => false,
                     ],
                 ]));
-                if(!CompatibilityHelper::str_contains($headers[0],HttpCode::OK))
+                if(!CompatibilityHelper::str_contains($headers[0],self::HTTP_STATUS_OK))
                     echo $row['location'].PHP_EOL;
             }
 


### PR DESCRIPTION
# Pull request for issue: #1067 

This is a pull request for the following functionalities:

* Fix error when we run the files url checker command on the bastion server
* Deploy GigaDB codebase to bastion server from pipeline

## How to test?

Clone my branch and push it to your github's fork of gigadb website.
Ensure the Gitlab pipeline is triggered and all tests pass on CI.

Provision a staging environment and deploy the branch from pipeline on that new enviromnent

Then SSH to bastion, you should be able after replacing ``(your gitlab username here)`` to run the following command:

```
$ docker run -e YII_PATH=/var/www/vendor/yiisoft/yii -it registry.gitlab.com/gigascience/forks/(your gitlab username here)-gigadb-website/production_app:staging ./protected/yiic files checkUrls --doi=100007
```
It should succeed with no output.

## How have functionalities been implemented?

Instead of relying on third party code for reference data of HTTP Status code, I created a constant in the command class itself to represent the HTTP status 200 OK. 

The bug was that the third party reference data for HTTP Status (Codeception\HttpCode) I used is only available in ``require-dev`` of composer.json because it's the testing library and is therefore not deployed on production (only libraries in ``require`` are to be deployed on production).

We don't want to use ``200`` directly in the code as that would introduce a [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Unnamed_numerical_constants) anti-pattern



## Any issues with implementation?

The fix to the deployment was only made for the files url checker command. 
The same problem happens with the dataset spreadsheet upload tool and the files url updater's database converter.
There are not part of the main GigaDB codebase.
The fix for those will be worked on in issue #1068.

## Any changes to automated tests?

Existing automated tests for the Files command cover the functionality being changed already.

## Any improvements to CI/CD pipeline?

Additionally, there is a problem with the deployment to cloud. The command is part of GigaDB Website codebase, but on cloud deployment, that codebase is only deployed on the webapp EC2 host as production Docker compose services.

So it was necessary to: 

* Update the Gitlab deployment job to also push the production appliction docker compose services container image to the bastion EC2 host
* Update the bastion playbook to deploy a secure Docker daemon and store on Gitlab the connection details using variables distinct from the webapp docker daemon's connection details (the key changes being in ``ops/infrastructure/roles/docker-postinstall/tasks/main.yml``)
* Replace environment REMOTE_DOCKER_HOST with REMOTE_WEBAPP_DOCKER and introduce  REMOTE_BASTION_DOCKER
* Update Terraform provisioning to open port for secure docker communication on bastion

Note that the previous way the command was deployed to bastion server is not correct as:

* We don't have garantee that the code running there matches a pipeline release/commit (problematic for release rollback, canary deployment, debugging)
* We mix in application deployment with infrastructure provisioning (our Ansible playbooks are meant for infrastructure configuration only)
* It is not scalable (whereas from pipeline we can deploy app to any provisioned environments at once), which is especially important for backoffice workers that get jobs from message queues
