### PR TITLE
Make gigadb website links to the jobs page

### DIFF
--- a/protected/views/layouts/new_datasetpage.php
+++ b/protected/views/layouts/new_datasetpage.php
@@ -140,6 +140,7 @@
                             <ul class="dropdown-menu">
                                 <li><a href="/site/about">General</a></li>
                                 <li><a href="/site/team">Our team</a></li>
+                                <li><a href="https://jobs.gigasciencejournal.com/">Jobs</a></li>
                                 <li><a href="/site/contact">Contact</a></li>
                                 <li><a href="/site/advisory">Advisory Board</a></li>
                             </ul>

--- a/protected/views/layouts/new_faq.php
+++ b/protected/views/layouts/new_faq.php
@@ -126,6 +126,7 @@
                             <ul class="dropdown-menu">
                                 <li><a href="/site/about">General</a></li>
                                 <li><a href="/site/team">Our team</a></li>
+                                <li><a href="https://jobs.gigasciencejournal.com/">Jobs</a></li>
                                 <li><a href="/site/contact">Contact</a></li>
                                 <li><a href="/site/advisory">Advisory Board</a></li>
                             </ul>

--- a/protected/views/layouts/new_main.php
+++ b/protected/views/layouts/new_main.php
@@ -126,6 +126,7 @@
                             <ul class="dropdown-menu">
                                 <li><a href="/site/about">General</a></li>
                                 <li><a href="/site/team">Our team</a></li>
+                                <li><a href="https://jobs.gigasciencejournal.com/">Jobs</a></li>
                                 <li><a href="/site/contact">Contact</a></li>
                                 <li><a href="/site/advisory">Advisory Board</a></li>
                             </ul>

--- a/tests/acceptance/StaticContentNavigation.feature
+++ b/tests/acceptance/StaticContentNavigation.feature
@@ -9,115 +9,169 @@ Feature: A user visit gigadb website
     Then I should see "GigaDB User Policies"
     And I should not see "<em>GigaDB</em> User Policies"
 
-    @ok @issue-870
-    Scenario: Update dataset types in controlled vocabulary tab
-      When I am on "/site/help#vocabulary"
-      Then I should see "Dataset types"
-      And I should see "Genomic"
-      And I should see "Transcriptomic"
-      And I should see "Epigenomic"
-      And I should see "Metagenomic"
-      And I should see "Metatranscriptomic"
-      And I should see "Genome mapping"
-      And I should see "Imaging"
-      And I should see "Software"
-      And I should see "Virtual-Machine"
-      And I should see "Workflow"
-      And I should see "Metabolomic"
-      And I should see "Proteomic"
-      And I should see "Lipidomic"
-      And I should see "Metabarcoding"
-      And I should see "Metadata"
-      And I should see "Network-Analysis"
-      And I should see "Neuroscience"
-      And I should see "Electro-encephalography (EEG)"
-      And I should see "Phenotyping"
-      And I should see "Ecology"
-      And I should see "Climate"
-      And I should see "Additional dataset types can be added, upon review, as new submissions are received."
+  @ok @issue-870
+  Scenario: Update dataset types in controlled vocabulary tab
+    When I am on "/site/help#vocabulary"
+    Then I should see "Dataset types"
+    And I should see "Genomic"
+    And I should see "Transcriptomic"
+    And I should see "Epigenomic"
+    And I should see "Metagenomic"
+    And I should see "Metatranscriptomic"
+    And I should see "Genome mapping"
+    And I should see "Imaging"
+    And I should see "Software"
+    And I should see "Virtual-Machine"
+    And I should see "Workflow"
+    And I should see "Metabolomic"
+    And I should see "Proteomic"
+    And I should see "Lipidomic"
+    And I should see "Metabarcoding"
+    And I should see "Metadata"
+    And I should see "Network-Analysis"
+    And I should see "Neuroscience"
+    And I should see "Electro-encephalography (EEG)"
+    And I should see "Phenotyping"
+    And I should see "Ecology"
+    And I should see "Climate"
+    And I should see "Additional dataset types can be added, upon review, as new submissions are received."
 
-    @ok @issue-871
-    Scenario: The anchor tag in working for GigaDB search tab
-      Given I am on "/site/help"
-      When I go to a page tab "/site/help#search"
-      Then I should see "Search operation"
-      And I should see "Search result"
-      And I should see "Filtering result"
+  @ok @issue-871
+  Scenario: The anchor tag in working for GigaDB search tab
+    Given I am on "/site/help"
+    When I go to a page tab "/site/help#search"
+    Then I should see "Search operation"
+    And I should see "Search result"
+    And I should see "Filtering result"
 
-    @ok @issue-871
-    Scenario: The anchor tag in working for submission guidelines tab
-      Given I am on "/site/help"
-      When I go to a page tab "/site/help#guidelines"
-      Then I should see "Mandatory fields are highlighted in yellow."
-      And I should see "Study"
-      And I should see "Samples"
-      And I should see "Files"
+  @ok @issue-871
+  Scenario: The anchor tag in working for submission guidelines tab
+    Given I am on "/site/help"
+    When I go to a page tab "/site/help#guidelines"
+    Then I should see "Mandatory fields are highlighted in yellow."
+    And I should see "Study"
+    And I should see "Samples"
+    And I should see "Files"
 
-    @ok @issue-871
-    Scenario: The anchor tag is working for controlled vocabulary tab
-      Given I am on "/site/help"
-      When I go to a page tab "/site/help#vocabulary"
-      Then I should see "Dataset types"
-      And I should see "File types"
-      And I should see "File formats"
-      And I should see "Upload status"
-      And I should see "DOI relationship"
-      And I should see "Missing Value reporting"
+  @ok @issue-871
+  Scenario: The anchor tag is working for controlled vocabulary tab
+    Given I am on "/site/help"
+    When I go to a page tab "/site/help#vocabulary"
+    Then I should see "Dataset types"
+    And I should see "File types"
+    And I should see "File formats"
+    And I should see "Upload status"
+    And I should see "DOI relationship"
+    And I should see "Missing Value reporting"
 
-    @ok @issue-871
-    Scenario: The anchor tag is working for Application programming interface
-      Given I am on "/site/help"
-      When I go to a page tab "/site/help#interface"
-      Then I should see "Availability"
-      And I should see "Comments and Bug reporting"
-      And I should see "Summary"
-      And I should see "Terminology"
-      And I should see "Examples"
-      And I should see "Command line usage"
+  @ok @issue-871
+  Scenario: The anchor tag is working for Application programming interface
+    Given I am on "/site/help"
+    When I go to a page tab "/site/help#interface"
+    Then I should see "Availability"
+    And I should see "Comments and Bug reporting"
+    And I should see "Summary"
+    And I should see "Terminology"
+    And I should see "Examples"
+    And I should see "Command line usage"
 
-    @ok @issue-872
-    Scenario: Scroll bar is found in tables in guide page
-      When I am on "/site/guide"
-      Then I should see an element has id "table_guide_submission" with class "scrollbar"
-      And I should see an element has id "table_guide_attribute" with class "scrollbar"
-      And I should see an element has id "table_guide_details" with class "scrollbar"
+  @ok @issue-872
+  Scenario: Scroll bar is found in tables in guide page
+    When I am on "/site/guide"
+    Then I should see an element has id "table_guide_submission" with class "scrollbar"
+    And I should see an element has id "table_guide_attribute" with class "scrollbar"
+    And I should see an element has id "table_guide_details" with class "scrollbar"
 
-    @ok @issue-872
-    Scenario: Scroll bar is found in tables in genomic page
-      When I am on "/site/guidegenomic"
-      Then I should see an element has id "table_genomic_format" with class "scrollbar"
-      And I should see an element has id "table_transcriptomic" with class "scrollbar"
-      And I should see an element has id "table_genomic_meta" with class "scrollbar"
+  @ok @issue-872
+  Scenario: Scroll bar is found in tables in genomic page
+    When I am on "/site/guidegenomic"
+    Then I should see an element has id "table_genomic_format" with class "scrollbar"
+    And I should see an element has id "table_transcriptomic" with class "scrollbar"
+    And I should see an element has id "table_genomic_meta" with class "scrollbar"
 
-    @ok @issue-872
-    Scenario: Scroll bar is found in tables in imaging page
-      When I am on "/site/guideimaging"
-      Then I should see an element has id "table_imaging_format" with class "scrollbar"
-      And I should see an element has id "table_imaging_attribute" with class "scrollbar"
-      And I should see an element has id "table_imaging_meta" with class "scrollbar"
+  @ok @issue-872
+  Scenario: Scroll bar is found in tables in imaging page
+    When I am on "/site/guideimaging"
+    Then I should see an element has id "table_imaging_format" with class "scrollbar"
+    And I should see an element has id "table_imaging_attribute" with class "scrollbar"
+    And I should see an element has id "table_imaging_meta" with class "scrollbar"
 
-    @ok @issue-872
-    Scenario: Scroll bar is found in tables in metabolomic page
-      When I am on "/site/guidemetabolomic"
-      Then I should see an element has id "table_metabolomic_data" with class "scrollbar"
-      And I should see an element has id "table_metabolomic_meta" with class "scrollbar"
+  @ok @issue-872
+  Scenario: Scroll bar is found in tables in metabolomic page
+    When I am on "/site/guidemetabolomic"
+    Then I should see an element has id "table_metabolomic_data" with class "scrollbar"
+    And I should see an element has id "table_metabolomic_meta" with class "scrollbar"
 
 
-    @ok @issue-872
-    Scenario: Scroll bar is found in tables in epigenomic page
-      When I am on "/site/guideepigenomic"
-      Then I should see an element has id "table_epigenomic_format" with class "scrollbar"
-      And I should see an element has id "table_epigenomic_meta" with class "scrollbar"
+  @ok @issue-872
+  Scenario: Scroll bar is found in tables in epigenomic page
+    When I am on "/site/guideepigenomic"
+    Then I should see an element has id "table_epigenomic_format" with class "scrollbar"
+    And I should see an element has id "table_epigenomic_meta" with class "scrollbar"
 
-    @ok @issue-872
-    Scenario: Scroll bar is found in tables in metagenomic page
-      When I am on "/site/guidemetagenomic"
-      Then I should see an element has id "table_metagenomic_format" with class "scrollbar"
-      And I should see an element has id "table_metatranscriptomic" with class "scrollbar"
-      And I should see an element has id "table_metagenomic_meta" with class "scrollbar"
+  @ok @issue-872
+  Scenario: Scroll bar is found in tables in metagenomic page
+    When I am on "/site/guidemetagenomic"
+    Then I should see an element has id "table_metagenomic_format" with class "scrollbar"
+    And I should see an element has id "table_metatranscriptomic" with class "scrollbar"
+    And I should see an element has id "table_metagenomic_meta" with class "scrollbar"
 
-    @ok @issue-872
-    Scenario: Scroll bar is found in tables in software page
-      When I am on "/site/guidesoftware"
-      Then I should see an element has id "table_software_format" with class "scrollbar"
-      And I should see an element has id "table_software_dataset" with class "scrollbar"
+  @ok @issue-872
+  Scenario: Scroll bar is found in tables in software page
+    When I am on "/site/guidesoftware"
+    Then I should see an element has id "table_software_format" with class "scrollbar"
+    And I should see an element has id "table_software_dataset" with class "scrollbar"
+
+  @ok @spike
+  Scenario: Jobs could be found in the About dropdown box in the main page
+    When I am on "/index.php"
+    And I press the button "About"
+    Then I should see "General"
+    And I should see "Our team"
+    And I should see "Jobs"
+    And I should see "Contact"
+    And I should see "Advisory Board"
+
+  @ok @spike
+  Scenario: Go to the Jobs page from the main page
+    When I am on "/index.php"
+    And I press the button "About"
+    And I press the button "Jobs"
+    Then I should see "Jobs at GigaScience"
+    And I am on "https://jobs.gigasciencejournal.com/"
+
+  @ok @spike
+  Scenario: Jobs could be found in the About dropdown box in the faq page
+    When I am on "/site/faq"
+    And I press the button "About"
+    Then I should see "General"
+    And I should see "Our team"
+    And I should see "Jobs"
+    And I should see "Contact"
+    And I should see "Advisory Board"
+
+  @ok @spike
+  Scenario: Go to the Jobs page from the faq page
+    When I am on "/site/faq"
+    And I press the button "About"
+    And I press the button "Jobs"
+    Then I should see "Jobs at GigaScience"
+    And I am on "https://jobs.gigasciencejournal.com/"
+
+  @ok @spike
+  Scenario: Jobs could be found in the About dropdown box in the dataset page
+    When I am on "/dataset/100006"
+    And I press the button "About"
+    Then I should see "General"
+    And I should see "Our team"
+    And I should see "Jobs"
+    And I should see "Contact"
+    And I should see "Advisory Board"
+
+  @ok @spike
+  Scenario: Go to the Jobs page from the dataset page
+    When I am on "/dataset/100006"
+    And I press the button "About"
+    And I press the button "Jobs"
+    Then I should see "Jobs at GigaScience"
+    And I am on "https://jobs.gigasciencejournal.com/"


### PR DESCRIPTION
This is a pull request for the following functionalities:

1. Created `Jobs` in the About dropdown box
2. Attached link to the `Jobs`

## How to test?
```
% docker-compose run --rm codecept run --no-redirect -g spike acceptance -v  
Creating deployment_codecept_run ... done
Codeception PHP Testing Framework v5.0.4 https://helpukrainewin.org
[Groups] spike 

Acceptance Tests (6) -----------------------------------------------------------------------------------------------------------------------------------
Modules: \Helper\Acceptance, Asserts, Db, WebDriver
--------------------------------------------------------------------------------------------------------------------------------------------------------
✔ A user visit gigadb website: Jobs could be found in the About dropdown box in the main page (2.85s)
✔ A user visit gigadb website: Go to the Jobs page from the main page (2.41s)
✔ A user visit gigadb website: Jobs could be found in the About dropdown box in the faq page (1.83s)
✔ A user visit gigadb website: Go to the Jobs page from the faq page (1.38s)
✔ A user visit gigadb website: Jobs could be found in the About dropdown box in the dataset page (19.46s)
✔ A user visit gigadb website: Go to the Jobs page from the dataset page (18.88s)
--------------------------------------------------------------------------------------------------------------------------------------------------------
Time: 01:30.732, Memory: 12.00 MB

OK (6 tests, 18 assertions)
```

Describe how the new functionalities can be tested by PR reviewers

## How have functionalities been implemented?

In main page, dataset page and faq page:
1. Created the `Jobs` in the About dropdown box
2. Attached link (https://jobs.gigasciencejournal.com/) to the `Jobs`



## Any issues with implementation?

Due to the legacy problem, `Jobs` in the About dropdown box needs to be implemented in the main page, dataset page and faq page, so the acceptance needs to cover these scenarios as well.

## Any changes to automated tests?

None.

## Any changes to documentation?

None.

## Any technical debt repayment?

None.

## Any improvements to CI/CD pipeline?

None.
