### PR TITLE
Allow Dataset Spreadsheet Uploader to deploy from pipeline even if errors on other apps pipeline

### DIFF
--- a/gigadb/app/tools/excel-spreadsheet-uploader/gitlab-config.yml
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/gitlab-config.yml
@@ -25,7 +25,6 @@ XLSUploaderBuildStaging:
     - docker tag ${CI_PROJECT_NAME}_production_pgclient:latest registry.gitlab.com/$CI_PROJECT_PATH/production_pgclient:$TARGET_ENV
     - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_xls_uploader:$TARGET_ENV
     - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_pgclient:$TARGET_ENV
-  dependencies: []
   environment:
     name: $TARGET_ENV
   artifacts:

--- a/gigadb/app/tools/excel-spreadsheet-uploader/gitlab-config.yml
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/gitlab-config.yml
@@ -25,6 +25,7 @@ XLSUploaderBuildStaging:
     - docker tag ${CI_PROJECT_NAME}_production_pgclient:latest registry.gitlab.com/$CI_PROJECT_PATH/production_pgclient:$TARGET_ENV
     - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_xls_uploader:$TARGET_ENV
     - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_pgclient:$TARGET_ENV
+  dependencies: []
   environment:
     name: $TARGET_ENV
   artifacts:

--- a/gigadb/app/tools/excel-spreadsheet-uploader/gitlab-config.yml
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/gitlab-config.yml
@@ -35,6 +35,7 @@ XLSUploaderBuildStaging:
       - .ci_env
     when: always
     expire_in: 3 days
+  needs: ["b_gigadb"]
 
 
 XLSUploaderDeployStaging:

--- a/gigadb/app/tools/excel-spreadsheet-uploader/gitlab-config.yml
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/gitlab-config.yml
@@ -64,3 +64,4 @@ XLSUploaderDeployStaging:
       - .ci_env
     when: always
     expire_in: 3 days
+  needs: ["XLSUploaderBuildStaging"]

--- a/gigareview/gitlab-config.yml
+++ b/gigareview/gitlab-config.yml
@@ -13,8 +13,7 @@ GigaReviewTest:
     - env | grep -iE "(REVIEW_ENV|REPO_NAME|POSTGRES_MAJOR_VERSION|POSTGRES_DB|POSTGRES_USER|POSTGRES_PASSWORD|GROUP_VARIABLES_URL|FORK_VARIABLES_URL|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN)"| tee gigareview/.env
     - cd gigareview
     - ./up.sh
-#    - "./tests/unit_runner && ./tests/functional_runner && ./tests/acceptance_runner"
-    - ls -alrt foobar
+    - "./tests/unit_runner && ./tests/functional_runner && ./tests/acceptance_runner"
   environment:
     name: dev
   artifacts:

--- a/gigareview/gitlab-config.yml
+++ b/gigareview/gitlab-config.yml
@@ -13,8 +13,8 @@ GigaReviewTest:
     - env | grep -iE "(REVIEW_ENV|REPO_NAME|POSTGRES_MAJOR_VERSION|POSTGRES_DB|POSTGRES_USER|POSTGRES_PASSWORD|GROUP_VARIABLES_URL|FORK_VARIABLES_URL|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN)"| tee gigareview/.env
     - cd gigareview
     - ./up.sh
-    - "./tests/unit_runner && ./tests/functional_runner && ./tests/acceptance_runner"
-    - false
+#    - "./tests/unit_runner && ./tests/functional_runner && ./tests/acceptance_runner"
+    - ls -alrt foobar
   environment:
     name: dev
   artifacts:

--- a/gigareview/gitlab-config.yml
+++ b/gigareview/gitlab-config.yml
@@ -14,6 +14,7 @@ GigaReviewTest:
     - cd gigareview
     - ./up.sh
     - "./tests/unit_runner && ./tests/functional_runner && ./tests/acceptance_runner"
+    - false
   environment:
     name: dev
   artifacts:


### PR DESCRIPTION
# Pull request for issue: #1068

This is a pull request for the following functionalities:

The dataset spreadsheet upload tool couldn't ``deploy`` from develop branch on Upstream project because Gigareview test job is failing. Those are two distinct apps, and the dataset spreadsheet upload tool's pipeline should progress on its own irrespective of what's happening on other pipelines.

## How to test?

Check out this branch and push it to your remote origin to trigger a pipeline.
You should see the jobs ``XLSUploaderBuildStaging`` and ``XLSUploaderDeployStaging`` actioned (and eventually complete) one after the other a soon as the ``b_gigadb`` job is finished (because we also want the "Conformance and security" stage to have run prior), irrespective of what's going with other jobs.

## How have functionalities been implemented?

We use Gitlab's [DAG mechanism](https://docs.gitlab.com/ee/ci/directed_acyclic_graph/) in the Gitlab configuration file for the dataset spreadsheet upload tool.
Implemented by adding  ``needs`` keyword to jobs that need to run in sequence independently of everything else

## Any issues with implementation?

This problem was discovered when Gigareview test job was failing with errors in Upstream project to deploy to GigaDB staging and beta website. 
That problem is still not solved. It's best looking  at fixing it when working on #1066.


