### PR TITLE
Fix: Upstream failed jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,6 +114,7 @@ ld_gigadb:
   stage: live deploy
   tags:
     - $GITLAB_USER_LOGIN
+  needs: ["base_images","build_live"]
   environment:
     name: "live"
     deployment_tier: production

--- a/gigadb/app/tools/files-url-updater/generate_config.sh
+++ b/gigadb/app/tools/files-url-updater/generate_config.sh
@@ -49,7 +49,7 @@ if ! [ -s ./.secrets ];then
 
     # deal with special case we are in Upstream
     if [[ $CI_PROJECT_URL == "https://gitlab.com/gigascience/upstream/gigadb-website" ]];then
-      PROJECT_VARIABLES_URL="https://gitlab.com/api/v4/projects/gigascience%2Fupstream%2F$REPO_NAME/variables"
+      PROJECT_VARIABLES_URL="https://gitlab.com/api/v4/projects/gigascience%2Fupstream%2Fgigadb-website/variables"
     fi
 
     echo "Retrieving variables from ${PROJECT_VARIABLES_URL}"

--- a/gigadb/app/tools/files-url-updater/generate_config.sh
+++ b/gigadb/app/tools/files-url-updater/generate_config.sh
@@ -57,7 +57,7 @@ if ! [ -s ./.secrets ];then
     curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${MISC_VARIABLES_URL}?per_page=100" | jq --arg ENVIRONMENT "$GIGADB_ENV" -r '.[] | select(.environment_scope == "*" or .environment_scope == $ENVIRONMENT ) | select(.key | test("_ftp_") ) | .key + "=" + .value' > .misc_var
 
     # Create .secrets from the multiple parts
-    cat .project_var .misc_var > .secrets && rm .project_var && rm .misc_var && rm .project_var_raw1 && rm .project_var_raw2 && rm .project_vars.json
+    cat .project_var .misc_var > .secrets #&& rm .project_var && rm .misc_var && rm .project_var_raw1 && rm .project_var_raw2 && rm .project_vars.json
 fi
 echo "Sourcing secrets"
 source "./.secrets"

--- a/gigadb/app/tools/files-url-updater/generate_config.sh
+++ b/gigadb/app/tools/files-url-updater/generate_config.sh
@@ -47,6 +47,11 @@ fi
 
 if ! [ -s ./.secrets ];then
 
+    # deal with special case we are in Upstream
+    if [[ $CI_PROJECT_URL == "https://gitlab.com/gigascience/upstream/gigadb-website" ]];then
+      PROJECT_VARIABLES_URL="https://gitlab.com/api/v4/projects/gigascience%2Fupstream%2F$REPO_NAME/variables"
+    fi
+
     echo "Retrieving variables from ${PROJECT_VARIABLES_URL}"
     curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${PROJECT_VARIABLES_URL}?per_page=100&page=1"  > .project_var_raw1
     curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${PROJECT_VARIABLES_URL}?per_page=100&page=2"  > .project_var_raw2

--- a/gigadb/app/tools/files-url-updater/gitlab-config.yml
+++ b/gigadb/app/tools/files-url-updater/gitlab-config.yml
@@ -24,6 +24,10 @@ FilesUrlsUpdaterTest:
       - gigadb/app/tools/files-url-updater/.secrets
       - .env
       - .secrets
+      - .project_var
+      - .project_var_raw1
+      - .project_var_raw2
+      - .project_vars.json
       - protected/config/db.json
     when: always
     expire_in: 1 week

--- a/gigadb/app/tools/files-url-updater/gitlab-config.yml
+++ b/gigadb/app/tools/files-url-updater/gitlab-config.yml
@@ -24,10 +24,10 @@ FilesUrlsUpdaterTest:
       - gigadb/app/tools/files-url-updater/.secrets
       - .env
       - .secrets
-      - .project_var
-      - .project_var_raw1
-      - .project_var_raw2
-      - .project_vars.json
+      - gigadb/app/tools/files-url-updater/.project_var
+      - gigadb/app/tools/files-url-updater/.project_var_raw1
+      - gigadb/app/tools/files-url-updater/.project_var_raw2
+      - gigadb/app/tools/files-url-updater/.project_vars.json
       - protected/config/db.json
     when: always
     expire_in: 1 week

--- a/gigadb/app/tools/files-url-updater/gitlab-config.yml
+++ b/gigadb/app/tools/files-url-updater/gitlab-config.yml
@@ -33,6 +33,7 @@ FilesUrlsUpdaterTest:
     expire_in: 1 week
   script:
     - env | grep -iE "(GIGADB_ENV|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN)"| tee gigadb/app/tools/files-url-updater/.env
+    - cp .secrets gigadb/app/tools/files-url-updater/
     - cd gigadb/app/tools/files-url-updater
     - $LOCAL_COMPOSE run --rm config
     - $LOCAL_COMPOSE run --rm updater composer install

--- a/gigadb/app/tools/files-url-updater/gitlab-config.yml
+++ b/gigadb/app/tools/files-url-updater/gitlab-config.yml
@@ -24,6 +24,7 @@ FilesUrlsUpdaterTest:
       - gigadb/app/tools/files-url-updater/.secrets
       - .env
       - .secrets
+      - .ci_env
       - gigadb/app/tools/files-url-updater/.project_var
       - gigadb/app/tools/files-url-updater/.project_var_raw1
       - gigadb/app/tools/files-url-updater/.project_var_raw2
@@ -32,7 +33,7 @@ FilesUrlsUpdaterTest:
     when: always
     expire_in: 1 week
   script:
-    - env | grep -iE "(GIGADB_ENV|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN)"| tee gigadb/app/tools/files-url-updater/.env
+    - env | grep -iE "(GIGADB_ENV|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN|CI_PROJECT_URL)"| tee gigadb/app/tools/files-url-updater/.env
     - cd gigadb/app/tools/files-url-updater
     - $LOCAL_COMPOSE run --rm config
     - $LOCAL_COMPOSE run --rm updater composer install
@@ -57,7 +58,7 @@ FilesUrlsUpdaterBuildStaging:
     PROJECT_VARIABLES_URL: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2F$REPO_NAME/variables"
     MISC_VARIABLES_URL: "https://gitlab.com/api/v4/projects/gigascience%2Fcnhk-infra/variables"
   script:
-    - env | grep -iE "(GIGADB_ENV|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN)"| tee gigadb/app/tools/files-url-updater/.env
+    - env | grep -iE "(GIGADB_ENV|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN|CI_PROJECT_URL)"| tee gigadb/app/tools/files-url-updater/.env
     - cd gigadb/app/tools/files-url-updater
     - $LOCAL_COMPOSE run --rm config #run generate_config to create configuration file with variables from staging
     - docker-compose -f docker-compose.yml run --rm updater composer install # install composer dependencies
@@ -118,8 +119,7 @@ FilesUrlsUpdaterBuildLive:
     PROJECT_VARIABLES_URL: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2F$REPO_NAME/variables"
     MISC_VARIABLES_URL: "https://gitlab.com/api/v4/projects/gigascience%2Fcnhk-infra/variables"
   script:
-    - env | grep -iE "(GIGADB_ENV|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN)"| tee gigadb/app/tools/files-url-updater/.env
-    - cp .secrets gigadb/app/tools/files-url-updater/
+    - env | grep -iE "(GIGADB_ENV|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN|CI_PROJECT_URL)"| tee gigadb/app/tools/files-url-updater/.env
     - cd gigadb/app/tools/files-url-updater
     - $LOCAL_COMPOSE run --rm config #run generate_config to create configuration file with variables from staging
     - docker-compose -f docker-compose.yml run --rm updater composer install # install composer dependencies

--- a/gigadb/app/tools/files-url-updater/gitlab-config.yml
+++ b/gigadb/app/tools/files-url-updater/gitlab-config.yml
@@ -59,6 +59,7 @@ FilesUrlsUpdaterBuildStaging:
     MISC_VARIABLES_URL: "https://gitlab.com/api/v4/projects/gigascience%2Fcnhk-infra/variables"
   script:
     - env | grep -iE "(GIGADB_ENV|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN)"| tee gigadb/app/tools/files-url-updater/.env
+    - cp .secrets gigadb/app/tools/files-url-updater/
     - cd gigadb/app/tools/files-url-updater
     - $LOCAL_COMPOSE run --rm config #run generate_config to create configuration file with variables from staging
     - docker-compose -f docker-compose.yml run --rm updater composer install # install composer dependencies
@@ -108,3 +109,65 @@ FilesUrlsUpdaterDeployStaging:
     name: $GIGADB_ENV
   dependencies: []
   needs: [ "FilesUrlsUpdaterBuildStaging" ]
+
+
+FilesUrlsUpdaterBuildLive:
+  stage: live build
+  variables:
+    LOCAL_COMPOSE: "docker-compose -f ./docker-compose.production.yml"
+    REPO_NAME: $CI_PROJECT_NAME
+    GIGADB_ENV: live
+    PROJECT_VARIABLES_URL: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2F$REPO_NAME/variables"
+    MISC_VARIABLES_URL: "https://gitlab.com/api/v4/projects/gigascience%2Fcnhk-infra/variables"
+  script:
+    - env | grep -iE "(GIGADB_ENV|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN)"| tee gigadb/app/tools/files-url-updater/.env
+    - cp .secrets gigadb/app/tools/files-url-updater/
+    - cd gigadb/app/tools/files-url-updater
+    - $LOCAL_COMPOSE run --rm config #run generate_config to create configuration file with variables from staging
+    - docker-compose -f docker-compose.yml run --rm updater composer install # install composer dependencies
+    - $LOCAL_COMPOSE build production_updater # build production container from the production docker file
+    - $LOCAL_COMPOSE build production_s3backup # build the container for production s3 backup
+    - $LOCAL_COMPOSE build production_pg9_3 # build the container for production version of legacy database server
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com # log in to Gitlab so we can push the container image there
+    - docker tag ${CI_PROJECT_NAME}_production_updater:latest registry.gitlab.com/$CI_PROJECT_PATH/production_updater:$GIGADB_ENV
+    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_updater:$GIGADB_ENV
+    - docker tag ${CI_PROJECT_NAME}_production_s3backup:latest registry.gitlab.com/$CI_PROJECT_PATH/production_s3backup:$GIGADB_ENV
+    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_s3backup:$GIGADB_ENV
+    - docker tag ${CI_PROJECT_NAME}_production_pg9_3:latest registry.gitlab.com/$CI_PROJECT_PATH/production_pg9_3:$GIGADB_ENV
+    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_pg9_3:$GIGADB_ENV
+  dependencies: []
+  environment:
+    name: live
+  artifacts:
+    paths:
+      - gigadb/app/tools/files-url-updater/.env
+      - gigadb/app/tools/files-url-updater/.secrets
+      - gigadb/app/tools/files-url-updater/config
+      - .env
+      - .secrets
+      - .ci_env
+    when: always
+    expire_in: 3 days
+  needs: ["FilesUrlsUpdaterDeployStaging"]
+
+FilesUrlsUpdaterDeployLive:
+  stage: live deploy
+  variables:
+    GIGADB_ENV: live
+    REMOTE_WEBAPP_DOCKER: "$remote_public_ip:2376"
+    REMOTE_BASTION_DOCKER: "$remote_bastion_public_ip:2376"
+  script:
+    # Deployment to bastion server
+    - mkdir -pv ~/.docker
+    - bash -c "echo '$docker_bastion_tlsauth_ca' >  ~/.docker/ca.pem"
+    - bash -c "echo '$docker_bastion_tlsauth_cert' > ~/.docker/cert.pem"
+    - bash -c "echo '$docker_bastion_tlsauth_key' > ~/.docker/key.pem"
+    - docker --tlsverify -H=$REMOTE_BASTION_DOCKER info
+    - docker --tlsverify -H=$REMOTE_BASTION_DOCKER login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
+    - docker --tlsverify -H=$REMOTE_BASTION_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_updater:$GIGADB_ENV
+    - docker --tlsverify -H=$REMOTE_BASTION_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_s3backup:$GIGADB_ENV
+    - docker --tlsverify -H=$REMOTE_BASTION_DOCKER pull registry.gitlab.com/$CI_PROJECT_PATH/production_pg9_3:$GIGADB_ENV
+  environment:
+    name: $GIGADB_ENV
+  dependencies: []
+  needs: [ "FilesUrlsUpdaterBuildLive" ]

--- a/gigadb/app/tools/files-url-updater/gitlab-config.yml
+++ b/gigadb/app/tools/files-url-updater/gitlab-config.yml
@@ -144,7 +144,7 @@ FilesUrlsUpdaterBuildLive:
       - .env
       - .secrets
       - .ci_env
-    when: always
+    when: manual
     expire_in: 3 days
   needs: ["FilesUrlsUpdaterDeployStaging"]
 

--- a/gigadb/app/tools/files-url-updater/gitlab-config.yml
+++ b/gigadb/app/tools/files-url-updater/gitlab-config.yml
@@ -136,6 +136,7 @@ FilesUrlsUpdaterBuildLive:
   dependencies: []
   environment:
     name: live
+  when: manual
   artifacts:
     paths:
       - gigadb/app/tools/files-url-updater/.env
@@ -144,7 +145,7 @@ FilesUrlsUpdaterBuildLive:
       - .env
       - .secrets
       - .ci_env
-    when: manual
+    when: always
     expire_in: 3 days
   needs: ["FilesUrlsUpdaterDeployStaging"]
 

--- a/gigadb/app/tools/files-url-updater/gitlab-config.yml
+++ b/gigadb/app/tools/files-url-updater/gitlab-config.yml
@@ -33,7 +33,6 @@ FilesUrlsUpdaterTest:
     expire_in: 1 week
   script:
     - env | grep -iE "(GIGADB_ENV|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN)"| tee gigadb/app/tools/files-url-updater/.env
-    - cp .secrets gigadb/app/tools/files-url-updater/
     - cd gigadb/app/tools/files-url-updater
     - $LOCAL_COMPOSE run --rm config
     - $LOCAL_COMPOSE run --rm updater composer install
@@ -44,7 +43,7 @@ FilesUrlsUpdaterTest:
     - sleep 5
     - $LOCAL_COMPOSE ps
     - $LOCAL_COMPOSE run --rm updater ./vendor/bin/codecept run tests/unit
-#    - $LOCAL_COMPOSE run --rm updater ./vendor/bin/codecept run tests/functional
+    - $LOCAL_COMPOSE run --rm updater ./vendor/bin/codecept run tests/functional
   needs: ["container_scanning","phpcs-security-audit-sast"]
   environment:
     name: dev
@@ -58,10 +57,7 @@ FilesUrlsUpdaterBuildStaging:
     PROJECT_VARIABLES_URL: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2F$REPO_NAME/variables"
     MISC_VARIABLES_URL: "https://gitlab.com/api/v4/projects/gigascience%2Fcnhk-infra/variables"
   script:
-    - echo $REPO_NAME
-    - echo $PROJECT_VARIABLES_URL
     - env | grep -iE "(GIGADB_ENV|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN)"| tee gigadb/app/tools/files-url-updater/.env
-    - cp .secrets gigadb/app/tools/files-url-updater/
     - cd gigadb/app/tools/files-url-updater
     - $LOCAL_COMPOSE run --rm config #run generate_config to create configuration file with variables from staging
     - docker-compose -f docker-compose.yml run --rm updater composer install # install composer dependencies

--- a/gigadb/app/tools/files-url-updater/gitlab-config.yml
+++ b/gigadb/app/tools/files-url-updater/gitlab-config.yml
@@ -58,6 +58,8 @@ FilesUrlsUpdaterBuildStaging:
     PROJECT_VARIABLES_URL: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2F$REPO_NAME/variables"
     MISC_VARIABLES_URL: "https://gitlab.com/api/v4/projects/gigascience%2Fcnhk-infra/variables"
   script:
+    - echo $REPO_NAME
+    - echo $PROJECT_VARIABLES_URL
     - env | grep -iE "(GIGADB_ENV|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN)"| tee gigadb/app/tools/files-url-updater/.env
     - cp .secrets gigadb/app/tools/files-url-updater/
     - cd gigadb/app/tools/files-url-updater

--- a/gigadb/app/tools/files-url-updater/gitlab-config.yml
+++ b/gigadb/app/tools/files-url-updater/gitlab-config.yml
@@ -44,7 +44,7 @@ FilesUrlsUpdaterTest:
     - sleep 5
     - $LOCAL_COMPOSE ps
     - $LOCAL_COMPOSE run --rm updater ./vendor/bin/codecept run tests/unit
-    - $LOCAL_COMPOSE run --rm updater ./vendor/bin/codecept run tests/functional
+#    - $LOCAL_COMPOSE run --rm updater ./vendor/bin/codecept run tests/functional
   needs: ["container_scanning","phpcs-security-audit-sast"]
   environment:
     name: dev

--- a/gigareview/README.md
+++ b/gigareview/README.md
@@ -76,6 +76,10 @@ They should already bet set on the Gigascience's Forks subgroup and on Upstream'
 | POSTGRES_USER     | postgres | no     | All          |
 | POSTGRES_PASSWORD | *******  | yes    | All          |
 
+Additionally, the variable POSTGRES_MAJOR_VERSION is also in use,
+but it hard-coded in the ``gitlab-config.yml`` file,
+so there is no need for it to be in Gitlab variables.
+
 # More detailed information (not necessary to get started)
 
 ## How was the project bootstrapped (for info only)

--- a/gigareview/README.md
+++ b/gigareview/README.md
@@ -51,7 +51,7 @@ As prerequisite, ensure the following variables are defined in Gitlab at project
 
 | Key | Value            | Masked  | Environments |
 | --- |------------------|---------|--------------|
-| REVIEW_DB_DATABASE | reviewdb         | staging | staging      |
+| REVIEW_DB_DATABASE | reviewdb         | no      | staging      |
 | REVIEW_DB_HOST | reviewdb         | no      | staging      |
 | REVIEW_DB_PASSWORD | (choose a value) | yes     | staging      |
 | REVIEW_DB_PORT | 5432             | no      | staging      |
@@ -61,6 +61,20 @@ As prerequisite, ensure the following variables are defined in Gitlab at project
 | REVIEW_DB_PASSWORD | (choose a value) | yes     | live         |
 | REVIEW_DB_PORT | 5432             | no      | live         |
 | REVIEW_DB_USERNAME | reviewdb         | no      | live         |
+
+
+## Other important variables
+
+Developers typically don't have to set those as they are not specific to a fork, 
+but they are needed by the Gigareview application.
+
+They should already bet set on the Gigascience's Forks subgroup and on Upstream's gigadb-website project.
+
+ Key               | Value    | Masked | Environments |
+|-------------------|----------|--------|--------------|
+| POSTGRES_DB       | postgres | no     | All          |
+| POSTGRES_USER     | postgres | no     | All          |
+| POSTGRES_PASSWORD | *******  | yes    | All          |
 
 # More detailed information (not necessary to get started)
 

--- a/gigareview/generate_config.sh
+++ b/gigareview/generate_config.sh
@@ -52,13 +52,13 @@ if ! [ -s ./.secrets ];then
     curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${PROJECT_VARIABLES_URL}?per_page=100&page=1"  > .project_var_raw1
     curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${PROJECT_VARIABLES_URL}?per_page=100&page=2"  > .project_var_raw2
     jq -s 'add' .project_var_raw1 .project_var_raw2 > .project_vars.json
-    cat .project_vars.json | jq --arg ENVIRONMENT $REVIEW_ENV -r '.[] | select( .environment_scope == $ENVIRONMENT ) | select(.key | test("key|ca|pem|cert";"i") | not ) |.key + "=" + .value' > .project_var
+    cat .project_vars.json | jq --arg ENVIRONMENT $REVIEW_ENV -r '.[] | select( .environment_scope == $ENVIRONMENT or .environment_scope == "*") | select(.key | test("key|ca|pem|cert";"i") | not ) |.key + "=" + .value' > .project_var
 
     echo "Retrieving variables from ${MISC_VARIABLES_URL}"
     curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${MISC_VARIABLES_URL}?per_page=100" | jq --arg ENVIRONMENT $REVIEW_ENV -r '.[] | select(.environment_scope == "*" or .environment_scope == $ENVIRONMENT ) | select(.key | test("sftp_") ) | .key + "=" + .value' > .misc_var
 
 
-    cat .group_var .fork_var .project_var .misc_var > .secrets #&& rm .group_var && rm .fork_var && rm .project_var && rm .misc_var && rm .project_var_raw1 && rm .project_var_raw2 && rm .project_vars.json
+    cat .group_var .fork_var .project_var .misc_var > .secrets && rm .group_var && rm .fork_var && rm .project_var && rm .misc_var && rm .project_var_raw1 && rm .project_var_raw2 && rm .project_vars.json
     echo "# Some help about this file in ops/configuration/variables/secrets-sample" >> .secrets
 fi
 echo "Sourcing secrets"

--- a/gigareview/generate_config.sh
+++ b/gigareview/generate_config.sh
@@ -34,11 +34,14 @@ echo "Generating configuration for environment: $REVIEW_ENV"
 # Only necessary on DEV, as on CI (STG and PROD), the variables are exposed to build environment
 
 if ! [ -s ./.secrets ];then
+
+    # deal with special case we are in Upstream
+    if [[ $CI_PROJECT_URL == "https://gitlab.com/gigascience/upstream/gigadb-website" ]];then
+      PROJECT_VARIABLES_URL="https://gitlab.com/api/v4/projects/gigascience%2Fupstream%2Fgigadb-website/variables"
+    fi
+
     echo "Retrieving variables from ${GROUP_VARIABLES_URL}"
     curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${GROUP_VARIABLES_URL}" | jq -r '.[] | select(.key != "ANALYTICS_PRIVATE_KEY") | .key + "=" + .value' > .group_var
-
-    echo "Retrieving variables from ${FORK_VARIABLES_URL}"
-    curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${FORK_VARIABLES_URL}?per_page=100" | jq -r '.[] | select(.key != "ANALYTICS_PRIVATE_KEY") | .key + "=" + .value' > .fork_var
 
     echo "Retrieving variables from ${PROJECT_VARIABLES_URL}"
     curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${PROJECT_VARIABLES_URL}?per_page=100&page=1"  > .project_var_raw1

--- a/gigareview/generate_config.sh
+++ b/gigareview/generate_config.sh
@@ -43,6 +43,11 @@ if ! [ -s ./.secrets ];then
     echo "Retrieving variables from ${GROUP_VARIABLES_URL}"
     curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${GROUP_VARIABLES_URL}" | jq -r '.[] | select(.key != "ANALYTICS_PRIVATE_KEY") | .key + "=" + .value' > .group_var
 
+    if [[ $CI_PROJECT_URL != "https://gitlab.com/gigascience/upstream/gigadb-website" ]];then
+      echo "Retrieving variables from ${FORK_VARIABLES_URL}"
+      curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${FORK_VARIABLES_URL}?per_page=100" | jq -r '.[] | select(.key != "ANALYTICS_PRIVATE_KEY") | .key + "=" + .value' > .fork_var
+    fi
+
     echo "Retrieving variables from ${PROJECT_VARIABLES_URL}"
     curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${PROJECT_VARIABLES_URL}?per_page=100&page=1"  > .project_var_raw1
     curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${PROJECT_VARIABLES_URL}?per_page=100&page=2"  > .project_var_raw2

--- a/gigareview/generate_config.sh
+++ b/gigareview/generate_config.sh
@@ -58,7 +58,7 @@ if ! [ -s ./.secrets ];then
     curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${MISC_VARIABLES_URL}?per_page=100" | jq --arg ENVIRONMENT $REVIEW_ENV -r '.[] | select(.environment_scope == "*" or .environment_scope == $ENVIRONMENT ) | select(.key | test("sftp_") ) | .key + "=" + .value' > .misc_var
 
 
-    cat .group_var .fork_var .project_var .misc_var > .secrets && rm .group_var && rm .fork_var && rm .project_var && rm .misc_var && rm .project_var_raw1 && rm .project_var_raw2 && rm .project_vars.json
+    cat .group_var .fork_var .project_var .misc_var > .secrets #&& rm .group_var && rm .fork_var && rm .project_var && rm .misc_var && rm .project_var_raw1 && rm .project_var_raw2 && rm .project_vars.json
     echo "# Some help about this file in ops/configuration/variables/secrets-sample" >> .secrets
 fi
 echo "Sourcing secrets"

--- a/gigareview/gitlab-config.yml
+++ b/gigareview/gitlab-config.yml
@@ -5,6 +5,7 @@ GigaReviewTest:
     REVIEW_ENV: dev
     POSTGRES_MAJOR_VERSION: 12
     GROUP_VARIABLES_URL: "https://gitlab.com/api/v4/groups/gigascience/variables?per_page=100"
+    FORK_VARIABLES_URL: "https://gitlab.com/api/v4/groups/3501869/variables"
     PROJECT_VARIABLES_URL: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2F$REPO_NAME/variables"
     MISC_VARIABLES_URL: "https://gitlab.com/api/v4/projects/gigascience%2Fcnhk-infra/variables"
   stage: test

--- a/gigareview/gitlab-config.yml
+++ b/gigareview/gitlab-config.yml
@@ -19,6 +19,10 @@ GigaReviewTest:
     paths:
       - gigareview/.env
       - gigareview/.secrets
+      - gigareview/.group_var
+      - gigareview/.fork_var
+      - gigareview/.project_var
+      - gigareview/.misc_var
       - gigareview/environments
       - .env
       - .secrets

--- a/gigareview/gitlab-config.yml
+++ b/gigareview/gitlab-config.yml
@@ -5,12 +5,11 @@ GigaReviewTest:
     REVIEW_ENV: dev
     POSTGRES_MAJOR_VERSION: 12
     GROUP_VARIABLES_URL: "https://gitlab.com/api/v4/groups/gigascience/variables?per_page=100"
-    FORK_VARIABLES_URL: "https://gitlab.com/api/v4/groups/3501869/variables"
     PROJECT_VARIABLES_URL: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2F$REPO_NAME/variables"
     MISC_VARIABLES_URL: "https://gitlab.com/api/v4/projects/gigascience%2Fcnhk-infra/variables"
   stage: test
   script:
-    - env | grep -iE "(REVIEW_ENV|REPO_NAME|POSTGRES_MAJOR_VERSION|POSTGRES_DB|POSTGRES_USER|POSTGRES_PASSWORD|GROUP_VARIABLES_URL|FORK_VARIABLES_URL|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN)"| tee gigareview/.env
+    - env | grep -iE "(REVIEW_ENV|REPO_NAME|POSTGRES_MAJOR_VERSION|POSTGRES_DB|POSTGRES_USER|POSTGRES_PASSWORD|GROUP_VARIABLES_URL|FORK_VARIABLES_URL|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN|CI_PROJECT_URL)"| tee gigareview/.env
     - cd gigareview
     - ./up.sh
     - "./tests/unit_runner && ./tests/functional_runner && ./tests/acceptance_runner"

--- a/gigareview/gitlab-config.yml
+++ b/gigareview/gitlab-config.yml
@@ -41,7 +41,7 @@ GigaReviewBuildStaging:
     PROJECT_VARIABLES_URL: "https://gitlab.com/api/v4/projects/gigascience%2Fforks%2F$REPO_NAME/variables"
     MISC_VARIABLES_URL: "https://gitlab.com/api/v4/projects/gigascience%2Fcnhk-infra/variables"
   script:
-    - env | grep -iE "(REVIEW_ENV|REPO_NAME|POSTGRES_MAJOR_VERSION|POSTGRES_DB|POSTGRES_USER|POSTGRES_PASSWORD|GROUP_VARIABLES_URL|FORK_VARIABLES_URL|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN)"| tee gigareview/.env
+    - env | grep -iE "(REVIEW_ENV|REPO_NAME|POSTGRES_MAJOR_VERSION|POSTGRES_DB|POSTGRES_USER|POSTGRES_PASSWORD|GROUP_VARIABLES_URL|FORK_VARIABLES_URL|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN|CI_PROJECT_URL)"| tee gigareview/.env
     - cd gigareview
     - ls -alrt
     - docker-compose -f docker-compose.production.yml run --rm config #run generate_config to create configuration file with variables from staging

--- a/gigareview/up.sh
+++ b/gigareview/up.sh
@@ -51,6 +51,9 @@ docker-compose up -d beanstalkd sftp_test
 # Starting webdriver service for the headless browser used in acceptance testing
 docker-compose up -d webdriver
 
+# Make sure DB server is in good state
+docker-compose ps
+docker-compose logs reviewdb
 # (Re)Creating Postgresql database and user for our application
 docker-compose run --rm console ./database.sh
 

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -255,7 +255,7 @@ build_live:
   stage: live build
   tags:
     - $GITLAB_USER_LOGIN
-  needs: ["a_gigadb"]
+  needs: ["base_images","a_gigadb"]
   environment:
     name: "live"
     deployment_tier: production

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -255,6 +255,7 @@ build_live:
   stage: live build
   tags:
     - $GITLAB_USER_LOGIN
+  needs: ["a_gigadb"]
   environment:
     name: "live"
     deployment_tier: production

--- a/ops/scripts/generate_config.sh
+++ b/ops/scripts/generate_config.sh
@@ -53,7 +53,7 @@ if ! [ -s ./.secrets ];then
     curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${MISC_VARIABLES_URL}?per_page=100" | jq --arg ENVIRONMENT $GIGADB_ENV -r '.[] | select(.environment_scope == "*" or .environment_scope == "dev" ) | select(.key | test("sftp_") ) | .key + "=" + .value' > .misc_var
 
 
-    cat .group_var .fork_var .project_var .misc_var > .secrets && rm .group_var && rm .fork_var && rm .project_var && rm .misc_var && rm .project_var_raw1 && rm .project_var_raw2 && rm .project_vars.json
+    cat .group_var .fork_var .project_var .misc_var > .secrets #&& rm .group_var && rm .fork_var && rm .project_var && rm .misc_var && rm .project_var_raw1 && rm .project_var_raw2 && rm .project_vars.json
     echo "# Some help about this file in ops/configuration/variables/secrets-sample" >> .secrets
 fi
 echo "Sourcing secrets"

--- a/ops/scripts/generate_config.sh
+++ b/ops/scripts/generate_config.sh
@@ -53,7 +53,7 @@ if ! [ -s ./.secrets ];then
     curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${MISC_VARIABLES_URL}?per_page=100" | jq --arg ENVIRONMENT $GIGADB_ENV -r '.[] | select(.environment_scope == "*" or .environment_scope == "dev" ) | select(.key | test("sftp_") ) | .key + "=" + .value' > .misc_var
 
 
-    cat .group_var .fork_var .project_var .misc_var > .secrets #&& rm .group_var && rm .fork_var && rm .project_var && rm .misc_var && rm .project_var_raw1 && rm .project_var_raw2 && rm .project_vars.json
+    cat .group_var .fork_var .project_var .misc_var > .secrets && rm .group_var && rm .fork_var && rm .project_var && rm .misc_var && rm .project_var_raw1 && rm .project_var_raw2 && rm .project_vars.json
     echo "# Some help about this file in ops/configuration/variables/secrets-sample" >> .secrets
 fi
 echo "Sourcing secrets"


### PR DESCRIPTION
# Pull request for issue: #<insert relevant github issue numbers that this PR is related to>

This is a pull request for the following functionalities:

Fix Pipeline failure on Upstream.
The issues were:

* gigareview test job fails 
* files-urls-updater test job fails
* build and deploy job for the main app will fail

## How to test?

This branch is the pipeline that's already deployed on staging.gigadb.org and beta.gigadb.org.
You can re-execute that pipeline at https://gitlab.com/gigascience/upstream/gigadb-website/.

You can also clone this branch and add a remote on your own Gitlab project and ensure the pipeline still execute there without errors.

## How have functionalities been implemented?

The issues were caused by the coumpound effect of the following problems:

* The url of gitlab variables API was hardcoded to ``forks``, so it fails on Upstream pipeline
* Jobs were added to DAG to allow the Gigasciences apps' pipeline to be independent of each other, but some common base job used for caching docker base image was missing in the ``needs`` keyword of the Gitlab config
* Some variables were not set in Upstream's CI/CD settings variables

The ``generate_config.sh`` in those new apps were changed to detect whether it's running as part of Upstream pipeline or not. It does so by checking the value of ``CI_PROJECT_URL`` (which therefore needs to be made available in the ``.env`` file by adding it to the filter used in Gitlab config steps that generate that file).


The build and deploy jobs for the main app need to depends on the ""base_images" job, so that its artifacts are available, this is done  by adding that job to the array value for the ``needs`` keyword in ``ops/pipelines/gigadb-build-jobs.yml`` and ``.gitlab-config.yml``.



## Any changes to documentation?

Finally, I've updated ``gigareview/README.md`` to mention the variables that were missing on Upstream

