### PR TITLE
Hide save current search functionality

### DIFF
--- a/protected/views/search/_search.php
+++ b/protected/views/search/_search.php
@@ -20,11 +20,10 @@
              'value'=>$model->keyword
         ));
           ?>
-            <span class="input-group-btn">
-       <button class="btn background-btn" type="submit">
-                                                <i class="fa fa-search"></i> Search again
-                                            </button>
-    <?
+        <span class="input-group-btn">
+            <button class="btn background-btn" type="submit"><i class="fa fa-search"></i> Search again</button>
+<!--TODO: Will re-implement the save search function in ticket #1168-->
+//    <?
 //        if(!Yii::app()->user->isGuest) {
 //    ?>
 <!--            <input type="button" id="save-search-criteria" class="btn background-btn" value="Save current search criteria"/>-->

--- a/protected/views/search/_search.php
+++ b/protected/views/search/_search.php
@@ -25,12 +25,12 @@
                                                 <i class="fa fa-search"></i> Search again
                                             </button>
     <?
-        if(!Yii::app()->user->isGuest) {
-    ?>
-            <input type="button" id="save-search-criteria" class="btn background-btn" value="Save current search criteria"/>
-    <?
-        }
-    ?>
+//        if(!Yii::app()->user->isGuest) {
+//    ?>
+<!--            <input type="button" id="save-search-criteria" class="btn background-btn" value="Save current search criteria"/>-->
+<!--    --><?//
+//        }
+//    ?>
         </span>
     </div>
 </div>

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -329,4 +329,12 @@ class AcceptanceTester extends \Codeception\Actor
     {
         $this->seeElement('input', ['type' => "button", 'value' => $option]);
     }
+
+    /**
+     * @Then I should not see an option :option
+     */
+    public function iShouldNotSeeAnOption($option)
+    {
+        $this->dontSeeElement('input', ['type' => "button", 'value' => $option]);
+    }
 }

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -321,4 +321,12 @@ class AcceptanceTester extends \Codeception\Actor
         $this->seeInPopup($message);
         $this->acceptPopup();
     }
+
+    /**
+     * @Then I should see an option :option
+     */
+    public function iShouldSeeAnOption($option)
+    {
+        $this->seeElement('input', ['type' => "button", 'value' => $option]);
+    }
 }

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -323,18 +323,18 @@ class AcceptanceTester extends \Codeception\Actor
     }
 
     /**
-     * @Then I should see an option :option
+     * @Then I should see an input button :button
      */
-    public function iShouldSeeAnOption($option)
+    public function iShouldSeeAnInputButton($button)
     {
-        $this->seeElement('input', ['type' => "button", 'value' => $option]);
+        $this->seeElement('input', ['type' => "button", 'value' => $button]);
     }
 
     /**
-     * @Then I should not see an option :option
+     * @Then I should not see an input button :button
      */
-    public function iShouldNotSeeAnOption($option)
+    public function iShouldNotSeeAnInputButton($button)
     {
-        $this->dontSeeElement('input', ['type' => "button", 'value' => $option]);
+        $this->dontSeeElement('input', ['type' => "button", 'value' => $button]);
     }
 }

--- a/tests/acceptance/SearchAuthors.feature
+++ b/tests/acceptance/SearchAuthors.feature
@@ -4,7 +4,7 @@ Feature:
   So that I can have my own search record
 
 
-  @wip @issue-1186
+  @ok @issue-1186
   Scenario: Hide the Save current search criteria option
     Given I sign in as a user
     And I am on "/"
@@ -15,4 +15,4 @@ Feature:
     And I should see a link "Pygoscelis_adeliae.s..." to "https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/Pygoscelis_adeliae.scaf.fa.gz"
     And I should see "Adelie penguin NCBI taxonomy"
     And I should see "Search again"
-    And I should see an option "Save current search criteria"
+    And I should not see an option "Save current search criteria"

--- a/tests/acceptance/SearchAuthors.feature
+++ b/tests/acceptance/SearchAuthors.feature
@@ -1,0 +1,18 @@
+Feature:
+  As an author
+  I want to save keywords from the search bar
+  So that I can have my own search record
+
+
+  @wip @issue-1186
+  Scenario: Hide the Save current search criteria option
+    Given I sign in as a user
+    And I am on "/"
+    And I fill in the field of "id" "keyword" with "penguin"
+    And I press the button "Search"
+    And I wait "1" seconds
+    Then I should see a link "Genomic data from Adelie penguin (Pygoscelis adeliae)." to "/dataset/100006"
+    And I should see a link "Pygoscelis_adeliae.s..." to "https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/Pygoscelis_adeliae.scaf.fa.gz"
+    And I should see "Adelie penguin NCBI taxonomy"
+    And I should see "Search again"
+    And I should see an option "Save current search criteria"

--- a/tests/acceptance/SearchAuthors.feature
+++ b/tests/acceptance/SearchAuthors.feature
@@ -15,4 +15,4 @@ Feature:
     And I should see a link "Pygoscelis_adeliae.s..." to "https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/Pygoscelis_adeliae.scaf.fa.gz"
     And I should see "Adelie penguin NCBI taxonomy"
     And I should see "Search again"
-    And I should not see an option "Save current search criteria"
+    And I should not see an input button "Save current search criteria"


### PR DESCRIPTION
# Pull request for issue: #1168

This is a pull request for the following functionalities:

Hide the `Save current search criteria` option in the search page after logging in as `User`.

## How to test?

##### Manual test
```
% cd gigadb-website
# spin up gigadb website
% ./up.sh
# go to http://gigadb.gigasciencejournal.com:9170/site/login, and log in as `User`
# go to http://gigadb.gigasciencejournal.com:9170/ and search for `penguin`
# in the result page http://gigadb.gigasciencejournal.com:9170/search/new?keyword=penguin, `Save current search criteria` is not found
```
##### Acceptance test
```
% cd gigadb-website
# spin up gigadb website
% ./up.sh
% docker-compose run --rm codecept run --no-redirect acceptance tests/acceptance/SearchAuthors.feature
Creating deployment_codecept_run ... done
Codeception PHP Testing Framework v5.0.4 https://helpukrainewin.org

Acceptance Tests (1) ----------------------------------------------------------------------------------------------------------------------------------
✔ : Hide the Save current search criteria option (6.01s)
-------------------------------------------------------------------------------------------------------------------------------------------------------
Time: 00:17.469, Memory: 10.00 MB

OK (1 test, 5 assertions)
```



## How have functionalities been implemented?
Hide the `save current search criteria` option by commenting the code block. 

## Any issues with implementation?

None.

## Any changes to automated tests?

None.

## Any changes to documentation?

None.

## Any technical debt repayment?

None.

## Any improvements to CI/CD pipeline?

None.
