### PR TITLE
Replace the gitter tokens with the Matrix's one

### DIFF
--- a/gigadb/app/tools/wasabi-migration/README.md
+++ b/gigadb/app/tools/wasabi-migration/README.md
@@ -20,14 +20,16 @@ to access Wasabi buckets.
 
 To enable the notification feature, the following credentials are also required:
 
-| Variable | Options | Environment | Value               |
-| -------- | ------- | ----------- |---------------------|
-| GITTER_API_TOKEN | Masked | All | Gitter api token    |
-| GITTER_IT_NOTIFICATION_ROOM_ID | Masked | All | Gitter chat room id |
+| Variable                       | Options | Environment | Value                  |
+|--------------------------------|--------|-------------|------------------------|
+| MATRIX_HOMESERVER              | ------- | All         | Matrix home server     |
+| MATRIX_TOKEN                   | Masked | All         | Matrix api token       |
+| MATRIX_IT_NOTIFICATION_ROOM_ID | Masked | All         | Matrix IT chat room id |
 
-Both `GITTER_API_TOKEN` and `GITTER_IT_NOTIFICATION_ROOM_ID` have been 
-defined in the `Forks` sub-group so, as a developer, there is no need to create
-these two variables.
+Both `MATRIX_HOMESERVER  `, `MATRIX_TOKEN` and `MATRIX_IT_NOTIFICATION_ROOM_ID` have been 
+defined in the `cngb-infra` sub-group so, as a developer, there is no need to create
+these three variables. Additional information, the `MATRIX_TOKEN` is for the user `gigatech23`,
+a specific user account for the tech team testing.
 
 ## Using migration tool on dev environment
 

--- a/gigadb/app/tools/wasabi-migration/generate_config.sh
+++ b/gigadb/app/tools/wasabi-migration/generate_config.sh
@@ -46,7 +46,7 @@ if ! [ -s ./.secrets ];then
     cat .project_vars.json | jq --arg ENVIRONMENT $GIGADB_ENV -r '.[] | select(.environment_scope == "*" or .environment_scope == "dev" ) | select(.key | test("private_key|tlsauth|ca|pem|cert";"i") | not ) |.key + "=" + .value' > .project_var
 
     echo "Retrieving variables from ${MISC_VARIABLES_URL}"
-    curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${MISC_VARIABLES_URL}?per_page=100" | jq --arg ENVIRONMENT $GIGADB_ENV -r '.[] | select(.environment_scope == "*" or .environment_scope == $ENVIRONMENT ) | select(.key | test("sftp_|GITTER_") ) | .key + "=" + .value' > .misc_var
+    curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${MISC_VARIABLES_URL}?per_page=100" | jq --arg ENVIRONMENT $GIGADB_ENV -r '.[] | select(.environment_scope == "*" or .environment_scope == $ENVIRONMENT ) | select(.key | test("sftp_|MATRIX_") ) | .key + "=" + .value' > .misc_var
 
     # Need to account for the fact that there is no .fork_var when dealing with
     # upstream configuration. An error will be generated if we try to cat a

--- a/gigadb/app/tools/wasabi-migration/send_notification.sh
+++ b/gigadb/app/tools/wasabi-migration/send_notification.sh
@@ -3,20 +3,22 @@
 source "/app/.secrets"
 
 serverName=$(uname -a | cut -f2 -d' ')
+transactionId=`date +%s`
+url="/_matrix/client/r0/rooms/$MATRIX_IT_NOTIFICATION_ROOM_ID/send/m.room.message/$transactionId"
 
 # If on backup server then source proxy settings and send notification
 if [ "$HOST_HOSTNAME" == "cngb-gigadb-bak" ];
 then
   source "/app/proxy_settings.sh" || exit 1
 
-  curl -X POST -i -H "Content-Type: application/json" \
+  curl -X PUT -i -H "Content-Type: application/json" \
     -H "Accept: application/json" \
-    -H "Authorization: Bearer $GITTER_API_TOKEN" "https://api.gitter.im/v1/rooms/$GITTER_IT_NOTIFICATION_ROOM_ID/chatMessages" \
-    -d '{"text":"***CNGB BACKUP SERVER*** : '"$1"'"}'
+    -H "Authorization: Bearer $MATRIX_TOKEN" \
+    -d '{"body":"***CNGB BACKUP SERVER*** : '"$1"'", "msgtype":"m.text"}' "${MATRIX_HOMESERVER}${url}"
 else
   # Rclone Docker container wants to send Gitter notification message
-  curl -X POST -i -H "Content-Type: application/json" \
+  curl -X PUT -i -H "Content-Type: application/json" \
     -H "Accept: application/json" \
-    -H "Authorization: Bearer $GITTER_API_TOKEN" "https://api.gitter.im/v1/rooms/$GITTER_IT_NOTIFICATION_ROOM_ID/chatMessages" \
-    -d '{"text":"(Drill) ***rclone.docker*** : '"$1"'"}'
+    -H "Authorization: Bearer $MATRIX_TOKEN" \
+    -d '{"body":"(Drill) ***rclone.docker*** : '"$1"'", "msgtype":"m.text"}' "${MATRIX_HOMESERVER}${url}"
 fi


### PR DESCRIPTION
# Pull request for issue: #1206

This is a pull request for the following functionalities:

Gitter has been acquired by Matrix, and sending message to the gitter room has to follow the Matrix's API, here is its [doc](https://spec.matrix.org/v1.3/client-server-api/)

## How to test?

Describe how the new functionalities can be tested by PR reviewers

```
# In local dev
% cd gigadb/app/tools/wasabi-migration
# remove old secrets file
% rm .secretes
# get the latest secrets file
% docker-compose run --rm config
# 
% ./migrate.sh 100001 100320 100 true                                                                                                                  
Starting wasabi-migration_swatchdog_1 ... done
Creating wasabi-migration_rclone_run ... done
Stopping wasabi-migration_swatchdog_1 ... done
# check the error message if sent to IT Notification room from user gigatech23, for example:
```
<img width="824" alt="image" src="https://user-images.githubusercontent.com/64770635/220042566-59ad84c3-8755-4fa4-9cee-b5ee677eafee.png">

```
# Build the image, save and copy to the CNGB backup server according to [here](https://github.com/pli888/gigadb-website/blob/develop/docs/sop/WASABI_DATA_MIGRATION.md#images)
# Log into CNGB backup server
# Follow the [steps](https://github.com/pli888/gigadb-website/blob/develop/docs/sop/WASABI_DATA_MIGRATION.md#using-migratesh-to-start-swatchdog-and-data-migration-process) to test the updated tokens
[gigadb@cngb-gigadb-bak wasabi-migration]$ ./migrate.sh 100001 100320 100 true  
Starting wasabi-migration_swatchdog_cngb_1 ... done
Stopping wasabi-migration_swatchdog_cngb_1 ... done
# check the error message if sent to IT Notification room from user gigatech23, for example:
```
<img width="821" alt="image" src="https://user-images.githubusercontent.com/64770635/220556134-c38227ff-36eb-4d3f-a83f-f990f9578247.png">


## How have functionalities been implemented?

Get a new set of tokens `MATRIX_HOMESERVER`, `MATRIX_TOKEN` and `MATRIX_IT_NOTIFICATION_ROOM_ID` after logging in as user `gigatech23`.
These tokens have been stored into the gitlab variables of the `cngb-infra` sub group. 

## Any issues with implementation?

The `MATRIX_TOKEN` of a particular user would be expired after logging out. 

## Any changes to automated tests?

Describe any automated tests that have been developed for the new 
functionalities

## Any changes to documentation?

Updated the variables in the README.

## Any technical debt repayment?

Describe changes to code that repays any technical debt

## Any improvements to CI/CD pipeline?

Describe any improvements to the Gitlab pipeline
