### PR TITLE
Documentation for copying files from author drop box bucket to live data bucket

### DIFF
--- a/docs/wasabidocs/AllowFullAccessOnAuthorBuckets.json
+++ b/docs/wasabidocs/AllowFullAccessOnAuthorBuckets.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::bucket-giga-d-*",
+        "arn:aws:s3:::bucket-giga-d-*/*"
+      ]
+    }
+  ]
+}

--- a/docs/wasabidocs/WASABI_USER_DROPBOXES.md
+++ b/docs/wasabidocs/WASABI_USER_DROPBOXES.md
@@ -195,7 +195,7 @@ the dataset in the live section of the `gigadb-datasets` bucket.
 Use [rclone copy](https://rclone.org/commands/rclone_copy/) to copy author's 
 dataset files into the newly created directory. For example:
 ```
-$ $ rclone copy wasabi:bucket-giga-d-23-00123/ wasabi:gigadb-datasets/live/pub/10.5524/102001_103000/102304/
+$ rclone copy wasabi:bucket-giga-d-23-00123/ wasabi:gigadb-datasets/live/pub/10.5524/102001_103000/102304/
 ```
 
 > Where `102304` is the new DOI directory for the dataset.

--- a/docs/wasabidocs/WASABI_USER_DROPBOXES.md
+++ b/docs/wasabidocs/WASABI_USER_DROPBOXES.md
@@ -153,4 +153,49 @@ bucket or directory using dropdown menus.
 
 The setup of the 100 plus user drop boxes can be [automated](https://wasabi-support.zendesk.com/hc/en-us/articles/360057225472).
 
-## 
+## Copy files from author bucket to live directory in gigadb-datasets bucket
+
+Rclone can be used to transfer files from an author's drop box to the live
+storage area in the `gigadb-datasets` bucket.
+
+### Install Rclone
+
+See https://rclone.org/install/ for instructions to install rclone command line
+tool.
+
+### Create rclone configuration to access Wasabi buckets
+
+You should already have a Wasabi access key and secret access key for your user
+account in Wasabi. With the [config](https://rclone.org/commands/rclone_config/)
+tool in rclone to create a configuration to access the GigaDB buckets in Wasabi:
+```
+$ rclone config
+```
+
+You will be asked to provide answers to a series of questions which will result
+in a configuration similar to this:
+```
+[wasabi]
+type = s3
+provider = Wasabi
+access_key_id = A23KJH9DUMMYKJHKAAAAA
+secret_access_key = dlakgalkkgj344DUMMYdfakjaklg
+endpoint = s3.ap-northeast-1.wasabisys.com
+acl = public-read
+```
+
+### Copy procedure
+
+Using the Wasabi web console, create a new directory named by the DOI number for
+the dataset in the live section of the `gigadb-datasets` bucket.
+
+> Currently, it is [not possible](https://forum.rclone.org/t/on-s3-rclone-should-create-persistent-empty-folders/16228/2)
+> to create the new directory in Wasabi using rclone.
+
+Use [rclone copy](https://rclone.org/commands/rclone_copy/) to copy author's 
+dataset files into the newly created directory. For example:
+```
+$ $ rclone copy wasabi:bucket-giga-d-23-00123/ wasabi:gigadb-datasets/live/pub/10.5524/102001_103000/102304/
+```
+
+> Where `102304` is the new DOI directory for the dataset.


### PR DESCRIPTION
# Pull request for issue: #1260 

This is a pull request for the following functionalities:

* Documentation for using rclone to copy files from an author drop box bucket to the live data bucket

## How to test?

Credentials for the `Chris` user have been shared in the team Gitter channel. This `Chris` user is a member of the `Curators` group in the test Wasabi account that has been set up using the test_AT_gigasciencejournal.com email account. The `Curators` group is attached with the `AllowFullAccessOnAuthorBuckets` policy which provides its users with full access to authors' buckets.

To test rclone's ability to copy files from an author drop box to the live data directory in the `dbgiga-datasets` bucket directory, follow the instructions in [WASABI_USER_DROPBOXES.md](https://github.com/pli888/gigadb-website/blob/wasabi-dropboxes/docs/wasabidocs/WASABI_USER_DROPBOXES.md#copy-files-from-author-bucket-to-live-directory-in-gigadb-datasets-bucket) for installing Rclone and creating a configuration to access the `Chris` user Wasabi account. You will need to provide the Wasabi credential's for the `Chris` user.

Execute the following command to copy files from the `bucket-giga-d-23-00123` author bucket to the live data bucket in 102304 directory:
```
$ rclone copy wasabi:bucket-giga-d-23-00123/ wasabi:dbgiga-datasets/live/pub/10.5524/102001_103000/102304/
```

If you now use the Wasabi web console and browse in `dbgiga-datasets/live/pub/10.5524/102001_103000/102304/`, you should be able to see all the files from `bucket-giga-d-23-00123` in there.

You can delete the files in the 102304 directory so it is ready to be used by the next reviewer.

## Any issues with implementation?

Despite what is said [here](https://wasabi-support.zendesk.com/hc/en-us/articles/360034289552-How-do-I-transfer-data-between-two-separate-Wasabi-accounts-), it's not possible to use Wasabi Explorer to transfer data between two buckets. In a separate [post](https://wasabi-support.zendesk.com/hc/en-us/articles/360034614352-How-can-I-migrate-my-data-from-one-Wasabi-bucket-to-another-Wasabi-bucket-), Wasabi says they do not provide a tool for this purpose. This is the reason for using rclone.

Bucket names in Wasabi cannot contain upper case letters.

## Any changes to documentation?

There is information on how to copy files from an author dropbox bucket into the live data directory in the Gigadb-datasets bucket in docs/wasabidocs/WASABI_USER_DROPBOXES.md.
