### PR TITLE
Create doc for wasabi bucket policies

### DIFF
--- a/docs/wasabidocs/policy-bucket.md
+++ b/docs/wasabidocs/policy-bucket.md
@@ -23,7 +23,77 @@ Policy: AllowDevelopersToSeeBucketListInTheConsole
 }
 ```
 
-The policy `IAMUsersManagePasswordAndKeys` is  attached to the group `Developers`, which allows all developers to manage their own password and access keys in the Wasabi console.
+### Group `Systems` policy
+
+The policy `AllowSystemUsersToListAndPutStagingAndLiveGigadbDatasetsBucket` is attached to the group `Systems`, which only allows `Systems` to list and put `gigadb-datasets/staging` and `gigadb-datasets/staging` bucket in the Wasabi console.
+
+
+Policy:AllowSystemUsersToListAndPutStagingAndLiveGigadbDatasetsBucket
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowSystemsUserToSeeBucketListInTheConsole",
+      "Action": ["s3:ListAllMyBuckets", "s3:GetBucketLocation"],
+      "Effect": "Allow",
+      "Resource": ["arn:aws:s3:::*"]
+    },
+    {
+        "Sid": "AllowSystemsUserToListGigadbDatasetBucketStagingFolder",
+        "Action": ["s3:ListBucket"],
+        "Effect": "Allow",
+        "Resource": ["arn:aws:s3:::gigadb-datasets"],
+        "Condition": {"StringEquals": {"s3:prefix": ["", "staging/"],"s3:delimiter":["/"]}}
+    },
+    {
+        "Sid": "AllowSystemsUserToListGigadbDatasetBucketLiveFolder",
+        "Action": ["s3:ListBucket"],
+        "Effect": "Allow",
+        "Resource": ["arn:aws:s3:::gigadb-datasets"],
+        "Condition": {"StringEquals": {"s3:prefix": ["","live/"],"s3:delimiter":["/"]}}
+    },
+    {
+         "Sid": "AllowSystemsUserToListgStagingFolder",
+         "Action": ["s3:ListBucket"],
+         "Effect": "Allow",
+         "Resource": ["arn:aws:s3:::gigadb-datasets"],
+         "Condition":{"StringLike":{"s3:prefix":["gigadb-datasets/staging/*"]}}
+    },
+    {
+         "Sid": "AllowSystemsUserToListLiveFolder",
+         "Action": ["s3:ListBucket"],
+         "Effect": "Allow",
+         "Resource": ["arn:aws:s3:::gigadb-datasets"],
+         "Condition":{"StringLike":{"s3:prefix":["gigadb-datasets/live/*"]}}
+    },
+    {
+	  "Sid": "AllowSystemUsersToPutIntoStagingAndLiveFolders",
+      "Effect": "Allow",
+      "Action": [
+				"s3:PutObject",
+				"s3:PutObjectAcl"
+			],
+      "Resource": [
+        "arn:aws:s3:::gigadb-datasets/staging/*",
+		"arn:aws:s3:::gigadb-datasets/live/*"
+      ]
+    },
+	{
+      "Sid": "NotAllowSystemUsersToDeleteStagingAndLiveGigadbDatasetsBucket",
+      "Effect": "Deny",
+      "Action": "s3:DeleteBucket",
+      "Resource": [
+        "arn:aws:s3:::gigadb-datasets/staging",
+		"arn:aws:s3:::gigadb-datasets/live"
+      ]
+    }
+  ]
+}
+```
+
+### General policy
+The policy `IAMUsersManagePasswordAndKeys` is attached to the group `Developers` and `Systems`, which allows all developers and system user to manage their own password and access keys in the Wasabi console.
 
 Policy: IAMUsersManagePasswordAndKeys
 ```
@@ -54,8 +124,9 @@ Policy: IAMUsersManagePasswordAndKeys
 }
 ```
 
+
 ### User policy
-This policy is attached to each user, which allows user to only access bucket `gigadb-cngb-backup` only, and developer is not allowed to delete bucket `gigadb-cngb-backup`. 
+This policy is attached to Developers, which allows developers to access all buckets, but is not allowed to delete buckets `gigadb-datasets` and `test-gigadb-datasets`. 
 
 Policy Name: AllowS3ReadWrite
 ```
@@ -63,7 +134,7 @@ Policy Name: AllowS3ReadWrite
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "AllowAccessToGigaDbCngbBackUpBucket",
+      "Sid": "AllowAccessToGigaDbDatasetsBucket",
       "Effect": "Allow",
       "Action": [
         "s3:ListBucket",
@@ -81,7 +152,7 @@ Policy Name: AllowS3ReadWrite
       ]
     },
     {
-      "Sid": "NotAllowDevelopersToDeleteGigaDbCngbBackUpBucket",
+      "Sid": "NotAllowDevelopersToDeleteGigaDbDatasetsCBucket",
       "Effect": "Deny",
       "Action": "s3:DeleteBucket",
       "Resource": [

--- a/docs/wasabidocs/policy-bucket.md
+++ b/docs/wasabidocs/policy-bucket.md
@@ -1,11 +1,45 @@
 # Wasabi permissions policy for bucket
 
 
+### General policy
+The policy `IAMUsersManagePasswordAndKeys` is attached to the group `Developers` and `Systems`, which allows all developers and systems user to manage their own password and access keys in the Wasabi console.
+
+Policy: IAMUsersManagePasswordAndKeys
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowManageOwnPasswords",
+      "Effect": "Allow",
+      "Action": [
+        "iam:ChangePassword",
+        "iam:GetUser"
+      ],
+      "Resource": "arn:aws:iam::*:user/${aws:username}"
+    },
+    {
+      "Sid": "AllowManageOwnAccessKeys",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateAccessKey",
+        "iam:DeleteAccessKey",
+        "iam:ListAccessKeys",
+        "iam:UpdateAccessKey"
+      ],
+      "Resource": "arn:aws:iam::*:user/${aws:username}"
+    }
+  ]
+}
+```
+
 ### Group `Developers` policy
 
-The policy `AllowDevelopersToSeeBucketListInTheConsole` is attached to the group `Developers`, which allows all developers to list every bucket in the Wasabi console. 
+The policy `AllowDevelopersToSeeBucketListInTheConsole` is attached to the group `Developers`, which allows all developers to list every bucket in the Wasabi console.
+It also allows developers to access all buckets, but is not allowed to delete buckets `gigadb-datasets` and `test-gigadb-datasets`.
 
-Policy: AllowDevelopersToSeeBucketListInTheConsole
+
+Policy: AllowDevelopersToListGetPutInGigadbDatasetsBucket
 ```
 {
   "Version": "2012-10-17",
@@ -18,6 +52,33 @@ Policy: AllowDevelopersToSeeBucketListInTheConsole
         "s3:GetBucketVersioning"
       ],
       "Resource": "arn:aws:s3:::*"
+    },
+    {
+      "Sid": "AllowAccessToGigaDbDatasetsBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:GetObjectAcl",
+        "s3:PutObjectAcl",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::test-gigadb-datasets",
+        "arn:aws:s3:::test-gigadb-datasets/*",
+        "arn:aws:s3:::gigadb-datasets",
+        "arn:aws:s3:::gigadb-datasets/*"
+      ]
+    },
+    {
+      "Sid": "NotAllowDevelopersToDeleteGigaDbDatasetsCBucket",
+      "Effect": "Deny",
+      "Action": "s3:DeleteBucket",
+      "Resource": [
+        "arn:aws:s3:::test-gigadb-datasets",
+        "arn:aws:s3:::gigadb-datasets"
+      ]
     }
   ]
 }
@@ -86,78 +147,6 @@ Policy:AllowSystemUsersToListAndPutStagingAndLiveGigadbDatasetsBucket
       "Resource": [
         "arn:aws:s3:::gigadb-datasets/staging",
 		"arn:aws:s3:::gigadb-datasets/live"
-      ]
-    }
-  ]
-}
-```
-
-### General policy
-The policy `IAMUsersManagePasswordAndKeys` is attached to the group `Developers` and `Systems`, which allows all developers and system user to manage their own password and access keys in the Wasabi console.
-
-Policy: IAMUsersManagePasswordAndKeys
-```
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AllowManageOwnPasswords",
-      "Effect": "Allow",
-      "Action": [
-        "iam:ChangePassword",
-        "iam:GetUser"
-      ],
-      "Resource": "arn:aws:iam::*:user/${aws:username}"
-    },
-    {
-      "Sid": "AllowManageOwnAccessKeys",
-      "Effect": "Allow",
-      "Action": [
-        "iam:CreateAccessKey",
-        "iam:DeleteAccessKey",
-        "iam:ListAccessKeys",
-        "iam:UpdateAccessKey"
-      ],
-      "Resource": "arn:aws:iam::*:user/${aws:username}"
-    }
-  ]
-}
-```
-
-
-### User policy
-This policy is attached to Developers, which allows developers to access all buckets, but is not allowed to delete buckets `gigadb-datasets` and `test-gigadb-datasets`. 
-
-Policy Name: AllowS3ReadWrite
-```
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AllowAccessToGigaDbDatasetsBucket",
-      "Effect": "Allow",
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetObject",
-        "s3:PutObject",
-        "s3:GetObjectAcl",
-        "s3:PutObjectAcl",
-        "s3:DeleteObject"
-      ],
-      "Resource": [
-        "arn:aws:s3:::test-gigadb-datasets",
-        "arn:aws:s3:::test-gigadb-datasets/*",
-        "arn:aws:s3:::gigadb-datasets",
-        "arn:aws:s3:::gigadb-datasets/*"
-      ]
-    },
-    {
-      "Sid": "NotAllowDevelopersToDeleteGigaDbDatasetsCBucket",
-      "Effect": "Deny",
-      "Action": "s3:DeleteBucket",
-      "Resource": [
-        "arn:aws:s3:::test-gigadb-datasets",
-        "arn:aws:s3:::gigadb-datasets"
       ]
     }
   ]

--- a/docs/wasabidocs/policy-bucket.md
+++ b/docs/wasabidocs/policy-bucket.md
@@ -96,21 +96,25 @@ Policy:AllowSystemUsersToListAndPutStagingAndLiveGigadbDatasetsBucket
   "Statement": [
     {
       "Sid": "AllowSystemsUserToSeeBucketListInTheConsole",
-      "Action": ["s3:ListAllMyBuckets", "s3:GetBucketLocation"],
       "Effect": "Allow",
+      "Action": ["s3:ListAllMyBuckets", "s3:GetBucketLocation"],
       "Resource": ["arn:aws:s3:::*"]
     },
     {
         "Sid": "AllowSystemsUserToListGigadbDatasetBucketStagingFolder",
-        "Action": ["s3:ListBucket"],
         "Effect": "Allow",
+        "Action": [
+            "s3:ListBucket"
+         ],
         "Resource": ["arn:aws:s3:::gigadb-datasets"],
         "Condition": {"StringEquals": {"s3:prefix": ["", "staging/"],"s3:delimiter":["/"]}}
     },
     {
         "Sid": "AllowSystemsUserToListGigadbDatasetBucketLiveFolder",
-        "Action": ["s3:ListBucket"],
         "Effect": "Allow",
+        "Action": [
+            "s3:ListBucket"
+         ],
         "Resource": ["arn:aws:s3:::gigadb-datasets"],
         "Condition": {"StringEquals": {"s3:prefix": ["","live/"],"s3:delimiter":["/"]}}
     },
@@ -119,26 +123,40 @@ Policy:AllowSystemUsersToListAndPutStagingAndLiveGigadbDatasetsBucket
          "Action": ["s3:ListBucket"],
          "Effect": "Allow",
          "Resource": ["arn:aws:s3:::gigadb-datasets"],
-         "Condition":{"StringLike":{"s3:prefix":["gigadb-datasets/staging/*"]}}
+         "Condition":{"StringLike":{"s3:prefix":["staging/*"]}}
     },
     {
          "Sid": "AllowSystemsUserToListLiveFolder",
          "Action": ["s3:ListBucket"],
          "Effect": "Allow",
          "Resource": ["arn:aws:s3:::gigadb-datasets"],
-         "Condition":{"StringLike":{"s3:prefix":["gigadb-datasets/live/*"]}}
+         "Condition":{"StringLike":{"s3:prefix":["live/*"]}}
     },
     {
-	  "Sid": "AllowSystemUsersToPutIntoStagingAndLiveFolders",
-      "Effect": "Allow",
-      "Action": [
-				"s3:PutObject",
-				"s3:PutObjectAcl"
-			],
-      "Resource": [
-        "arn:aws:s3:::gigadb-datasets/staging/*",
-		"arn:aws:s3:::gigadb-datasets/live/*"
-      ]
+         "Sid": "AllowSystemsUserToListAndPutStagingFolder",
+         "Effect": "Allow",
+         "Action": [
+            "s3:ListBucket",
+            "s3:PutObject",
+			"s3:PutObjectAcl"
+         ],
+         "Resource": [
+            "arn:aws:s3:::gigadb-datasets/staging",
+            "arn:aws:s3:::gigadb-datasets/staging/*"
+         ]
+    },
+    {
+         "Sid": "AllowSystemsUserToListAndPutLiveFolder",
+         "Effect": "Allow",
+         "Action": [
+            "s3:ListBucket",
+            "s3:PutObject",
+			"s3:PutObjectAcl"
+         ],
+         "Resource": [
+            "arn:aws:s3:::gigadb-datasets/live",
+            "arn:aws:s3:::gigadb-datasets/live/*"
+         ]
     },
 	{
       "Sid": "NotAllowSystemUsersToDeleteStagingAndLiveGigadbDatasetsBucket",

--- a/docs/wasabidocs/policy-bucket.md
+++ b/docs/wasabidocs/policy-bucket.md
@@ -55,7 +55,7 @@ Policy: IAMUsersManagePasswordAndKeys
 ```
 
 ### User policy
-This policy is attached to each user, which allows user to access bucket `gigadb-cngb-backup` only, and developer is not allowed to delete bucket `gigadb-cngb-backup`. 
+This policy is attached to each user, which allows user to only access bucket `gigadb-cngb-backup` only, and developer is not allowed to delete bucket `gigadb-cngb-backup`. 
 
 Policy Name: AllowS3ReadWrite
 ```

--- a/docs/wasabidocs/policy-bucket.md
+++ b/docs/wasabidocs/policy-bucket.md
@@ -1,0 +1,89 @@
+# Wasabi permissions policy for bucket
+
+
+### Group `Developers` policy
+
+The policy `AllowDevelopersToSeeBucketListInTheConsole` is attached to the group `Developers`, which allows all developers to list every bucket in the Wasabi console. 
+
+Policy: AllowDevelopersToSeeBucketListInTheConsole
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowDevelopersToSeeBucketListInTheConsole",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListAllMyBuckets",
+        "s3:GetBucketVersioning"
+      ],
+      "Resource": "arn:aws:s3:::*"
+    }
+  ]
+}
+```
+
+The policy `IAMUsersManagePasswordAndKeys` is  attached to the group `Developers`, which allows all developers to manage their own password and access keys in the Wasabi console.
+
+Policy: IAMUsersManagePasswordAndKeys
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowManageOwnPasswords",
+      "Effect": "Allow",
+      "Action": [
+        "iam:ChangePassword",
+        "iam:GetUser"
+      ],
+      "Resource": "arn:aws:iam::*:user/${aws:username}"
+    },
+    {
+      "Sid": "AllowManageOwnAccessKeys",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateAccessKey",
+        "iam:DeleteAccessKey",
+        "iam:ListAccessKeys",
+        "iam:UpdateAccessKey"
+      ],
+      "Resource": "arn:aws:iam::*:user/${aws:username}"
+    }
+  ]
+}
+```
+
+### User policy
+This policy is attached to each user, which allows user to access bucket `gigadb-cngb-backup` only, and developer is not allowed to delete bucket `gigadb-cngb-backup`. 
+
+Policy Name: AllowS3ReadWrite
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowAccessToGigaDbCngbBackUpBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:GetObjectAcl",
+        "s3:PutObjectAcl",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::gigadb-cngb-backup",
+        "arn:aws:s3:::gigadb-cngb-backup/*"
+      ]
+    },
+    {
+      "Sid": "NotAllowDevelopersToDeleteGigaDbCngbBackUpBucket",
+      "Effect": "Deny",
+      "Action": "s3:DeleteBucket",
+      "Resource": "arn:aws:s3:::gigadb-cngb-backup"
+    }
+  ]
+}
+```

--- a/docs/wasabidocs/policy-bucket.md
+++ b/docs/wasabidocs/policy-bucket.md
@@ -108,74 +108,57 @@ Policy:AllowSystemUsersToListAndPutStagingAndLiveGigadbDatasetsBucket
     {
       "Sid": "AllowSystemsUserToSeeBucketListInTheConsole",
       "Effect": "Allow",
-      "Action": ["s3:ListAllMyBuckets", "s3:GetBucketLocation"],
-      "Resource": ["arn:aws:s3:::*"]
+      "Action": [
+        "s3:ListAllMyBuckets",
+        "s3:GetBucketLocation"
+      ],
+      "Resource": "arn:aws:s3:::*"
     },
     {
-        "Sid": "AllowSystemsUserToListGigadbDatasetBucketStagingFolder",
-        "Effect": "Allow",
-        "Action": [
-            "s3:ListBucket"
-         ],
-        "Resource": ["arn:aws:s3:::gigadb-datasets"],
-        "Condition": {"StringEquals": {"s3:prefix": ["", "staging/"],"s3:delimiter":["/"]}}
+      "Sid": "AllowSystemsUserToListGigabbDatasetsBucket",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": [
+        "arn:aws:s3:::gigadb-datasets",
+        "arn:aws:s3:::gigadb-datasets/*"
+      ]
     },
     {
-        "Sid": "AllowSystemsUserToListGigadbDatasetBucketLiveFolder",
-        "Effect": "Allow",
-        "Action": [
-            "s3:ListBucket"
-         ],
-        "Resource": ["arn:aws:s3:::gigadb-datasets"],
-        "Condition": {"StringEquals": {"s3:prefix": ["","live/"],"s3:delimiter":["/"]}}
-    },
-    {
-         "Sid": "AllowSystemsUserToListgStagingFolder",
-         "Action": ["s3:ListBucket"],
-         "Effect": "Allow",
-         "Resource": ["arn:aws:s3:::gigadb-datasets"],
-         "Condition":{"StringLike":{"s3:prefix":["staging/*"]}}
-    },
-    {
-         "Sid": "AllowSystemsUserToListLiveFolder",
-         "Action": ["s3:ListBucket"],
-         "Effect": "Allow",
-         "Resource": ["arn:aws:s3:::gigadb-datasets"],
-         "Condition":{"StringLike":{"s3:prefix":["live/*"]}}
-    },
-    {
-         "Sid": "AllowSystemsUserToListAndPutStagingFolder",
-         "Effect": "Allow",
-         "Action": [
-            "s3:ListBucket",
-            "s3:PutObject",
-			"s3:PutObjectAcl"
-         ],
-         "Resource": [
-            "arn:aws:s3:::gigadb-datasets/staging",
-            "arn:aws:s3:::gigadb-datasets/staging/*"
-         ]
-    },
-    {
-         "Sid": "AllowSystemsUserToListAndPutLiveFolder",
-         "Effect": "Allow",
-         "Action": [
-            "s3:ListBucket",
-            "s3:PutObject",
-			"s3:PutObjectAcl"
-         ],
-         "Resource": [
-            "arn:aws:s3:::gigadb-datasets/live",
-            "arn:aws:s3:::gigadb-datasets/live/*"
-         ]
-    },
-	{
-      "Sid": "NotAllowSystemUsersToDeleteStagingAndLiveGigadbDatasetsBucket",
-      "Effect": "Deny",
-      "Action": "s3:DeleteBucket",
+      "Sid": "AllowSystemsUserToListAndPutGigadbDatasetBucketStagingFolder",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
       "Resource": [
         "arn:aws:s3:::gigadb-datasets/staging",
-		"arn:aws:s3:::gigadb-datasets/live"
+        "arn:aws:s3:::gigadb-datasets/staging/*"
+      ]
+    },
+    {
+      "Sid": "AllowSystemsUserToListAndPutGigadbDatasetBucketLiveFolder",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": [
+        "arn:aws:s3:::gigadb-datasets/live",
+        "arn:aws:s3:::gigadb-datasets/live/*"
+      ]
+    },
+    {
+      "Sid": "NotAllowSystemUsersToDeleteGigadbDatasetsBucketAndObject",
+      "Effect": "Deny",
+      "Action": [
+        "s3:DeleteBucket",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::gigadb-datasets",
+        "arn:aws:s3:::gigadb-datasets/*"
       ]
     }
   ]

--- a/docs/wasabidocs/policy-bucket.md
+++ b/docs/wasabidocs/policy-bucket.md
@@ -115,7 +115,7 @@ Policy:AllowSystemUsersToListAndPutStagingAndLiveGigadbDatasetsBucket
       "Resource": "arn:aws:s3:::*"
     },
     {
-      "Sid": "AllowSystemsUserToListGigabbDatasetsBucket",
+      "Sid": "AllowSystemsUserToListGigadbDatasetsBucket",
       "Effect": "Allow",
       "Action": "s3:ListBucket",
       "Resource": [
@@ -127,6 +127,8 @@ Policy:AllowSystemUsersToListAndPutStagingAndLiveGigadbDatasetsBucket
       "Sid": "AllowSystemsUserToListAndPutGigadbDatasetBucketStagingFolder",
       "Effect": "Allow",
       "Action": [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
         "s3:ListBucket",
         "s3:PutObject",
         "s3:PutObjectAcl"
@@ -140,6 +142,8 @@ Policy:AllowSystemUsersToListAndPutStagingAndLiveGigadbDatasetsBucket
       "Sid": "AllowSystemsUserToListAndPutGigadbDatasetBucketLiveFolder",
       "Effect": "Allow",
       "Action": [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
         "s3:ListBucket",
         "s3:PutObject",
         "s3:PutObjectAcl"

--- a/docs/wasabidocs/policy-bucket.md
+++ b/docs/wasabidocs/policy-bucket.md
@@ -61,23 +61,34 @@ Policy: AllowDevelopersToListGetPutInGigadbDatasetsBucket
         "s3:GetObject",
         "s3:PutObject",
         "s3:GetObjectAcl",
-        "s3:PutObjectAcl",
-        "s3:DeleteObject"
+        "s3:PutObjectAcl"
       ],
       "Resource": [
-        "arn:aws:s3:::test-gigadb-datasets",
-        "arn:aws:s3:::test-gigadb-datasets/*",
         "arn:aws:s3:::gigadb-datasets",
         "arn:aws:s3:::gigadb-datasets/*"
       ]
     },
+	{
+	  "Sid": "AllowAllS3ActionInTestGigaDbDatasetsBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "arn:aws:s3:::test-gigadb-datasets",
+        "arn:aws:s3:::test-gigadb-datasets/*"
+      ]
+	},
     {
       "Sid": "NotAllowDevelopersToDeleteGigaDbDatasetsCBucket",
       "Effect": "Deny",
-      "Action": "s3:DeleteBucket",
+      "Action": ["s3:DeleteBucket","s3:DeleteObject"],
       "Resource": [
         "arn:aws:s3:::test-gigadb-datasets",
-        "arn:aws:s3:::gigadb-datasets"
+        "arn:aws:s3:::gigadb-datasets/staging",
+        "arn:aws:s3:::gigadb-datasets/staging/*",
+        "arn:aws:s3:::gigadb-datasets/live",
+        "arn:aws:s3:::gigadb-datasets/live/*"
       ]
     }
   ]

--- a/docs/wasabidocs/policy-bucket.md
+++ b/docs/wasabidocs/policy-bucket.md
@@ -74,15 +74,20 @@ Policy Name: AllowS3ReadWrite
         "s3:DeleteObject"
       ],
       "Resource": [
-        "arn:aws:s3:::gigadb-cngb-backup",
-        "arn:aws:s3:::gigadb-cngb-backup/*"
+        "arn:aws:s3:::test-gigadb-datasets",
+        "arn:aws:s3:::test-gigadb-datasets/*",
+        "arn:aws:s3:::gigadb-datasets",
+        "arn:aws:s3:::gigadb-datasets/*"
       ]
     },
     {
       "Sid": "NotAllowDevelopersToDeleteGigaDbCngbBackUpBucket",
       "Effect": "Deny",
       "Action": "s3:DeleteBucket",
-      "Resource": "arn:aws:s3:::gigadb-cngb-backup"
+      "Resource": [
+        "arn:aws:s3:::test-gigadb-datasets",
+        "arn:aws:s3:::gigadb-datasets"
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Pull request for issue: #1130 

This is a pull request for the following functionalities:

This PR contains the policies applying to the Wasabi bucket `gigadb-datasets` for backup gigadb cngb data.

## How to test?

Log in Wasabi console as a subuser at [here](https://console.wasabisys.com/#/subuserLogin), then you will see the console dashboard like:
<img width="1481" alt="image" src="https://user-images.githubusercontent.com/64770635/201263442-c2e01b5d-a6ae-4f81-ac4a-2b670b32f24c.png">

### Pre-requisite
```
# Check rclone version
% rclone --version
rclone v1.59.2
- os/version: darwin 11.6 (64 bit)
- os/kernel: 20.6.0 (x86_64)
- os/type: darwin
- os/arch: amd64
- go/version: go1.19.1
- go/linking: dynamic
- go/tags: none
# Check rclone config file
% rclone config file
Configuration file is stored at:
/Users/kencho/.config/rclone/rclone.conf
# Config rclone configuration
vi ~/.config/rclone/rclone.conf
[wasabi$User]
type = s3
provider = Wasabi
env_auth = true
access_key_id = {user input}
secret_access_key = {user input}
region = ap-northeast-1
endpoint = s3.ap-northeast-1.wasabisys.com

[wasabiMigration]
type = s3
provider = Wasabi
env_auth = true
access_key_id = {user input}
secret_access_key = {user input}
region = ap-northeast-1
endpoint = s3.ap-northeast-1.wasabisys.com
```

### Upload file as a Developer user
```
# Check the connection as Developers `Ken`
% rclone ls wasabiKen:gigadb-datasets/
    25964 dev/dermatology.data
    39975 dev/pub/10.5524/100001_101000/100002/CR.kegg.gz
      649 dev/pub/10.5524/100001_101000/100002/readme.txt
     2696 dev/pub/10.5524/100001_101000/100012/Keller.gff
     3164 dev/pub/10.5524/100001_101000/100012/readme.txt
    79710 staging/Aldabra_Giant_Tortoise.png
% rclone lsd wasabiKen:gigadb-datasets
           0 2022-11-10 18:16:12        -1 CI
           0 2022-11-10 18:16:12        -1 dev
           0 2022-11-10 18:16:12        -1 live
           0 2022-11-10 18:16:12        -1 staging
% rclone copy --dry-run ~/Downloads/Aldabra_Giant_Tortoise.png wasabiKen:gigadb-datasets/live  
2022/11/11 11:54:57 NOTICE: Aldabra_Giant_Tortoise.png: Skipped copy as --dry-run is set (size 77.842Ki)
2022/11/11 11:54:57 NOTICE: 
Transferred:       77.842 KiB / 77.842 KiB, 100%, 0 B/s, ETA -
Transferred:            1 / 1, 100%
Elapsed time:         0.3s
 % rclone copy ~/Downloads/Aldabra_Giant_Tortoise.png
 wasabiKen:gigadb-datasets/live --s3-no-check-bucket
% rclone ls wasabiKen:gigadb-datasets/
    25964 dev/dermatology.data
    39975 dev/pub/10.5524/100001_101000/100002/CR.kegg.gz
      649 dev/pub/10.5524/100001_101000/100002/readme.txt
     2696 dev/pub/10.5524/100001_101000/100012/Keller.gff
     3164 dev/pub/10.5524/100001_101000/100012/readme.txt
    79710 live/Aldabra_Giant_Tortoise.png
    79710 staging/Aldabra_Giant_Tortoise.png
```

### Upload file as a Systems user
```
# Check the connection as Systems `Migration`
 % rclone ls wasabiMigration:gigadb-datasets
    25964 dev/dermatology.data
    39975 dev/pub/10.5524/100001_101000/100002/CR.kegg.gz
      649 dev/pub/10.5524/100001_101000/100002/readme.txt
     2696 dev/pub/10.5524/100001_101000/100012/Keller.gff
     3164 dev/pub/10.5524/100001_101000/100012/readme.txt
    79710 live/Aldabra_Giant_Tortoise.png
    79710 staging/Aldabra_Giant_Tortoise.png
    79710 staging/test-folder/Aldabra_Giant_Tortoise.png
% rclone lsd wasabiMigration:gigadb-datasets
           0 2022-11-10 18:21:32        -1 CI
           0 2022-11-10 18:21:32        -1 dev
           0 2022-11-10 18:21:32        -1 live
           0 2022-11-10 18:21:32        -1 staging
% rclone ls wasabiMigration:gigadb-datasets/live
%
% rclone copy -vv ~/Downloads/Aldabra_Giant_Tortoise.png wasabiMigration:gigadb-datasets/live --s3-no-check-bucket 
2022/11/14 17:14:56 DEBUG : rclone: Version "v1.59.2" starting with parameters ["rclone" "copy" "-vv" "/Users/kencho/Downloads/Aldabra_Giant_Tortoise.png" "wasabiMigration:gigadb-datasets/live" "--s3-no-check-bucket"]
2022/11/14 17:14:56 DEBUG : Creating backend with remote "/Users/kencho/Downloads/Aldabra_Giant_Tortoise.png"
2022/11/14 17:14:56 DEBUG : Using config file from "/Users/kencho/.config/rclone/rclone.conf"
2022/11/14 17:14:56 DEBUG : fs cache: adding new entry for parent of "/Users/kencho/Downloads/Aldabra_Giant_Tortoise.png", "/Users/kencho/Downloads"
2022/11/14 17:14:56 DEBUG : Creating backend with remote "wasabiMigration:gigadb-datasets/live"
2022/11/14 17:14:56 DEBUG : wasabiMigration: detected overridden config - adding "{Dn7qA}" suffix to name
2022/11/14 17:14:56 DEBUG : fs cache: renaming cache item "wasabiMigration:gigadb-datasets/live" to be canonical "wasabiMigration{Dn7qA}:gigadb-datasets/live"
2022/11/14 17:14:56 DEBUG : Aldabra_Giant_Tortoise.png: Need to transfer - File not found at Destination
2022/11/14 17:14:57 DEBUG : Aldabra_Giant_Tortoise.png: md5 = a744da781ede0eb9c490fc2da9f50266 OK
2022/11/14 17:14:57 INFO  : Aldabra_Giant_Tortoise.png: Copied (new)
2022/11/14 17:14:57 INFO  : 
Transferred:       77.842 KiB / 77.842 KiB, 100%, 0 B/s, ETA -
Transferred:            1 / 1, 100%
Elapsed time:         1.1s

2022/11/14 17:14:57 DEBUG : 7 go routines active
% rclone ls wasabiMigration:gigadb-datasets/live
    79710 Aldabra_Giant_Tortoise.png
 % rclone ls wasabiMigration:gigadb-datasets/staging
    79710 Aldabra_Giant_Tortoise.png
    79710 test-folder/Aldabra_Giant_Tortoise.png
% rclone copy -vv ~/Downloads/Aldabra_Giant_Tortoise.png wasabiMigration:gigadb-datasets/staging
2022/11/14 17:25:12 DEBUG : rclone: Version "v1.59.2" starting with parameters ["rclone" "copy" "-vv" "/Users/kencho/Downloads/Aldabra_Giant_Tortoise.png" "wasabiMigration:gigadb-datasets/staging"]
2022/11/14 17:25:12 DEBUG : Creating backend with remote "/Users/kencho/Downloads/Aldabra_Giant_Tortoise.png"
2022/11/14 17:25:12 DEBUG : Using config file from "/Users/kencho/.config/rclone/rclone.conf"
2022/11/14 17:25:12 DEBUG : fs cache: adding new entry for parent of "/Users/kencho/Downloads/Aldabra_Giant_Tortoise.png", "/Users/kencho/Downloads"
2022/11/14 17:25:12 DEBUG : Creating backend with remote "wasabiMigration:gigadb-datasets/staging"
2022/11/14 17:25:12 DEBUG : Aldabra_Giant_Tortoise.png: Size and modification time the same (differ by 0s, within tolerance 1ns)
2022/11/14 17:25:12 DEBUG : Aldabra_Giant_Tortoise.png: Unchanged skipping
2022/11/14 17:25:12 INFO  : 
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.3s
2022/11/14 17:25:12 DEBUG : 6 go routines active
% rclone copy -v ~/Downloads/Aldabra_Giant_Tortoise.png wasabiMigration:gigadb-datasets/dev 
2022/11/14 17:21:59 ERROR : Attempt 1/3 failed with 1 errors and: Forbidden: Forbidden
        status code: 403, request id: B34BE28C0E963D13, host id: t83YXjgJrz+XjUNv+dhyZ7vjbb7nRbHP2NBXI0TYUamf+RNg53USRnT+7s3YbYI1EBOYkWalIm9V
2022/11/14 17:21:59 ERROR : Attempt 2/3 failed with 1 errors and: Forbidden: Forbidden
        status code: 403, request id: A1DFDCF87435FC98, host id: C9P2w+KBhBx0MEm0bVz0dx7JwLInTf/ACi/R3GctFr0/OsU8iIxj3Hwm3CwTSR5TnJJQgXRcjG7o
2022/11/14 17:21:59 ERROR : Attempt 3/3 failed with 1 errors and: Forbidden: Forbidden
        status code: 403, request id: 5CF627851E8A8BA1, host id: PXk4HbV5vSzEh2nb+9hiSaZ+2jYXbQtFua3rQuzO4HUHEKItlfKMSCojfPOhHqcR1Z/33JpSZFiO
2022/11/14 17:21:59 INFO  : 
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Errors:                 1 (retrying may help)
Elapsed time:         1.2s

2022/11/14 17:21:59 Failed to copy: Forbidden: Forbidden
        status code: 403, request id: 5CF627851E8A8BA1, host id: PXk4HbV5vSzEh2nb+9hiSaZ+2jYXbQtFua3rQuzO4HUHEKItlfKMSCojfPOhHqcR1Z/33JpSZFiO
% rclone copy -v ~/Downloads/Aldabra_Giant_Tortoise.png wasabiMigration:gigadb-datasets/CI
2022/11/14 17:22:30 ERROR : Attempt 1/3 failed with 1 errors and: Forbidden: Forbidden
        status code: 403, request id: ABF4CF8F9D238C20, host id: ltSmXfnwX1QyNoqeBMFMezkMUWTlkSN1RMBwpdQ6rxtXalAApOncEMeCYcdEKAta74MtPG0DLVlr
2022/11/14 17:22:30 ERROR : Attempt 2/3 failed with 1 errors and: Forbidden: Forbidden
        status code: 403, request id: 55A54B211D9174F0, host id: bxCkHo58cKQjF5gIRYgw4kyVWgNMpQkq4sBAAJSiqkpIJv4IjbpHwEwRHicu/fBuBC+6+Zgmqx0G
2022/11/14 17:22:30 ERROR : Attempt 3/3 failed with 1 errors and: Forbidden: Forbidden
        status code: 403, request id: 54A7FCB61F8A9834, host id: XOQ5il8NZGJLhIeJDZvBrB06oA4k5W43f1YlRdTL4ERt6/rNdel3zr/Vwn3b6yH+l3rfd2aj736u
2022/11/14 17:22:30 INFO  : 
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Errors:                 1 (retrying may help)
Elapsed time:         0.6s

2022/11/14 17:22:30 Failed to copy: Forbidden: Forbidden
        status code: 403, request id: 54A7FCB61F8A9834, host id: XOQ5il8NZGJLhIeJDZvBrB06oA4k5W43f1YlRdTL4ERt6/rNdel3zr/Vwn3b6yH+l3rfd2aj736u


# This is a reported bug that rclone will check for the existence of bucket if it is empty at first, details at https://forum.rclone.org/t/required-s3-permissions-for-backup-dir/24307
% rclone copy ~/Downloads/GigaDBUpload_102203_GIGA-D-21-00197_hamster.xls wasabi:test-gigadb-datasets
2022/10/16 15:34:47 ERROR : GigaDBUpload_102203_GIGA-D-21-00197_hamster.xls: Failed to copy: AccessDenied: User: arn:aws:iam::100000166496:user/Ken is not authorized to perform: s3:CreateBucket on resource: arn:aws:s3:::test-gigadb-datasets
	status code: 403, request id: 2F6AACDDCFB89BD0, host id: vVUeezxra5fA6Jrniei4tTupUAUAtYM82eMJrBKU4QyHaM9/YvjdEotaCX34LqksEszDDjzttw8/
# The workaround of uploading file to the bucket at the first time is adding `--s3-no-check-bucket`
% rclone copy `--s3-no-check-bucket` ~/Downloads/GigaDBUpload_102203_GIGA-D-21-00197_hamster.xls wasabi:test-gigadb-datasets
% rclone ls wasabi:test-gigadb-datasets
    76288 GigaDBUpload_102203_GIGA-D-21-00197_hamster.xls
```

### Delete the bucket  or object in `gigadb-datasets` as Developers is not allowed
```
% rclone purge wasabiKen:gigadb-datasets/live
2022/11/14 17:31:47 ERROR : Aldabra_Giant_Tortoise.png: Couldn't delete: AccessDenied: User: arn:aws:iam::100000166496:user/Ken is not authorized to perform: s3:DeleteObject on resource: arn:aws:s3:::gigadb-datasets/live/Aldabra_Giant_Tortoise.png with an explicit deny
        status code: 403, request id: FC0CA4A79BA857F5, host id: 9jk4RZ2aVPL26kwpRYgwXgoAohxRzGL0/sBCxUKJhDhKNqRR2Cr2Vrf5pMiWhjL6qf6AJqhqYAYD
2022/11/14 17:31:47 ERROR : Attempt 1/3 failed with 2 errors and: failed to delete 1 files
2022/11/14 17:31:47 ERROR : Aldabra_Giant_Tortoise.png: Couldn't delete: AccessDenied: User: arn:aws:iam::100000166496:user/Ken is not authorized to perform: s3:DeleteObject on resource: arn:aws:s3:::gigadb-datasets/live/Aldabra_Giant_Tortoise.png with an explicit deny
        status code: 403, request id: 0F1914D096D2D4CC, host id: 0FgWmJ1nbGSehqpT88XpfZekwKSDCoF95eA3kNKfsG3AuqHn43/6A3kKF4f5fazYH8RA7IMf4ygk
2022/11/14 17:31:47 ERROR : Attempt 2/3 failed with 2 errors and: failed to delete 1 files
2022/11/14 17:31:47 ERROR : Aldabra_Giant_Tortoise.png: Couldn't delete: AccessDenied: User: arn:aws:iam::100000166496:user/Ken is not authorized to perform: s3:DeleteObject on resource: arn:aws:s3:::gigadb-datasets/live/Aldabra_Giant_Tortoise.png with an explicit deny
        status code: 403, request id: 0F4990292217BCC9, host id: zdo6pEg2QQyH/t6sIIaLJ6PaBvvICJqaNwfulLM/XmL/wgyCq0xlBo4CkVAV1zF5ZKqZvA89mfgw
2022/11/14 17:31:47 ERROR : Attempt 3/3 failed with 2 errors and: failed to delete 1 files
2022/11/14 17:31:47 Failed to purge with 2 errors: last error was: failed to delete 1 files

```

# Delete object, but not delete bucket, in `test-gigadb-datasets` as Developers is not allowed
```
 % rclone delete wasabiKen:gigadb-datasets/live/Aldabra_Giant_Tortoise.png
2022/11/14 17:33:27 ERROR : Aldabra_Giant_Tortoise.png: Couldn't delete: AccessDenied: User: arn:aws:iam::100000166496:user/Ken is not authorized to perform: s3:DeleteObject on resource: arn:aws:s3:::gigadb-datasets/live/Aldabra_Giant_Tortoise.png with an explicit deny
        status code: 403, request id: CE3516B889E6A9D5, host id: sya3eg3VfjU7AvnNy9M2tlBUZWc7ILvfnySsPSDggysfZ++voHaqTdg6Fde5kRglUhz30stIQZKh
2022/11/14 17:33:27 ERROR : Attempt 1/3 failed with 2 errors and: failed to delete 1 files
2022/11/14 17:33:27 ERROR : Aldabra_Giant_Tortoise.png: Couldn't delete: AccessDenied: User: arn:aws:iam::100000166496:user/Ken is not authorized to perform: s3:DeleteObject on resource: arn:aws:s3:::gigadb-datasets/live/Aldabra_Giant_Tortoise.png with an explicit deny
        status code: 403, request id: 665F3BCFE80058B6, host id: GWnq+bublrl1xDBaRFhfycSwmtKNCYkh5vaQeKrqZVXKCoTc/KR+3Q0UNO/nZlOwUBxvTCbjg4W6
2022/11/14 17:33:27 ERROR : Attempt 2/3 failed with 2 errors and: failed to delete 1 files
2022/11/14 17:33:27 ERROR : Aldabra_Giant_Tortoise.png: Couldn't delete: AccessDenied: User: arn:aws:iam::100000166496:user/Ken is not authorized to perform: s3:DeleteObject on resource: arn:aws:s3:::gigadb-datasets/live/Aldabra_Giant_Tortoise.png with an explicit deny
        status code: 403, request id: A8B442142DBA8470, host id: ogoqiMqHkxlEhNhVjBxPTdGjYww3xjJfJeHwSSiijSfrSLFF27XtTXSQ/nSkhVS468k4zo+a0FAt
2022/11/14 17:33:27 ERROR : Attempt 3/3 failed with 2 errors and: failed to delete 1 files
2022/11/14 17:33:27 Failed to delete with 2 errors: last error was: failed to delete 1 files
% rclone purge -vv wasabiKen:test-gigadb-datasets
2022/11/11 12:16:22 DEBUG : rclone: Version "v1.59.2" starting with parameters ["rclone" "purge" "-vv" "wasabiKen:test-gigadb-datasets"]
2022/11/11 12:16:22 DEBUG : Creating backend with remote "wasabiKen:test-gigadb-datasets"
2022/11/11 12:16:22 DEBUG : Using config file from "/Users/kencho/.config/rclone/rclone.conf"
2022/11/11 12:16:22 DEBUG : Waiting for deletions to finish
2022/11/11 12:16:23 INFO  : test-ken-20221010: Removing directory
2022/11/11 12:16:23 INFO  : peter: Removing directory
2022/11/11 12:16:23 INFO  : S3 bucket test-gigadb-datasets: Removing directory
2022/11/11 12:16:23 ERROR : : Failed to rmdir: AccessDenied: User: arn:aws:iam::100000166496:user/Ken is not authorized to perform: s3:DeleteBucket on resource: arn:aws:s3:::test-gigadb-datasets with an explicit deny
        status code: 403, request id: 24AB2C3C8E47CC5B, host id: 9wXPYMZZ/UC9yhhFmUZ95EDHVZByT8mnAPMzNBeLU4BccRhIy7kKvrwCTr7kUyuAqUHNVc2NO3do
2022/11/11 12:16:23 ERROR : Attempt 1/3 failed with 1 errors and: AccessDenied: User: arn:aws:iam::100000166496:user/Ken is not authorized to perform: s3:DeleteBucket on resource: arn:aws:s3:::test-gigadb-datasets with an explicit deny
        status code: 403, request id: 24AB2C3C8E47CC5B, host id: 9wXPYMZZ/UC9yhhFmUZ95EDHVZByT8mnAPMzNBeLU4BccRhIy7kKvrwCTr7kUyuAqUHNVc2NO3do
2022/11/11 12:16:23 DEBUG : Waiting for deletions to finish
2022/11/11 12:16:23 INFO  : test-ken-20221010: Removing directory
2022/11/11 12:16:23 INFO  : peter: Removing directory
2022/11/11 12:16:23 INFO  : S3 bucket test-gigadb-datasets: Removing directory
2022/11/11 12:16:23 ERROR : : Failed to rmdir: AccessDenied: User: arn:aws:iam::100000166496:user/Ken is not authorized to perform: s3:DeleteBucket on resource: arn:aws:s3:::test-gigadb-datasets with an explicit deny
        status code: 403, request id: 7D7CD48F09909CD2, host id: JAy+4U/i4WLKk4QG+FBIE9Ziraz49T7Ugwesmf9aNtL1cRscCeOtZcX3Y7DRy794MOeS04pGkWSz
2022/11/11 12:16:23 ERROR : Attempt 2/3 failed with 1 errors and: AccessDenied: User: arn:aws:iam::100000166496:user/Ken is not authorized to perform: s3:DeleteBucket on resource: arn:aws:s3:::test-gigadb-datasets with an explicit deny
        status code: 403, request id: 7D7CD48F09909CD2, host id: JAy+4U/i4WLKk4QG+FBIE9Ziraz49T7Ugwesmf9aNtL1cRscCeOtZcX3Y7DRy794MOeS04pGkWSz
2022/11/11 12:16:23 DEBUG : Waiting for deletions to finish
2022/11/11 12:16:23 INFO  : test-ken-20221010: Removing directory
2022/11/11 12:16:23 INFO  : peter: Removing directory
2022/11/11 12:16:23 INFO  : S3 bucket test-gigadb-datasets: Removing directory
2022/11/11 12:16:23 ERROR : : Failed to rmdir: AccessDenied: User: arn:aws:iam::100000166496:user/Ken is not authorized to perform: s3:DeleteBucket on resource: arn:aws:s3:::test-gigadb-datasets with an explicit deny
        status code: 403, request id: 91F37DDA225CB77A, host id: EuRAsCogJUQjurcJV+GfvGsLEH9Vv0wX6BOVfjYh2Qh1nXnGTXWcxEwYDnXWdUoyDgNZl6zjNiyV
2022/11/11 12:16:23 ERROR : Attempt 3/3 failed with 1 errors and: AccessDenied: User: arn:aws:iam::100000166496:user/Ken is not authorized to perform: s3:DeleteBucket on resource: arn:aws:s3:::test-gigadb-datasets with an explicit deny
        status code: 403, request id: 91F37DDA225CB77A, host id: EuRAsCogJUQjurcJV+GfvGsLEH9Vv0wX6BOVfjYh2Qh1nXnGTXWcxEwYDnXWdUoyDgNZl6zjNiyV
2022/11/11 12:16:23 DEBUG : 8 go routines active
2022/11/11 12:16:23 Failed to purge: AccessDenied: User: arn:aws:iam::100000166496:user/Ken is not authorized to perform: s3:DeleteBucket on resource: arn:aws:s3:::test-gigadb-datasets with an explicit deny
        status code: 403, request id: 91F37DDA225CB77A, host id: EuRAsCogJUQjurcJV+GfvGsLEH9Vv0wX6BOVfjYh2Qh1nXnGTXWcxEwYDnXWdUoyDgNZl6zjNiyV
```

### Delete the bucket  or object in `gigadb-datasets` as Systems is not allowed
```
 % rclone purge -vv  wasabiMigration:gigadb-datasets/live/                         
2022/11/11 12:24:29 DEBUG : rclone: Version "v1.59.2" starting with parameters ["rclone" "purge" "-vv" "wasabiMigration:gigadb-datasets/live/"]
2022/11/11 12:24:29 DEBUG : Creating backend with remote "wasabiMigration:gigadb-datasets/live/"
2022/11/11 12:24:29 DEBUG : Using config file from "/Users/kencho/.config/rclone/rclone.conf"
2022/11/11 12:24:29 DEBUG : fs cache: renaming cache item "wasabiMigration:gigadb-datasets/live/" to be canonical "wasabiMigration:gigadb-datasets/live"
2022/11/11 12:24:29 DEBUG : Waiting for deletions to finish
2022/11/11 12:24:29 ERROR : Aldabra_Giant_Tortoise.png: Couldn't delete: AccessDenied: Access Denied
        status code: 403, request id: C351A0E43EAB015E, host id: rNplrvco/OmCP64GLUm8+xAQ79uK46qv0qCjxGs+I4LG60Evt7mST7vFre37xfNBnsUDHzVCiB13
2022/11/11 12:24:29 ERROR : Attempt 1/3 failed with 2 errors and: failed to delete 1 files
2022/11/11 12:24:29 DEBUG : Waiting for deletions to finish
2022/11/11 12:24:29 ERROR : Aldabra_Giant_Tortoise.png: Couldn't delete: AccessDenied: Access Denied
        status code: 403, request id: 61766316DD4AC8CA, host id: EwmTMvbQOBqJMu/ErX59M3vPkBqwcW3aE3pCcf0DIZwWZ/7cLIi/MMBLK/f3pTDhGF3HYiCGKyUQ
2022/11/11 12:24:29 ERROR : Attempt 2/3 failed with 2 errors and: failed to delete 1 files
2022/11/11 12:24:29 DEBUG : Waiting for deletions to finish
2022/11/11 12:24:30 ERROR : Aldabra_Giant_Tortoise.png: Couldn't delete: AccessDenied: Access Denied
        status code: 403, request id: C5E433ECAD3A0133, host id: mdVEWD5SfgVcpUeD90KxPeAWfkU29n1vOJ+rjRN4aJcbLl5MPqRhhE+ppVb1CmElybDjry+gQS2M
2022/11/11 12:24:30 ERROR : Attempt 3/3 failed with 2 errors and: failed to delete 1 files
2022/11/11 12:24:30 DEBUG : 6 go routines active
2022/11/11 12:24:30 Failed to purge with 2 errors: last error was: failed to delete 1 files
% rclone purge -vv  wasabiMigration:gigadb-datasets/staging
2022/11/11 12:24:58 DEBUG : rclone: Version "v1.59.2" starting with parameters ["rclone" "purge" "-vv" "wasabiMigration:gigadb-datasets/staging"]
2022/11/11 12:24:58 DEBUG : Creating backend with remote "wasabiMigration:gigadb-datasets/staging"
2022/11/11 12:24:58 DEBUG : Using config file from "/Users/kencho/.config/rclone/rclone.conf"
2022/11/11 12:24:58 DEBUG : Waiting for deletions to finish
2022/11/11 12:24:58 ERROR : Aldabra_Giant_Tortoise.png: Couldn't delete: AccessDenied: Access Denied
        status code: 403, request id: 0DC2B388A242E9E8, host id: ShuXhzJc2yl7vVJuZjXPGzX/3QgtPq+Wb0BsLMOAGhx46TbuasmdmIh//MHiGciHeoWQmvt1hZEf
2022/11/11 12:24:58 ERROR : Attempt 1/3 failed with 2 errors and: failed to delete 1 files
2022/11/11 12:24:58 DEBUG : Waiting for deletions to finish
2022/11/11 12:24:58 ERROR : Aldabra_Giant_Tortoise.png: Couldn't delete: AccessDenied: Access Denied
        status code: 403, request id: 4AD6108E64369C6F, host id: evOnspV2GEdFe/kzSBVgqUUC/7ZecaN8MrA/Gqljj4v90Vz7Oi0oWx40nmPFNF8wkYelbTIJYLRY
2022/11/11 12:24:58 ERROR : Attempt 2/3 failed with 2 errors and: failed to delete 1 files
2022/11/11 12:24:58 DEBUG : Waiting for deletions to finish
2022/11/11 12:24:59 ERROR : Aldabra_Giant_Tortoise.png: Couldn't delete: AccessDenied: Access Denied
        status code: 403, request id: 429495188D700EAE, host id: 4WlOzk5wGRDhxNe3HFlvme6/J4ic9qWKJHutfsoTe67BBvWsl2emRtwalhM0Warqbb1DiVH/Qk5x
2022/11/11 12:24:59 ERROR : Attempt 3/3 failed with 2 errors and: failed to delete 1 files
2022/11/11 12:24:59 DEBUG : 6 go routines active
2022/11/11 12:24:59 Failed to purge with 2 errors: last error was: failed to delete 1 files
% rclone purge -vv  wasabiMigration:gigadb-datasets
2022/11/11 12:25:15 DEBUG : rclone: Version "v1.59.2" starting with parameters ["rclone" "purge" "-vv" "wasabiMigration:gigadb-datasets"]
2022/11/11 12:25:15 DEBUG : Creating backend with remote "wasabiMigration:gigadb-datasets"
2022/11/11 12:25:15 DEBUG : Using config file from "/Users/kencho/.config/rclone/rclone.conf"
2022/11/11 12:25:15 DEBUG : Waiting for deletions to finish
2022/11/11 12:25:15 ERROR : failed to list: AccessDenied: Access Denied
        status code: 403, request id: 4C60A8C4A324926E, host id: Tfbt7OELS/zzIW6xxnTH4THvucE5qP/BPnU/zmdS9fo6s2Sy8imzQWyGGkSb4TGMZMN3Xqj6k134
2022/11/11 12:25:16 ERROR : S3 bucket gigadb-datasets: Failed to list "CI": AccessDenied: Access Denied
        status code: 403, request id: E43BD62063A4F0E0, host id: 1KJ/sWatogRgWW7WqqxiQTNo16uBBp01q0yjljR6GtLOwgpJS4ncTuBWVbO/17LscRYjT4o5dKaK
2022/11/11 12:25:16 ERROR : S3 bucket gigadb-datasets: Failed to list "dev": AccessDenied: Access Denied
        status code: 403, request id: 6BFFF6845A95DD8A, host id: dvIa4IqgXQ5tPXKIbgnCVd1ig649dVVPIqFXZc1I95LM79imFHEWCHTXXBHQn1VM3IoiBLvJ/bis
2022/11/11 12:25:16 INFO  : dev: Removing directory
2022/11/11 12:25:16 INFO  : CI: Removing directory
2022/11/11 12:25:16 ERROR : Attempt 1/3 failed with 3 errors and: AccessDenied: Access Denied
        status code: 403, request id: 6BFFF6845A95DD8A, host id: dvIa4IqgXQ5tPXKIbgnCVd1ig649dVVPIqFXZc1I95LM79imFHEWCHTXXBHQn1VM3IoiBLvJ/bis
2022/11/11 12:25:16 DEBUG : Waiting for deletions to finish
2022/11/11 12:25:16 ERROR : failed to list: AccessDenied: Access Denied
        status code: 403, request id: 2CE2743373978A81, host id: REojF26MN764QsEbRAw1Liy2SEeLDyuPYgEqEosTTM2n2tX4mWTswpUac+tkt4KPuDKKVjBGeT+8
2022/11/11 12:25:16 ERROR : S3 bucket gigadb-datasets: Failed to list "CI": AccessDenied: Access Denied
        status code: 403, request id: 73FFF56C5DA9E688, host id: xxTh0cDST8okWiUH6HxKFQIJJpdJqFxKn/BeLIEB/DCUa6IDGHnRUmzewwLZ0sMeUxGzB9xB3vEd
2022/11/11 12:25:16 ERROR : S3 bucket gigadb-datasets: Failed to list "dev": AccessDenied: Access Denied
        status code: 403, request id: 2B5ACC59F2D6CAE2, host id: ptBkeUDuSlpKBmj0XezHCyLr/f5U8li1LSzW0L5uAwzxBTSMK6Oj58mVLCckWAGXIlmgBl6ylPNy
2022/11/11 12:25:16 INFO  : dev: Removing directory
2022/11/11 12:25:16 INFO  : CI: Removing directory
2022/11/11 12:25:16 ERROR : Attempt 2/3 failed with 3 errors and: AccessDenied: Access Denied
        status code: 403, request id: 2B5ACC59F2D6CAE2, host id: ptBkeUDuSlpKBmj0XezHCyLr/f5U8li1LSzW0L5uAwzxBTSMK6Oj58mVLCckWAGXIlmgBl6ylPNy
2022/11/11 12:25:16 DEBUG : Waiting for deletions to finish
2022/11/11 12:25:16 ERROR : failed to list: AccessDenied: Access Denied
        status code: 403, request id: A151DE90D2BB1EBC, host id: 1EHIwIOLb58/H/se9nx1cfVAA9+BVlTMI3Av0pETpdMqKo+GlMqOwHAd7PsJqVb87qDmbTVxyrh0
2022/11/11 12:25:16 ERROR : S3 bucket gigadb-datasets: Failed to list "CI": AccessDenied: Access Denied
        status code: 403, request id: C28ECA022A9F930E, host id: ux7dpeVX4Yo38liWuLEMH5NbSX1Cu0lrXFD6wx6MdxDt2lm4Z28FsBOTyEFILipnYsoahlMcAo4n
2022/11/11 12:25:16 ERROR : S3 bucket gigadb-datasets: Failed to list "dev": AccessDenied: Access Denied
        status code: 403, request id: 5174B354D8FB951F, host id: QsuauBCH0mNb4BlGTay01xCKNNRAcdArxq8awGyvWHPXOVWJpFGNmPnRAQQbmxX2ljLBMiyDYySs
2022/11/11 12:25:16 INFO  : dev: Removing directory
2022/11/11 12:25:16 INFO  : CI: Removing directory
2022/11/11 12:25:16 ERROR : Attempt 3/3 failed with 3 errors and: AccessDenied: Access Denied
        status code: 403, request id: 5174B354D8FB951F, host id: QsuauBCH0mNb4BlGTay01xCKNNRAcdArxq8awGyvWHPXOVWJpFGNmPnRAQQbmxX2ljLBMiyDYySs
2022/11/11 12:25:16 DEBUG : 12 go routines active
2022/11/11 12:25:16 Failed to purge with 3 errors: last error was: AccessDenied: Access Denied
        status code: 403, request id: 5174B354D8FB951F, host id: QsuauBCH0mNb4BlGTay01xCKNNRAcdArxq8awGyvWHPXOVWJpFGNmPnRAQQbmxX2ljLBMiyDYySs
```


## Any changes to documentation?
Directory `docs/wasabidocs/` is created to store Wasabi bucket policy.
