### PR TITLE
Sprint task 1115, 1116 create editors note col in manuscript table and update validation rules on manuscript class

### DIFF
--- a/gigareview/common/models/Manuscript.php
+++ b/gigareview/common/models/Manuscript.php
@@ -47,7 +47,7 @@ class Manuscript extends \yii\db\ActiveRecord
         return [
             [['doi', 'created_at', 'updated_at'], 'default', 'value' => null],
             [['doi', 'created_at', 'updated_at'], 'integer'],
-            [['publication_date', 'editorial_status_date'], 'safe'],
+            [['publication_date', 'editorial_status_date'], 'date', 'format' => 'dd/MM/yyyy'],
             [['manuscript_number'], 'match', 'pattern' => '/^GIGA\-D\-[0-9]{2}\-[0-9]{5}/'],
             [['editors_note'], 'string'],
             [['manuscript_number', 'article_title', 'editorial_status'], 'string', 'max' => 255],

--- a/gigareview/common/models/Manuscript.php
+++ b/gigareview/common/models/Manuscript.php
@@ -48,7 +48,7 @@ class Manuscript extends \yii\db\ActiveRecord
             [['doi', 'created_at', 'updated_at'], 'default', 'value' => null],
             [['doi', 'created_at', 'updated_at'], 'integer'],
             [['publication_date', 'editorial_status_date'], 'date', 'format' => 'dd/MM/yyyy'],
-            [['manuscript_number'], 'match', 'pattern' => '/^GIGA\-D\-[0-9]{2}\-[0-9]{5}/'],
+            [['manuscript_number'], 'match', 'pattern' => '/^GIGA\-D\-\d{2}\-\d{5}/'],
             [['editors_note'], 'string'],
             [['manuscript_number', 'article_title', 'editorial_status'], 'string', 'max' => 255],
         ];

--- a/gigareview/common/models/Manuscript.php
+++ b/gigareview/common/models/Manuscript.php
@@ -50,7 +50,7 @@ class Manuscript extends \yii\db\ActiveRecord
             [['publication_date', 'editorial_status_date'], 'date', 'format' => 'dd/MM/yyyy'],
             [['manuscript_number'], 'match', 'pattern' => '/^GIGA\-D\-\d{2}\-\d{5}$/'],
             [['editors_note'], 'string'],
-            [['editorial_status'], 'match', 'pattern' => '/^Final\sDecision\s[a-zA-z]+$/'],
+            [['editorial_status'], 'match', 'pattern' => '/^Final\sDecision\sAccept$/'],
             [['manuscript_number', 'article_title', 'editorial_status'], 'string', 'max' => 255],
         ];
     }

--- a/gigareview/common/models/Manuscript.php
+++ b/gigareview/common/models/Manuscript.php
@@ -48,8 +48,9 @@ class Manuscript extends \yii\db\ActiveRecord
             [['doi', 'created_at', 'updated_at'], 'default', 'value' => null],
             [['doi', 'created_at', 'updated_at'], 'integer'],
             [['publication_date', 'editorial_status_date'], 'date', 'format' => 'dd/MM/yyyy'],
-            [['manuscript_number'], 'match', 'pattern' => '/^GIGA\-D\-\d{2}\-\d{5}/'],
+            [['manuscript_number'], 'match', 'pattern' => '/^GIGA\-D\-\d{2}\-\d{5}$/'],
             [['editors_note'], 'string'],
+            [['editorial_status'], 'match', 'pattern' => '/^Final\sDecision\s[a-zA-z]+$/'],
             [['manuscript_number', 'article_title', 'editorial_status'], 'string', 'max' => 255],
         ];
     }

--- a/gigareview/common/models/Manuscript.php
+++ b/gigareview/common/models/Manuscript.php
@@ -48,6 +48,7 @@ class Manuscript extends \yii\db\ActiveRecord
             [['doi', 'created_at', 'updated_at'], 'default', 'value' => null],
             [['doi', 'created_at', 'updated_at'], 'integer'],
             [['publication_date', 'editorial_status_date'], 'safe'],
+            [['manuscript_number'], 'match', 'pattern' => '/^GIGA\-D\-[0-9]{2}\-[0-9]{5}/'],
             [['editors_note'], 'string'],
             [['manuscript_number', 'article_title', 'editorial_status'], 'string', 'max' => 255],
         ];

--- a/gigareview/common/models/Manuscript.php
+++ b/gigareview/common/models/Manuscript.php
@@ -15,6 +15,7 @@ use yii\behaviors\TimestampBehavior;
  * @property string|null $publication_date
  * @property string|null $editorial_status
  * @property string|null $editorial_status_date
+ * @property string|null $editors_note
  * @property int|null $created_at
  * @property int|null $updated_at
  */
@@ -47,6 +48,7 @@ class Manuscript extends \yii\db\ActiveRecord
             [['doi', 'created_at', 'updated_at'], 'default', 'value' => null],
             [['doi', 'created_at', 'updated_at'], 'integer'],
             [['publication_date', 'editorial_status_date'], 'safe'],
+            [['editors_note'], 'string'],
             [['manuscript_number', 'article_title', 'editorial_status'], 'string', 'max' => 255],
         ];
     }
@@ -64,6 +66,7 @@ class Manuscript extends \yii\db\ActiveRecord
             'publication_date' => 'Publication Date',
             'editorial_status' => 'Editorial Status',
             'editorial_status_date' => 'Editorial Status Date',
+            'editors_note' => 'Editors Note',
             'created_at' => 'Created At',
             'updated_at' => 'Updated At',
         ];

--- a/gigareview/common/tests/unit/EMReportJobTest.php
+++ b/gigareview/common/tests/unit/EMReportJobTest.php
@@ -72,7 +72,7 @@ class EMReportJobTest extends \Codeception\Test\Unit
         $emReportJob = new EMReportJob();
         $storeStatus = $emReportJob->storeManuscripts($mockManuscript);
 
-        $this->assertTrue($storeStatus === true, "Record is not stored to manuscript table!");
+        $this->assertTrue($storeStatus, "Record is not stored to manuscript table!");
     }
 
     public function testCanStoreTwoInstancesToManuscriptTable()
@@ -91,7 +91,7 @@ class EMReportJobTest extends \Codeception\Test\Unit
                 'manuscript_number' => 'GIGA-D-22-00060',
                 'article_title' => 'A chromosome-level genome of the booklouse, Liposcelis brunnea provides insight into louse evolution and environmental stress adaptation',
                 'editorial_status_date' => '6/7/2022',
-                'editorial_status' => 'Final Decision Reject'
+                'editorial_status' => 'Final Decision Accept'
             ]
         );
 
@@ -101,18 +101,63 @@ class EMReportJobTest extends \Codeception\Test\Unit
         $emReportJob = new EMReportJob();
         $storeStatus = $emReportJob->storeManuscripts($mockManuscripts);
 
-        $this->assertTrue($storeStatus === true, "Records are not stored to manuscript table!");
+        $this->assertTrue($storeStatus, "Records are not stored to manuscript table!");
     }
 
-    public function testCannotStoreEmptyInstanceToManuscriptTable()
+    public function testCannotStoreInstanceWithInvalidManuscriptNumberToManuscriptTable()
     {
-        $mockManuscriptEmpty = $this->make(Manuscript::class);
+        $mockManuscriptOne = $this->make(Manuscript::class,
+            [
+                'manuscript_number' => 'GIGA-D-22-abcde',
+                'article_title' => 'Test manuscript review with invalid manuscript number',
+                'editorial_status_date' => '6/7/2022',
+                'editorial_status' => 'Final Decision Accept'
+            ]
+        );
 
-        $mockManuscripts[] = $mockManuscriptEmpty;
+        $mockManuscript[] = $mockManuscriptOne;
 
         $emReportJob = new EMReportJob();
-        $storeStatus = $emReportJob->storeManuscripts($mockManuscripts);
+        $storeStatus = $emReportJob->storeManuscripts($mockManuscript);
 
-        $this->assertFalse($storeStatus === false, "Records stored to manuscript table!");
+        $this->assertFalse($storeStatus, "Instance is stored to manuscript table!");
+    }
+
+    public function testCannotStoreInstanceWithInvalidDateFormatToManuscriptTable()
+    {
+        $mockManuscriptOne = $this->make(Manuscript::class,
+            [
+                'manuscript_number' => 'GIGA-D-22-00099',
+                'article_title' => 'Test manuscript review with invalid date format',
+                'editorial_status_date' => '6-7-2022',
+                'editorial_status' => 'Final Decision Accept'
+            ]
+        );
+
+        $mockManuscript[] = $mockManuscriptOne;
+
+        $emReportJob = new EMReportJob();
+        $storeStatus = $emReportJob->storeManuscripts($mockManuscript);
+
+        $this->assertFalse($storeStatus, "Instance is stored to manuscript table!");
+    }
+
+    public function testCannotStoreInstanceWithInvalidEditorialStatusToManuscriptTable()
+    {
+        $mockManuscriptOne = $this->make(Manuscript::class,
+            [
+                'manuscript_number' => 'GIGA-D-22-00060',
+                'article_title' => 'Test manuscript review with invalid editorial status',
+                'editorial_status_date' => '6/7/2022',
+                'editorial_status' => 'Final Decision Reject'
+            ]
+        );
+
+        $mockManuscript[] = $mockManuscriptOne;
+
+        $emReportJob = new EMReportJob();
+        $storeStatus = $emReportJob->storeManuscripts($mockManuscript);
+
+        $this->assertFalse($storeStatus, "Instance is stored to manuscript table!");
     }
 }

--- a/gigareview/common/tests/unit/EMReportJobTest.php
+++ b/gigareview/common/tests/unit/EMReportJobTest.php
@@ -40,6 +40,18 @@ class EMReportJobTest extends \Codeception\Test\Unit
                 'editorial_status_date' => '6/7/2022',
                 'editorial_status' => 'Final Decision Pending'
             ],
+            [
+                'manuscript_number' => 'GIGA-D-22-abcde',
+                'article_title' => 'Test manuscript review with invalid manuscript number format',
+                'editorial_status_date' => '6/7/2022',
+                'editorial_status' => 'Final Decision Accept'
+            ],
+            [
+                'manuscript_number' => 'GIGA-D-22-00099',
+                'article_title' => 'Test manuscript review with invalid date format',
+                'editorial_status_date' => '6-7-2022',
+                'editorial_status' => 'Final Decision Accept'
+            ]
         ];
 
         $sampleCsvReportPath = "console/tests/_data/Report-GIGA-em-manuscripts-latest-214-20220607004243.csv";

--- a/gigareview/common/tests/unit/EMReportJobTest.php
+++ b/gigareview/common/tests/unit/EMReportJobTest.php
@@ -30,15 +30,9 @@ class EMReportJobTest extends \Codeception\Test\Unit
             ],
             [
                 'manuscript_number' => 'GIGA-D-22-00060',
-                'article_title' => 'A chromosome-level genome of the booklouse, Liposcelis brunnea provides insight into louse evolution and environmental stress adaptation',
+                'article_title' => 'Test manuscript review with invalid editorial status',
                 'editorial_status_date' => '6/7/2022',
                 'editorial_status' => 'Final Decision Reject'
-            ],
-            [
-                'manuscript_number' => 'GIGA-D-22-00030',
-                'article_title' => 'A novel ground truth multispectral image dataset with weight, anthocyanins and brix index measures of grape berries tested for its utility in machine learning pipelines',
-                'editorial_status_date' => '6/7/2022',
-                'editorial_status' => 'Final Decision Pending'
             ],
             [
                 'manuscript_number' => 'GIGA-D-22-abcde',

--- a/gigareview/common/tests/unit/EMReportJobTest.php
+++ b/gigareview/common/tests/unit/EMReportJobTest.php
@@ -72,7 +72,7 @@ class EMReportJobTest extends \Codeception\Test\Unit
         $emReportJob = new EMReportJob();
         $storeStatus = $emReportJob->storeManuscripts($mockManuscript);
 
-        $this->assertTrue($storeStatus, "Record is not stored to manuscript table!");
+        $this->assertTrue($storeStatus, "Instance is not stored to the manuscript table!");
     }
 
     public function testCanStoreTwoInstancesToManuscriptTable()
@@ -101,7 +101,7 @@ class EMReportJobTest extends \Codeception\Test\Unit
         $emReportJob = new EMReportJob();
         $storeStatus = $emReportJob->storeManuscripts($mockManuscripts);
 
-        $this->assertTrue($storeStatus, "Records are not stored to manuscript table!");
+        $this->assertTrue($storeStatus, "Instances are not stored to the manuscript table!");
     }
 
     public function testCannotStoreInstanceWithInvalidManuscriptNumberToManuscriptTable()
@@ -120,7 +120,7 @@ class EMReportJobTest extends \Codeception\Test\Unit
         $emReportJob = new EMReportJob();
         $storeStatus = $emReportJob->storeManuscripts($mockManuscript);
 
-        $this->assertFalse($storeStatus, "Instance is stored to manuscript table!");
+        $this->assertFalse($storeStatus, "Instance with invalid manuscript number is stored to the manuscript table!");
     }
 
     public function testCannotStoreInstanceWithInvalidDateFormatToManuscriptTable()
@@ -139,7 +139,7 @@ class EMReportJobTest extends \Codeception\Test\Unit
         $emReportJob = new EMReportJob();
         $storeStatus = $emReportJob->storeManuscripts($mockManuscript);
 
-        $this->assertFalse($storeStatus, "Instance is stored to manuscript table!");
+        $this->assertFalse($storeStatus, "Instance with invalid date format is stored to the manuscript table!");
     }
 
     public function testCannotStoreInstanceWithInvalidEditorialStatusToManuscriptTable()
@@ -158,6 +158,6 @@ class EMReportJobTest extends \Codeception\Test\Unit
         $emReportJob = new EMReportJob();
         $storeStatus = $emReportJob->storeManuscripts($mockManuscript);
 
-        $this->assertFalse($storeStatus, "Instance is stored to manuscript table!");
+        $this->assertFalse($storeStatus, "Instance with invalid editorial status is stored to the manuscript table!");
     }
 }

--- a/gigareview/common/tests/unit/ManuscriptTest.php
+++ b/gigareview/common/tests/unit/ManuscriptTest.php
@@ -45,7 +45,6 @@ class ManuscriptTest extends \Codeception\Test\Unit
         ];
 
         $manuscriptInstance = Manuscript::createInstancesFromEmReport($sampleCsvReportData);
-        file_put_contents('test-1instance.txt', print_r($manuscriptInstance,true));
         $this->assertNotNull($manuscriptInstance);
         $this->assertIsArray($manuscriptInstance);
 

--- a/gigareview/common/tests/unit/ManuscriptTest.php
+++ b/gigareview/common/tests/unit/ManuscriptTest.php
@@ -54,8 +54,8 @@ class ManuscriptTest extends \Codeception\Test\Unit
             $this->assertArrayHasKey('article_title', $instance, "Key article_title is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status_date', $instance, "Key editorial_status_date is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status', $instance, "Key editorial_status is not found in Manuscript instance!");
-            $this->assertRegExp('/^GIGA\-D\-\d{2}\-\d{5}$/', $sampleCsvReportData[0]['manuscript_number'], "Value ".$sampleCsvReportData[0]['manuscript_number']." pattern is not matched in Manuscript instance!");
-            $this->assertRegExp('/^Final\sDecision\s[a-zA-Z]+$/', $sampleCsvReportData[0]['editorial_status'], "Value ".$sampleCsvReportData[0]['editorial_status']." pattern is not matched in Manuscript instance!");
+            $this->assertRegExp('/^GIGA\-D\-\d{2}\-\d{5}$/', $sampleCsvReportData[0]['manuscript_number'], "Value ".$sampleCsvReportData[0]['manuscript_number']." pattern is not matched in Manuscript csv file!");
+            $this->assertRegExp('/^Final\sDecision\s[a-zA-Z]+$/', $sampleCsvReportData[0]['editorial_status'], "Value ".$sampleCsvReportData[0]['editorial_status']." pattern is not matched in Manuscript csv file!");
             $this->assertEquals($sampleCsvReportData[0]['manuscript_number'], $instance->manuscript_number, "Value ".$sampleCsvReportData[0]['manuscript_number']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleCsvReportData[0]['article_title'], $instance->article_title, "Value ".$sampleCsvReportData[0]['article_title']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleCsvReportData[0]['editorial_status_date'], $instance->editorial_status_date, "Value ".$sampleCsvReportData[0]['editorial_status_date']." is not matched in Manuscript instance!");
@@ -90,8 +90,8 @@ class ManuscriptTest extends \Codeception\Test\Unit
             $this->assertArrayHasKey('article_title', $manuscriptInstance, "Key article_title is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status_date', $manuscriptInstance, "Key editorial_status_date is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status', $manuscriptInstance, "Key editorial_status is not found in Manuscript instance!");
-            $this->assertRegExp('/^GIGA\-D\-\d{2}\-\d{5}$/', $manuscriptInstance->manuscript_number,"Value ".$sampleData['manuscript_number']." pattern is not matched in Manuscript instance!");
-            $this->assertRegExp('/^Final\sDecision\s[a-zA-Z]+$/', $manuscriptInstance->editorial_status, "Value ".$sampleData['editorial_status']." pattern is not matched in Manuscript instance!");
+            $this->assertRegExp('/^GIGA\-D\-\d{2}\-\d{5}$/', $sampleData['manuscript_number'],"Value ".$sampleData['manuscript_number']." pattern is not matched in Manuscript csv file!");
+            $this->assertRegExp('/^Final\sDecision\s[a-zA-Z]+$/', $sampleData['editorial_status'], "Value ".$sampleData['editorial_status']." pattern is not matched in Manuscript csv file!");
             $this->assertEquals($sampleData['manuscript_number'], $manuscriptInstance->manuscript_number, "Value ".$sampleData['manuscript_number']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleData['article_title'], $manuscriptInstance->article_title, "Value ".$sampleData['article_title']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleData['editorial_status_date'], $manuscriptInstance->editorial_status_date, "Value ".$sampleData['editorial_status_date']." is not matched in Manuscript instance!");

--- a/gigareview/common/tests/unit/ManuscriptTest.php
+++ b/gigareview/common/tests/unit/ManuscriptTest.php
@@ -27,7 +27,7 @@ class ManuscriptTest extends \Codeception\Test\Unit
         $this->assertNull($manuscript->updated_at);
         $manuscript->save();
         $this->assertNotNull($manuscript->created_at);
-        $manuscript->manuscript_number = "Test-GIGA-D-22-12345";
+        $manuscript->manuscript_number = "GIGA-D-22-12345";
         sleep(1);
         $manuscript->save();
         $this->assertGreaterThan($manuscript->created_at, $manuscript->updated_at);
@@ -54,7 +54,7 @@ class ManuscriptTest extends \Codeception\Test\Unit
             $this->assertArrayHasKey('article_title', $instance, "Key article_title is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status_date', $instance, "Key editorial_status_date is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status', $instance, "Key editorial_status is not found in Manuscript instance!");
-            $this->assertRegExp('/^GIGA\-D\-[0-9]{2}\-[0-9]{5}/', $sampleCsvReportData[0]['manuscript_number'], "Value ".$sampleCsvReportData[0]['manuscript_number']." pattern is not matched in Manuscript instance!");
+            $this->assertRegExp('/^GIGA\-D\-\d{2}\-\d{5}/', $sampleCsvReportData[0]['manuscript_number'], "Value ".$sampleCsvReportData[0]['manuscript_number']." pattern is not matched in Manuscript instance!");
             $this->assertEquals($sampleCsvReportData[0]['manuscript_number'], $instance->manuscript_number, "Value ".$sampleCsvReportData[0]['manuscript_number']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleCsvReportData[0]['article_title'], $instance->article_title, "Value ".$sampleCsvReportData[0]['article_title']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleCsvReportData[0]['editorial_status_date'], $instance->editorial_status_date, "Value ".$sampleCsvReportData[0]['editorial_status_date']." is not matched in Manuscript instance!");
@@ -89,7 +89,7 @@ class ManuscriptTest extends \Codeception\Test\Unit
             $this->assertArrayHasKey('article_title', $manuscriptInstance, "Key article_title is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status_date', $manuscriptInstance, "Key editorial_status_date is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status', $manuscriptInstance, "Key editorial_status is not found in Manuscript instance!");
-            $this->assertRegExp('/^GIGA\-D\-[0-9]{2}\-[0-9]{5}/', $manuscriptInstance->manuscript_number,"Value ".$sampleData['manuscript_number']." pattern is not matched in Manuscript instance!");
+            $this->assertRegExp('/^GIGA\-D\-\d{2}\-\d{5}/', $manuscriptInstance->manuscript_number,"Value ".$sampleData['manuscript_number']." pattern is not matched in Manuscript instance!");
             $this->assertEquals($sampleData['manuscript_number'], $manuscriptInstance->manuscript_number, "Value ".$sampleData['manuscript_number']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleData['article_title'], $manuscriptInstance->article_title, "Value ".$sampleData['article_title']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleData['editorial_status_date'], $manuscriptInstance->editorial_status_date, "Value ".$sampleData['editorial_status_date']." is not matched in Manuscript instance!");

--- a/gigareview/common/tests/unit/ManuscriptTest.php
+++ b/gigareview/common/tests/unit/ManuscriptTest.php
@@ -54,6 +54,7 @@ class ManuscriptTest extends \Codeception\Test\Unit
             $this->assertArrayHasKey('article_title', $instance, "Key article_title is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status_date', $instance, "Key editorial_status_date is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status', $instance, "Key editorial_status is not found in Manuscript instance!");
+            $this->assertRegExp('/^GIGA\-D\-[0-9]{2}\-[0-9]{5}/', $sampleCsvReportData[0]['manuscript_number'], "Value ".$sampleCsvReportData[0]['manuscript_number']." pattern is not matched in Manuscript instance!");
             $this->assertEquals($sampleCsvReportData[0]['manuscript_number'], $instance->manuscript_number, "Value ".$sampleCsvReportData[0]['manuscript_number']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleCsvReportData[0]['article_title'], $instance->article_title, "Value ".$sampleCsvReportData[0]['article_title']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleCsvReportData[0]['editorial_status_date'], $instance->editorial_status_date, "Value ".$sampleCsvReportData[0]['editorial_status_date']." is not matched in Manuscript instance!");
@@ -88,6 +89,7 @@ class ManuscriptTest extends \Codeception\Test\Unit
             $this->assertArrayHasKey('article_title', $manuscriptInstance, "Key article_title is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status_date', $manuscriptInstance, "Key editorial_status_date is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status', $manuscriptInstance, "Key editorial_status is not found in Manuscript instance!");
+            $this->assertRegExp('/^GIGA\-D\-[0-9]{2}\-[0-9]{5}/', $manuscriptInstance->manuscript_number,"Value ".$sampleData['manuscript_number']." pattern is not matched in Manuscript instance!");
             $this->assertEquals($sampleData['manuscript_number'], $manuscriptInstance->manuscript_number, "Value ".$sampleData['manuscript_number']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleData['article_title'], $manuscriptInstance->article_title, "Value ".$sampleData['article_title']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleData['editorial_status_date'], $manuscriptInstance->editorial_status_date, "Value ".$sampleData['editorial_status_date']." is not matched in Manuscript instance!");

--- a/gigareview/common/tests/unit/ManuscriptTest.php
+++ b/gigareview/common/tests/unit/ManuscriptTest.php
@@ -55,7 +55,7 @@ class ManuscriptTest extends \Codeception\Test\Unit
             $this->assertArrayHasKey('editorial_status_date', $instance, "Key editorial_status_date is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status', $instance, "Key editorial_status is not found in Manuscript instance!");
             $this->assertRegExp('/^GIGA\-D\-\d{2}\-\d{5}$/', $sampleCsvReportData[0]['manuscript_number'], "Value ".$sampleCsvReportData[0]['manuscript_number']." pattern is not matched in Manuscript csv file!");
-            $this->assertRegExp('/^Final\sDecision\s[a-zA-Z]+$/', $sampleCsvReportData[0]['editorial_status'], "Value ".$sampleCsvReportData[0]['editorial_status']." pattern is not matched in Manuscript csv file!");
+            $this->assertStringMatchesFormat('Final Decision Accept', $sampleCsvReportData[0]['editorial_status'], "Value ".$sampleCsvReportData[0]['editorial_status']." pattern is not matched in Manuscript csv file!");
             $this->assertEquals($sampleCsvReportData[0]['manuscript_number'], $instance->manuscript_number, "Value ".$sampleCsvReportData[0]['manuscript_number']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleCsvReportData[0]['article_title'], $instance->article_title, "Value ".$sampleCsvReportData[0]['article_title']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleCsvReportData[0]['editorial_status_date'], $instance->editorial_status_date, "Value ".$sampleCsvReportData[0]['editorial_status_date']." is not matched in Manuscript instance!");
@@ -76,7 +76,7 @@ class ManuscriptTest extends \Codeception\Test\Unit
                 'manuscript_number' => 'GIGA-D-22-00060',
                 'article_title' => 'A chromosome-level genome of the booklouse, Liposcelis brunnea provides insight into louse evolution and environmental stress adaptation',
                 'editorial_status_date' => '6/7/2022',
-                'editorial_status' => 'Final Decision Reject'
+                'editorial_status' => 'Final Decision Accept'
             ],
         ];
 
@@ -91,7 +91,7 @@ class ManuscriptTest extends \Codeception\Test\Unit
             $this->assertArrayHasKey('editorial_status_date', $manuscriptInstance, "Key editorial_status_date is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status', $manuscriptInstance, "Key editorial_status is not found in Manuscript instance!");
             $this->assertRegExp('/^GIGA\-D\-\d{2}\-\d{5}$/', $sampleData['manuscript_number'],"Value ".$sampleData['manuscript_number']." pattern is not matched in Manuscript csv file!");
-            $this->assertRegExp('/^Final\sDecision\s[a-zA-Z]+$/', $sampleData['editorial_status'], "Value ".$sampleData['editorial_status']." pattern is not matched in Manuscript csv file!");
+            $this->assertStringMatchesFormat('Final Decision Accept', $sampleData['editorial_status'], "Value ".$sampleData['editorial_status']." pattern is not matched in Manuscript csv file!");
             $this->assertEquals($sampleData['manuscript_number'], $manuscriptInstance->manuscript_number, "Value ".$sampleData['manuscript_number']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleData['article_title'], $manuscriptInstance->article_title, "Value ".$sampleData['article_title']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleData['editorial_status_date'], $manuscriptInstance->editorial_status_date, "Value ".$sampleData['editorial_status_date']." is not matched in Manuscript instance!");

--- a/gigareview/common/tests/unit/ManuscriptTest.php
+++ b/gigareview/common/tests/unit/ManuscriptTest.php
@@ -54,7 +54,8 @@ class ManuscriptTest extends \Codeception\Test\Unit
             $this->assertArrayHasKey('article_title', $instance, "Key article_title is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status_date', $instance, "Key editorial_status_date is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status', $instance, "Key editorial_status is not found in Manuscript instance!");
-            $this->assertRegExp('/^GIGA\-D\-\d{2}\-\d{5}/', $sampleCsvReportData[0]['manuscript_number'], "Value ".$sampleCsvReportData[0]['manuscript_number']." pattern is not matched in Manuscript instance!");
+            $this->assertRegExp('/^GIGA\-D\-\d{2}\-\d{5}$/', $sampleCsvReportData[0]['manuscript_number'], "Value ".$sampleCsvReportData[0]['manuscript_number']." pattern is not matched in Manuscript instance!");
+            $this->assertRegExp('/^Final\sDecision\s[a-zA-Z]+$/', $sampleCsvReportData[0]['editorial_status'], "Value ".$sampleCsvReportData[0]['editorial_status']." pattern is not matched in Manuscript instance!");
             $this->assertEquals($sampleCsvReportData[0]['manuscript_number'], $instance->manuscript_number, "Value ".$sampleCsvReportData[0]['manuscript_number']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleCsvReportData[0]['article_title'], $instance->article_title, "Value ".$sampleCsvReportData[0]['article_title']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleCsvReportData[0]['editorial_status_date'], $instance->editorial_status_date, "Value ".$sampleCsvReportData[0]['editorial_status_date']." is not matched in Manuscript instance!");
@@ -89,7 +90,8 @@ class ManuscriptTest extends \Codeception\Test\Unit
             $this->assertArrayHasKey('article_title', $manuscriptInstance, "Key article_title is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status_date', $manuscriptInstance, "Key editorial_status_date is not found in Manuscript instance!");
             $this->assertArrayHasKey('editorial_status', $manuscriptInstance, "Key editorial_status is not found in Manuscript instance!");
-            $this->assertRegExp('/^GIGA\-D\-\d{2}\-\d{5}/', $manuscriptInstance->manuscript_number,"Value ".$sampleData['manuscript_number']." pattern is not matched in Manuscript instance!");
+            $this->assertRegExp('/^GIGA\-D\-\d{2}\-\d{5}$/', $manuscriptInstance->manuscript_number,"Value ".$sampleData['manuscript_number']." pattern is not matched in Manuscript instance!");
+            $this->assertRegExp('/^Final\sDecision\s[a-zA-Z]+$/', $manuscriptInstance->editorial_status, "Value ".$sampleData['editorial_status']." pattern is not matched in Manuscript instance!");
             $this->assertEquals($sampleData['manuscript_number'], $manuscriptInstance->manuscript_number, "Value ".$sampleData['manuscript_number']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleData['article_title'], $manuscriptInstance->article_title, "Value ".$sampleData['article_title']." is not matched in Manuscript instance!");
             $this->assertEquals($sampleData['editorial_status_date'], $manuscriptInstance->editorial_status_date, "Value ".$sampleData['editorial_status_date']." is not matched in Manuscript instance!");

--- a/gigareview/console/migrations/m220629_145450_create_manuscript_table.php
+++ b/gigareview/console/migrations/m220629_145450_create_manuscript_table.php
@@ -20,6 +20,7 @@ class m220629_145450_create_manuscript_table extends Migration
             'publication_date' => $this->date(),
             'editorial_status' => $this->string(),
             'editorial_status_date' => $this->date(),
+            'editors_note' => $this->text(),
             'created_at' => $this->biginteger(),
             'updated_at' => $this->biginteger(),
         ]);

--- a/gigareview/console/tests/_data/Report-GIGA-em-manuscripts-latest-214-20220607004243.csv
+++ b/gigareview/console/tests/_data/Report-GIGA-em-manuscripts-latest-214-20220607004243.csv
@@ -2,3 +2,5 @@ Manuscript Number,Article Title,Editorial Status Date,Editorial Status
 GIGA-D-22-00054,"A machine learning framework for discovery and enrichment of metagenomics metadata from open access publications",6/7/2022,Final Decision Accept
 GIGA-D-22-00060,"A chromosome-level genome of the booklouse, Liposcelis brunnea provides insight into louse evolution and environmental stress adaptation",6/7/2022,Final Decision Reject
 GIGA-D-22-00030,"A novel ground truth multispectral image dataset with weight, anthocyanins and brix index measures of grape berries tested for its utility in machine learning pipelines",6/7/2022,Final Decision Pending
+GIGA-D-22-abcde,"Test manuscript review with invalid manuscript number format",6/7/2022,Final Decision Accept
+GIGA-D-22-00099,"Test manuscript review with invalid date format",6-7-2022,Final Decision Accept

--- a/gigareview/console/tests/_data/Report-GIGA-em-manuscripts-latest-214-20220607004243.csv
+++ b/gigareview/console/tests/_data/Report-GIGA-em-manuscripts-latest-214-20220607004243.csv
@@ -1,6 +1,5 @@
 Manuscript Number,Article Title,Editorial Status Date,Editorial Status
 GIGA-D-22-00054,"A machine learning framework for discovery and enrichment of metagenomics metadata from open access publications",6/7/2022,Final Decision Accept
-GIGA-D-22-00060,"A chromosome-level genome of the booklouse, Liposcelis brunnea provides insight into louse evolution and environmental stress adaptation",6/7/2022,Final Decision Reject
-GIGA-D-22-00030,"A novel ground truth multispectral image dataset with weight, anthocyanins and brix index measures of grape berries tested for its utility in machine learning pipelines",6/7/2022,Final Decision Pending
+GIGA-D-22-00060,"Test manuscript review with invalid editorial status",6/7/2022,Final Decision Reject
 GIGA-D-22-abcde,"Test manuscript review with invalid manuscript number format",6/7/2022,Final Decision Accept
 GIGA-D-22-00099,"Test manuscript review with invalid date format",6-7-2022,Final Decision Accept

--- a/gigareview/console/tests/functional/EMReportJobCest.php
+++ b/gigareview/console/tests/functional/EMReportJobCest.php
@@ -30,8 +30,7 @@ class EMReportJobCest
         $I->canSeeInDatabase("manuscript", ["manuscript_number" => "GIGA-D-22-00054", "article_title" => "A machine learning framework for discovery and enrichment of metagenomics metadata from open access publications", "editorial_status" => "Final Decision Accept", "editorial_status_date" => "2022-06-07"]);
 
         // Manuscript with invalid editorial status is not saved to manuscript table
-        $I->cantSeeInDatabase("manuscript", ["manuscript_number" => "GIGA-D-22-00060", "article_title" => "A chromosome-level genome of the booklouse, Liposcelis brunnea provides insight into louse evolution and environmental stress adaptation", "editorial_status" => "Final Decision Reject", "editorial_status_date" => "2022-06-07"]);
-        $I->cantSeeInDatabase("manuscript", ["manuscript_number" => "GIGA-D-22-00030", "article_title" => "A novel ground truth multispectral image dataset with weight, anthocyanins and brix index measures of grape berries tested for its utility in machine learning pipelines", "editorial_status" => "Final Decision Pending", "editorial_status_date" => "2022-06-07"]);
+        $I->cantSeeInDatabase("manuscript", ["manuscript_number" => "GIGA-D-22-00060", "article_title" => "Test manuscript review with invalid editorial status", "editorial_status" => "Final Decision Reject", "editorial_status_date" => "2022-06-07"]);
 
         // Manuscript with invalid manuscript number format is not saved to manuscript table
         $I->cantSeeInDatabase("manuscript", ["manuscript_number" => "GIGA-D-22-abcde", "article_title" => " Test manuscript review with invalid manuscript number format", "editorial_status"=> "Final Decision Accept","editorial_status_date" => "2022-06-07"]);
@@ -63,13 +62,12 @@ class EMReportJobCest
 
         // Manuscript with invalid editorial status is not saved to manuscript table
         $I->cantSeeInDatabase("manuscript", $sampleCsvReportData[1]);
-        $I->cantSeeInDatabase("manuscript", $sampleCsvReportData[2]);
 
         // Manuscript with invalid manuscript number format is not saved to manuscript table
-        $I->cantSeeInDatabase("manuscript", $sampleCsvReportData[3]);
+        $I->cantSeeInDatabase("manuscript", $sampleCsvReportData[2]);
 
         // Manuscript with invalid date format is not saved to manuscript table
-        $I->cantSeeInDatabase("manuscript", $sampleCsvReportData[4]);
+        $I->cantSeeInDatabase("manuscript", $sampleCsvReportData[3]);
 
         $I->canSeeInDatabase("ingest", ["file_name"=>$sampleCsvReportName, "report_type"=>Ingest::REPORT_TYPES['manuscripts'], "fetch_status"=>Ingest::FETCH_STATUS_DISPATCHED, "parse_status"=>null, "store_status"=>null, "remote_file_status"=>null]);
         $I->canSeeInDatabase("ingest", ["file_name"=>$sampleCsvReportName, "report_type"=>Ingest::REPORT_TYPES['manuscripts'], "fetch_status"=>Ingest::FETCH_STATUS_DISPATCHED, "parse_status"=>Ingest::PARSE_STATUS_YES, "store_status"=>Ingest::STORE_STATUS_YES, "remote_file_status"=>Ingest::REMOTE_FILES_STATUS_EXISTS]);

--- a/gigareview/console/tests/functional/EMReportJobCest.php
+++ b/gigareview/console/tests/functional/EMReportJobCest.php
@@ -52,7 +52,6 @@ class EMReportJobCest
         $sampleCsvReportName = "Report-GIGA-em-manuscripts-latest-214-20220607004243.csv";
 
         $sampleCsvReportData = EMReportJob::parseReport($csvReportDir.$sampleCsvReportName);
-        file_put_contents('test-row.txt', print_r($sampleCsvReportData,true));
 
         $I->runShellCommand("./yii_test fetch-reports/fetch", false);
         $I->canSeeInDatabase("ingest", ["file_name"=>"Report-GIGA-em-manuscripts-latest-214-20220607004243.csv", "report_type"=>Ingest::REPORT_TYPES['manuscripts'], "fetch_status"=>Ingest::FETCH_STATUS_DISPATCHED, "parse_status"=>null, "store_status"=>null, "remote_file_status"=>null]);


### PR DESCRIPTION
# Pull request for issue: #1115, #1116

This is a pull request for the following functionalities:

* Added `editors note` column to manuscript table
* Added regex rules to `manuscript_number`, `editorial_status`
* Added rule for Editorial Status Date: should be a date


## How to test?
```
# Go to gigareview dir and spin up the services
% cd gigareview
% ./up.sh

# Change the sftp config in `common/config/params-local.php`
'sftp' => [
        "host" => "sftp_test",
        "username" => "testuser",
        "password" => "testpass",
        "baseDirectory" => "editorialmanager",
    ],

# Fetch the latest manuscript report from sftp server
% docker-compose run --rm console ./yii fetch-reports/fetch
Creating review_console_run ... done
Fetching manuscripts report...
Got content for /Report-GIGA-em-manuscripts-latest-214-20220607004243.csv
Pushed a new job with ID 1 for report manuscripts to manuscripts_q
Fetching authors report...
Got content for /Report-GIGA-em-authors-latest-214-20220607004243.csv
Pushed a new job with ID 2 for report authors to authors_q
Fetching reviewers report...
Got content for /Report-GIGA-em-reviewers-latest-214-20220607004243.csv
Pushed a new job with ID 3 for report reviewers to reviewers_q
Fetching questions report...
Got content for /Report-GIGA-em-questions-latest-214-20220607004243.csv
Pushed a new job with ID 4 for report questions to questions_q
Fetching reviews report...
Got content for /Report-GIGA-em-reviews-latest-214-20220607004243.csv
Pushed a new job with ID 5 for report reviews to reviews_q

# Push the job to worker
% docker-compose up -d manuscripts-worker
review_beanstalkd_1 is up-to-date
review_reviewdb_1 is up-to-date
Starting review_manuscripts-worker_1 ... done

# Check the worker status
% docker logs review_manuscripts-worker_1
2022-09-16 08:46:31 [pid: 1] - Worker is started
2022-09-16 08:46:31 [pid: 1] - Worker is stopped (0:00:00)
2022-09-16 08:48:45 [pid: 1] - Worker is started
2022-09-16 08:48:45 [1] common\models\EMReportJob (attempt: 1, pid: 1) - Started
2022-09-16 08:48:46 [1] common\models\EMReportJob (attempt: 1, pid: 1) - Done (0.403 s, 8.37 MiB)
2022-09-16 08:48:46 [pid: 1] - Worker is stopped (0:00:01)

# Check table `manuscript` and `ingest` in db `reviewdb`
% docker-compose run --rm console bash -c "PGPASSWORD=reviewdb psql -U reviewdb -h reviewdb -d reviewdb -p 5432 -c 'Select * from manuscript;'"
Creating review_console_run ... done
| id | doi | manuscript_number | article_title | publication_date | editorial_status | editorial_status_date | editors_note | created_at | updated_at |
| -- | --- | ----------------- | ------------- | ---------------- | ----------------- | -------------------- | ------------ | ---------- | ---------- |
| 1  |     | GIGA-D-22-00054   | A machine learning framework for discovery and enrichment of metagenomics metadata from open access publications |      | Final Decision Accept | 2022-06-07 |        | 1663318126 | 1663318126 |
(1 row)

 % docker-compose run --rm console bash -c "PGPASSWORD=reviewdb psql -U reviewdb -h reviewdb -d reviewdb -p 5432 -c 'Select * from ingest;'"    
Creating review_console_run ... done
 id |  file_name | report_type | fetch_status | parse_status | store_status | remote_file_status | created
_at | updated_at 
----+--------+-------------+--------------+--------------+--------------+--------------------+------------+------------
  1 | Report-GIGA-em-manuscripts-latest-214-20220607004243.csv |           1 |            3 |              |              |                    | 1663318
093 | 1663318094
  2 | Report-GIGA-em-authors-latest-214-20220607004243.csv     |           2 |            3 |              |              |                    | 1663318
094 | 1663318094
  3 | Report-GIGA-em-reviewers-latest-214-20220607004243.csv   |           3 |            3 |              |              |                    | 1663318
094 | 1663318094
  4 | Report-GIGA-em-questions-latest-214-20220607004243.csv   |           4 |            3 |              |              |                    | 1663318
094 | 1663318094
  5 | Report-GIGA-em-reviews-latest-214-20220607004243.csv     |           5 |            3 |              |              |                    | 1663318
094 | 1663318094
  6 | Report-GIGA-em-manuscripts-latest-214-20220607004243.csv |           1 |            3 |            1 |            1 |                  1 | 1663318
126 | 1663318126
(6 rows)

# unit test
 % docker-compose run --rm console ./vendor/codeception/codeception/codecept -c common/codeception.yml run -vvv unit common/tests/unit/ManuscriptTest.php 
% docker-compose run --rm console ./vendor/codeception/codeception/codecept -c common/codeception.yml run -vvv unit common/tests/unit/EMReportJobTest.ph

# functional test
% docker-compose run --rm console ./vendor/codeception/codeception/codecept -c console/codeception.yml run functional -vvv console/tests/functional/EMReportJobCest.php
```

## How have functionalities been implemented?

1. A text column `editors_note` is added to the manuscript table.
2. Manuscript Number` only with format `GIGA-D-\d\d-\d\d\d\d\d` will be saved to manuscript table.
3. Editorial Status Date only with format `dd/MM/yyyy` will be saved to manuscript table.
4. Editorial Status only matches `Final Decision Accept` will be saved to manuscript table.

With above points implemented, `editors_note` column can be observed, and after executing the `manuscript` worker, only test data with manucript_number `GIGA-D-22-00054` will be saved to the table `manuscript` because its entries have correct format.

The regex patterns are tested in the unit test `ManuscriptTest`.

The effect of implementing the regex patterns on saving the Manuscript Instances  are tested in the unit test `EMReportJobTest` and  functional test `EMReportJobCest`.
 
## Any issues with implementation?

Test dataset `gigareview/console/tests/_data/Report-GIGA-em-manuscripts-latest-214-20220607004243.csv` has to be updated to include test data with invalid formats for passing different test scenarios.

## Any changes to automated tests?

None.

## Any changes to documentation?

None.

## Any technical debt repayment?

None. 

## Any improvements to CI/CD pipeline?

None. 
