### PR TITLE
Fix migration tool

### DIFF
--- a/gigadb/app/tools/wasabi-migration/rclone_copy.sh
+++ b/gigadb/app/tools/wasabi-migration/rclone_copy.sh
@@ -69,7 +69,7 @@ while [[ $# -gt 0 ]]; do
         if [ "$HOST_HOSTNAME" == "cngb-gigadb-bak" ];
         then
             # Use path to the mounted real data on backup server
-            SOURCE_PATH="/data/gigadb/pub/10.5524"
+            SOURCE_PATH="/live-data/gigadb/pub/10.5524"
             # And copy to live directory on Wasabi if on backup server
             DESTINATION_PATH="wasabi:gigadb-datasets/live/pub/10.5524"
             echo "$(date +'%Y/%m/%d %H:%M:%S') INFO  : Updated paths to data for CNGB backup server" >> "$LOGFILE"

--- a/gigadb/app/tools/wasabi-migration/rclone_copy.sh
+++ b/gigadb/app/tools/wasabi-migration/rclone_copy.sh
@@ -69,7 +69,7 @@ while [[ $# -gt 0 ]]; do
         if [ "$HOST_HOSTNAME" == "cngb-gigadb-bak" ];
         then
             # Use path to the mounted real data on backup server
-            SOURCE_PATH="/live-data/gigadb/pub/10.5524"
+            SOURCE_PATH="/data/gigadb/pub/10.5524"
             # And copy to live directory on Wasabi if on backup server
             DESTINATION_PATH="wasabi:gigadb-datasets/live/pub/10.5524"
             echo "$(date +'%Y/%m/%d %H:%M:%S') INFO  : Updated paths to data for CNGB backup server" >> "$LOGFILE"
@@ -121,7 +121,8 @@ do
     destination_dataset_path="${DESTINATION_PATH}/${dir_range}/${current_doi}"
 
     # Check directory for current DOI exists
-    if [ -d "$source_dataset_path" ]; then
+    if [ -d "$source_dataset_path" ];
+    then
         echo "$(date +'%Y/%m/%d %H:%M:%S') DEBUG  : Found directory $source_dataset_path" >> "$LOGFILE"
         echo "$(date +'%Y/%m/%d %H:%M:%S') INFO  : Attempting to copy dataset ${current_doi} to ${destination_dataset_path}"  >> "$LOGFILE"
 
@@ -142,6 +143,8 @@ do
         else 
             echo "$(date +'%Y/%m/%d %H:%M:%S') ERROR  : Problem with copying files to Wasabi - rclone has exit code: $rclone_exit_code" >> "$LOGFILE"
         fi
+    else
+        echo "$(date +'%Y/%m/%d %H:%M:%S') DEBUG  : Could not find directory $source_dataset_path" >> "$LOGFILE"
     fi
 
     # Increment current DOI

--- a/gigadb/app/tools/wasabi-migration/rclone_copy.sh
+++ b/gigadb/app/tools/wasabi-migration/rclone_copy.sh
@@ -102,10 +102,10 @@ fi
 if [ "$starting_doi" -lt 101000 ];
 then
     dir_range="100001_101000"
-elif [ "$starting_doi" -lt 102000 ] && [ "$starting_doi" -gt 101001 ];
+elif [ "$starting_doi" -lt 102001 ] && [ "$starting_doi" -gt 101000 ];
 then
     dir_range="101001_102000"
-elif [ "$starting_doi" -lt 103000 ] && [ "$starting_doi" -gt 102001 ];
+elif [ "$starting_doi" -lt 103001 ] && [ "$starting_doi" -gt 102000 ];
 then
     dir_range="102001_103000"
 fi

--- a/gigadb/app/tools/wasabi-migration/rclone_copy.sh
+++ b/gigadb/app/tools/wasabi-migration/rclone_copy.sh
@@ -96,11 +96,11 @@ if [ "$batch_size" -gt "$max_batch_size" ]; then
 fi
 
 # Determine DOI range directory to use based on starting DOI
-if [ "$starting_doi" -lt 101000 ]; then
+if [ "$starting_doi" -le 101000 ]; then
     dir_range="100001_101000"
-elif [ "$starting_doi" -lt 102001 ] && [ "$starting_doi" -gt 101000 ]; then
+elif [ "$starting_doi" -le 102000 ] && [ "$starting_doi" -ge 101001 ]; then
     dir_range="101001_102000"
-elif [ "$starting_doi" -lt 103001 ] && [ "$starting_doi" -gt 102000 ]; then
+elif [ "$starting_doi" -le 103000 ] && [ "$starting_doi" -ge 102001 ]; then
     dir_range="102001_103000"
 fi
 

--- a/gigadb/app/tools/wasabi-migration/rclone_copy.sh
+++ b/gigadb/app/tools/wasabi-migration/rclone_copy.sh
@@ -32,8 +32,7 @@ max_batch_size=100
 
 # If we're on the backup server then source proxy settings to perform 
 # data transfer as determined by its expected hostname
-if [ "$HOST_HOSTNAME" == "cngb-gigadb-bak" ];
-then
+if [ "$HOST_HOSTNAME" == "cngb-gigadb-bak" ]; then
     source "$APP_SOURCE/proxy_settings.sh" || exit 1
     echo "$(date +'%Y/%m/%d %H:%M:%S') DEBUG  : Sourced proxy settings for CNGB backup server" >> "$LOGFILE"
     # Also update destination to staging directory to 
@@ -66,8 +65,7 @@ while [[ $# -gt 0 ]]; do
     # to live directory in Wasabi
     --use-live-data)
         # Ensure we are on backup server otherwise there is no access to live data
-        if [ "$HOST_HOSTNAME" == "cngb-gigadb-bak" ];
-        then
+        if [ "$HOST_HOSTNAME" == "cngb-gigadb-bak" ]; then
             # Use path to the mounted real data on backup server
             SOURCE_PATH="/live-data/gigadb/pub/10.5524"
             # And copy to live directory on Wasabi if on backup server
@@ -92,21 +90,17 @@ echo "$(date +'%Y/%m/%d %H:%M:%S') INFO  : Ending DOI is: $ending_doi" >> "$LOGF
 
 # Check batch size between DOIs
 batch_size="$(($ending_doi-$starting_doi))"
-if [ "$batch_size" -gt "$max_batch_size" ];
-then
+if [ "$batch_size" -gt "$max_batch_size" ]; then
     echo "$(date +'%Y/%m/%d %H:%M:%S') ERROR  : Batch size is more than $max_batch_size - please reduce size of batch to copy!" >> "$LOGFILE"
     exit
 fi
 
 # Determine DOI range directory to use based on starting DOI
-if [ "$starting_doi" -lt 101000 ];
-then
+if [ "$starting_doi" -lt 101000 ]; then
     dir_range="100001_101000"
-elif [ "$starting_doi" -lt 102001 ] && [ "$starting_doi" -gt 101000 ];
-then
+elif [ "$starting_doi" -lt 102001 ] && [ "$starting_doi" -gt 101000 ]; then
     dir_range="101001_102000"
-elif [ "$starting_doi" -lt 103001 ] && [ "$starting_doi" -gt 102000 ];
-then
+elif [ "$starting_doi" -lt 103001 ] && [ "$starting_doi" -gt 102000 ]; then
     dir_range="102001_103000"
 fi
 
@@ -121,8 +115,7 @@ do
     destination_dataset_path="${DESTINATION_PATH}/${dir_range}/${current_doi}"
 
     # Check directory for current DOI exists
-    if [ -d "$source_dataset_path" ];
-    then
+    if [ -d "$source_dataset_path" ]; then
         echo "$(date +'%Y/%m/%d %H:%M:%S') DEBUG  : Found directory $source_dataset_path" >> "$LOGFILE"
         echo "$(date +'%Y/%m/%d %H:%M:%S') INFO  : Attempting to copy dataset ${current_doi} to ${destination_dataset_path}"  >> "$LOGFILE"
 
@@ -137,8 +130,7 @@ do
 
         # Check exit code for rclone command
         rclone_exit_code=$?
-        if [ $rclone_exit_code -eq 0 ]
-        then 
+        if [ $rclone_exit_code -eq 0 ]; then
             echo "$(date +'%Y/%m/%d %H:%M:%S') INFO  : Successfully copied files to Wasabi for DOI: $current_doi" >> "$LOGFILE"
         else 
             echo "$(date +'%Y/%m/%d %H:%M:%S') ERROR  : Problem with copying files to Wasabi - rclone has exit code: $rclone_exit_code" >> "$LOGFILE"

--- a/gigadb/app/tools/wasabi-migration/rclone_copy.sh
+++ b/gigadb/app/tools/wasabi-migration/rclone_copy.sh
@@ -106,7 +106,7 @@ fi
 
 # Copy dataset files for all DOIs between starting and ending DOIs
 current_doi="$starting_doi"
-while [ "$current_doi" -lt "$ending_doi" ] || [ "$current_doi" -eq "$ending_doi" ]
+while [ "$current_doi" -le "$ending_doi" ]
 do
     echo "$(date +'%Y/%m/%d %H:%M:%S') INFO  : Assessing DOI: $current_doi" >> "$LOGFILE"
   


### PR DESCRIPTION
# Pull request for issue: #1204

This is a pull request for the following functionalities:

* Fix rclone_copy.sh script so that correct directory range is used when creating directory paths to datasets

## How to test?

See SOP [WASABI_DATA_MIGRATION.md](https://github.com/pli888/gigadb-website/blob/fix-migration-tool/docs/sop/WASABI_DATA_MIGRATION.md).

## How have functionalities been implemented?

The conditions in the conditional statement in rclone_copy.sh script have been corrected based on latest batch upload command that failed:
```
nohup ./migrate.sh 102001 102100 101 true &
```

The above batch upload command is now working based on its log:
```
2023/02/15 14:36:01 DEBUG  : Sourced proxy settings for CNGB backup server
2023/02/15 14:36:01 INFO  : Updated paths to data for CNGB backup server
2023/02/15 14:36:01 DEBUG  : Begin new batch migration to Wasabi
2023/02/15 14:36:01 INFO  : Starting DOI is: 102001
2023/02/15 14:36:01 INFO  : Ending DOI is: 102100
2023/02/15 14:36:01 INFO  : Assessing DOI: 102001
2023/02/15 14:36:02 DEBUG  : Found directory /live-data/gigadb/pub/10.5524/102001_103000/102001
2023/02/15 14:36:02 INFO  : Attempting to copy dataset 102001 to wasabi:gigadb-datasets/live/pub/10.5524/102001_103000/102001
2023/02/15 14:36:52 INFO  : DSC_4553.JPG: Copied (new)
2023/02/15 14:36:53 INFO  : DSC_4551.JPG: Copied (new)
2023/02/15 14:36:58 INFO  : DSC_4552.JPG: Copied (new)
2023/02/15 14:37:14 INFO  : DSC_4554.JPG: Copied (new)
2023/02/15 14:37:21 INFO  : DSC_4555.JPG: Copied (new)
2023/02/15 14:37:28 INFO  : DSC_4556.JPG: Copied (new)
2023/02/15 14:37:30 INFO  : HCNGB_00002292.JPG: Copied (new)
2023/02/15 14:37:30 INFO  : Successfully copied files to Wasabi for DOI: 102001
```

The rclone_copy.sh script now also reports the directory path if a dataset could not be found.

