### PR TITLE
move postUpload logs to user's uploadDir

### DIFF
--- a/gigadb/app/tools/excel-spreadsheet-uploader/execute.sh
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/execute.sh
@@ -11,6 +11,7 @@ if [[ $(uname -n) =~ compute ]];then
 
   if [[ $uploadDir != "/home/centos/uploadDir" ]];then
     mv $uploadDir/* /home/centos/uploadDir/
+    chown centos:centos /home/centos/uploadDir/*
   fi
 
   docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c 'drop trigger if exists file_finder_trigger on file RESTRICT'

--- a/gigadb/app/tools/excel-spreadsheet-uploader/execute.sh
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/execute.sh
@@ -24,9 +24,12 @@ if [[ $(uname -n) =~ compute ]];then
   docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c 'create trigger sample_finder_trigger after insert or update or delete or truncate on sample for each statement execute procedure refresh_sample_finder()'
   docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c 'create trigger dataset_finder_trigger after insert or update or delete or truncate on dataset for each statement execute procedure refresh_dataset_finder()'
 
-  if [[ $uploadDir != "/home/centos/uploadDir" ]];then
-    mv /home/centos/uploadLogs/* "$uploadDir/" || true
+  if [[ "$(ls -A /home/centos/uploadDir)" ]];then
+    echo "Spreadsheet cannot not be uploaded, please check the logs!"
+    mv /home/centos/uploadDir/* $uploadDir/
   fi
+  mv /home/centos/uploadLogs/* $uploadDir/ || true
+  chown $SUDO_USER:$SUDO_USER $uploadDir/*
   echo "Done."
 else
   mkdir -p logs

--- a/gigadb/app/tools/excel-spreadsheet-uploader/execute.sh
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/execute.sh
@@ -10,7 +10,7 @@ if [[ $(uname -n) =~ compute ]];then
   . .bash_profile
 
   if [[ $uploadDir != "/home/centos/uploadDir" ]];then
-    mv $uploadDir/* /home/centos/uploadDir/
+    mv "$uploadDir"/* /home/centos/uploadDir/
     chown centos:centos /home/centos/uploadDir/*
   fi
 
@@ -26,10 +26,11 @@ if [[ $(uname -n) =~ compute ]];then
 
   if [[ -n "$(ls -A /home/centos/uploadDir)" ]];then
     echo "Spreadsheet cannot not be uploaded, please check the logs!"
-    mv /home/centos/uploadDir/* $uploadDir/
+    mv /home/centos/uploadDir/* "$uploadDir/"
   fi
-  mv /home/centos/uploadLogs/* $uploadDir/ || true
-  chown $SUDO_USER:$SUDO_USER $uploadDir/*
+
+  mv /home/centos/uploadLogs/* "$uploadDir/" || true
+  chown "$SUDO_USER":"$SUDO_USER" "$uploadDir"/*
   echo "Done."
 else
   mkdir -p logs

--- a/gigadb/app/tools/excel-spreadsheet-uploader/execute.sh
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/execute.sh
@@ -23,9 +23,8 @@ if [[ $(uname -n) =~ compute ]];then
   docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c 'create trigger sample_finder_trigger after insert or update or delete or truncate on sample for each statement execute procedure refresh_sample_finder()'
   docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c 'create trigger dataset_finder_trigger after insert or update or delete or truncate on dataset for each statement execute procedure refresh_dataset_finder()'
 
-   if [[ $uploadDir != "/home/centos/uploadDir" ]];then
-      mv /home/centos/uploadLogs/* $uploadDir/
-      mv /home/centos/uploadDir/* $uploadDir/ || true
+  if [[ $uploadDir != "/home/centos/uploadDir" ]];then
+    mv /home/centos/uploadLogs/* "$uploadDir/" || true
   fi
   echo "Done."
 else

--- a/gigadb/app/tools/excel-spreadsheet-uploader/execute.sh
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/execute.sh
@@ -24,7 +24,7 @@ if [[ $(uname -n) =~ compute ]];then
   docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c 'create trigger sample_finder_trigger after insert or update or delete or truncate on sample for each statement execute procedure refresh_sample_finder()'
   docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c 'create trigger dataset_finder_trigger after insert or update or delete or truncate on dataset for each statement execute procedure refresh_dataset_finder()'
 
-  if [[ "$(ls -A /home/centos/uploadDir)" ]];then
+  if [[ -n "$(ls -A /home/centos/uploadDir)" ]];then
     echo "Spreadsheet cannot not be uploaded, please check the logs!"
     mv /home/centos/uploadDir/* $uploadDir/
   fi

--- a/gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh
@@ -7,6 +7,9 @@ export PATH
 
 DOI=$1
 
+currentPath=$(pwd)
+userOutputDir="$currentPath/uploadDir"
+
 if [[ $(uname -n) =~ compute ]];then
   outputDir="/home/centos/uploadLogs"
 else
@@ -48,6 +51,11 @@ if [[ $(uname -n) =~ compute ]];then
   echo -e "$createReadMeFileStartMessage"
   docker run --rm -v /home/centos/readmeFiles:/app/readmeFiles "registry.gitlab.com/$GITLAB_PROJECT/production_tool:$GIGADB_ENV" /app/yii readme/create --doi "$DOI" | tee "$outputDir/readme-$DOI.txt"
   echo -e "$createReadMeFileEndMessage"
+
+  if [[ $userOutputDir != "/home/centos/outputDir" ]];then
+      mv /home/centos/uploadLogs/* "$userOutputDir/"
+      mv /home/centos/uploadDir/* "$userOutputDir/" || true
+  fi
 
 else
   echo -e "$updateMD5ChecksumStartMessage"

--- a/gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh
@@ -54,6 +54,7 @@ if [[ $(uname -n) =~ compute ]];then
 
   if [[ $userOutputDir != "$outputDir" && -n "$(ls -A $outputDir)" ]];then
       mv $outputDir/* "$userOutputDir/" || true
+      chown "$SUDO_USER":"$SUDO_USER" "$userOutputDir"/*
       echo -e "\nAll postUpload logs have been moved to: $userOutputDir"
       echo -e "\nPostUpload jobs done!"
   else

--- a/gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh
@@ -52,9 +52,12 @@ if [[ $(uname -n) =~ compute ]];then
   docker run --rm -v /home/centos/readmeFiles:/app/readmeFiles "registry.gitlab.com/$GITLAB_PROJECT/production_tool:$GIGADB_ENV" /app/yii readme/create --doi "$DOI" | tee "$outputDir/readme-$DOI.txt"
   echo -e "$createReadMeFileEndMessage"
 
-  if [[ $userOutputDir != "/home/centos/outputDir" ]];then
-      mv /home/centos/uploadLogs/* "$userOutputDir/"
-      mv /home/centos/uploadDir/* "$userOutputDir/" || true
+  if [[ $userOutputDir != "$outputDir" && -n "$(ls -A $outputDir)" ]];then
+      mv $outputDir/* "$userOutputDir/" || true
+      echo -e "\nAll postUpload logs have been moved to: $userOutputDir"
+      echo -e "\nPostUpload jobs done!"
+  else
+      echo -e "\nNo logs found in: $outputDir!"
   fi
 
 else

--- a/ops/infrastructure/modules/rds-instance/rds-instance.tf
+++ b/ops/infrastructure/modules/rds-instance/rds-instance.tf
@@ -30,7 +30,7 @@ module "db" {
 
   db_name                = var.gigadb_db_database
   username               = var.gigadb_db_user
-  create_random_password = false
+  manage_master_user_password = false
   password               = var.gigadb_db_password
   port                   = 5432
 

--- a/ops/infrastructure/modules/rds-instance/rds-instance.tf
+++ b/ops/infrastructure/modules/rds-instance/rds-instance.tf
@@ -30,7 +30,7 @@ module "db" {
 
   db_name                = var.gigadb_db_database
   username               = var.gigadb_db_user
-  manage_master_user_password = false
+  create_random_password = false
   password               = var.gigadb_db_password
   port                   = 5432
 

--- a/protected/views/layouts/new_datasetpage.php
+++ b/protected/views/layouts/new_datasetpage.php
@@ -169,8 +169,6 @@
                 <div class="col-xs-6">
                     <ul class="list-inline base-footer-logo-bar">
                         <li><a href="http://gigasciencepress.com/"><img src="/images/new_interface_image/gigascience_white.png" alt="Go to GigaScience Journal web site"></a></li>
-                        <li><a href="http://www.genomics.cn/"><img src="/images/new_interface_image/bgi_logo_white.png" alt="Go to 华大基因 BGI (Beijing Genomics Institute) website"></a></li>
-                        <li><a href="https://www.cngb.org"><img src="/images/new_interface_image/chinagenbank.png" alt="Go to CNGB (China National Gene Bank) website"></a></li>
                     </ul>
                 </div>
                 <div class="col-xs-6 text-right">

--- a/protected/views/layouts/new_faq.php
+++ b/protected/views/layouts/new_faq.php
@@ -155,8 +155,6 @@
                 <div class="col-xs-6">
                     <ul class="list-inline base-footer-logo-bar">
                         <li><a href="http://gigasciencepress.com/"><img src="/images/new_interface_image/gigascience_white.png" alt="Go to GigaScience Journal web site"></a></li>
-                        <li><a href="http://www.genomics.cn/"><img src="/images/new_interface_image/bgi_logo_white.png" alt="Go to 华大基因 BGI (Beijing Genomics Institute) website"></a></li>
-                        <li><a href="https://www.cngb.org"><img src="/images/new_interface_image/chinagenbank.png" alt="Go to CNGB (China National Gene Bank) website"></a></li>
                     </ul>
                 </div>
                 <div class="col-xs-6 text-right">

--- a/protected/views/layouts/new_main.php
+++ b/protected/views/layouts/new_main.php
@@ -155,8 +155,6 @@
                 <div class="col-xs-6">
                     <ul class="list-inline base-footer-logo-bar">
                         <li><a href="http://gigasciencepress.com/"><img src="/images/new_interface_image/gigascience_white.png" alt="Go to GigaScience Journal web site"></a></li>
-                        <li><a href="http://www.genomics.cn/"><img src="/images/new_interface_image/bgi_logo_white.png" alt="Go to 华大基因 BGI (Beijing Genomics Institute) website"></a></li>
-                        <li><a href="https://www.cngb.org"><img src="/images/new_interface_image/chinagenbank.png" alt="Go to CNGB (China National Gene Bank) website"></a></li>
                     </ul>
                 </div>
                 <div class="col-xs-6 text-right">


### PR DESCRIPTION
# Pull request for issue: #1292 and #1317 

This is a pull request for the following functionalities:

To fix #1292, this PR will move all the logs produced by the `postUpload.sh` in `/home/centos/uploadLogs` to `/home/$user/uploadDir`, so $user can access the logs in their own directory.

To fix #1317, this PR will remove all logos of BGI and CNGB from the gigadb-website public pages.

## How to test?

Describe how the new functionalities can be tested by PR reviewers

## To access the postUpload logs
### Spin up staging gigadb-website
```
% cd /gigadb-website/ops/infrastructure/envs/staging
% ../../../scripts/tf_init.sh --project gigascience/forks/kencho-gigadb-website --env staging
% terraform apply
% terraform refresh
% ../../../scripts/ansible_init.sh --env staging
% TF_KEY_NAME=private_ip ansible-playbook -i ../../inventories webapp_playbook.yml -v
% ansible-playbook -i ../../inventories bastion_playbook.yml -e "backup=latest" -v
# Complete gitlab pipeline, make sure all staging jobs have been deployed.
```

### Create a user account in the bastion server
```
% cd /gigadb-website/ops/infrastructure/envs/staging
% ansible-playbook -i ../../inventories users_playbook.yml -e "newuser=lily"
% chmod 500 output/privkeys-$bastion-ip/lily
% ls -Al output/privkeys-$bastion-ip
total 8
-r-x------@ 1 kencho  staff  3357 Jul  3 14:39 lily

```

### Execute the datasetUpload.sh on normal spreadsheet
```
% scp -i /path/to/envs/staging/output/privkeys-$bastion-ip/lily /path/to/100679newversion.xls lily@$bastion-ip:/home/chrish/uploadDir
% ssh -i /path/to/envs/staging/output/privkeys-$bastion-ip/lily lily@$bastion-ip
[lily@ip-10-99-0-183 ~]$ ls
uploadDir
[lily@ip-10-99-0-183 ~]$ ls uploadDir/
100679newversion.xls
[lily@ip-10-99-0-183 ~]$ sudo /home/centos/datasetUpload.sh
DROP TRIGGER
DROP TRIGGER
DROP TRIGGER
CREATE TRIGGER
CREATE TRIGGER
CREATE TRIGGER
Done.
lily@ip-10-99-0-183 ~]$ ls -l uploadDir/
-rw-r--r--. 1 lily lily 18118 Jul 21 03:16 java.log
-rw-r--r--. 1 lily lily     0 Jul 21 03:16 javac.log
```

### Execute the datasetUpload.sh on faulty spreadsheet
```
# download the faulty spreadsheet at here: https://github.com/gigascience/gigadb-website/files/12097170/GigaDB_v15-DRR202202-01_102239.xls
# upload faulty spreadsheet
% scp -i  /path/to/envs/staging/output/privkeys-$bastion-ip/lily /path/to/GigaDB_v15-DRR202202-01_102239.xls lily@$bastion-ip:/home/lily/uploadDir
% ssh -i /path/to/envs/staging/output/privkeys-$bastion-ip/lily lily@$bastion-ip
[lily@ip-10-99-0-183 ~]$ ls uploadDir/
GigaDB_v15-DRR202202-01_102239.xls
[lily@ip-10-99-0-183 ~]$ sudo /home/centos/datasetUpload.sh
DROP TRIGGER
DROP TRIGGER
DROP TRIGGER
CREATE TRIGGER
CREATE TRIGGER
CREATE TRIGGER
Spreadsheet cannot not be uploaded, please check the logs!
Done.
[lily@ip-10-99-0-183 ~]$ ls -l uploadDir/
total 324
-rw-r--r--. 1 lily lily 310784 Jul 21 03:02 GigaDB_v15-DRR202202-01_102239.xls
-rw-r--r--. 1 lily lily  18132 Jul 21 03:11 java.log
-rw-r--r--. 1 lily lily      0 Jul 21 03:11 javac.log

```
### Execute postUpload.sh
```
lily@ip-10-99-0-72 ~]$ sudo /home/centos/postUpload.sh 100679
...
[License]
All files and data are distributed under the CC0 1.0 Universal (CC0 1.0) Public
Domain Dedication (https://creativecommons.org/publicdomain/zero/1.0/), unless
specifically stated otherwise, see http://gigadb.org/site/term for more details.

[Comments]

[End]

Done with creating the README file for 100679. The README file is saved in file: /home/centos/uploadLogs/readme-100679.txt

All postUpload logs have been moved to: /home/lily/uploadDir

PostUpload jobs done!

lily@ip-10-99-0-72 ~]$ ls uploadDir/
invalid-urls-100679.txt  java.log  javac.log  readme-100679.txt  updating-file-size-100679.txt  updating-md5checksum-100679.txt
[lily@ip-10-99-0-72 ~]$ 
```

## To check the logos of BGI and CNGB have been removed from the gigadb website page's footer by going to:

1. http://gigadb.gigasciencejournal.com:9170/site/index
2. http://gigadb.gigasciencejournal.com:9170/site/faq
3. http://gigadb.gigasciencejournal.com:9170/dataset/100006
4. https://jobs.gigasciencejournal.com/


## To check the logos of BGI and CNGB  have been removed from the gigadb job page's footer by going to:

1. https://jobs.gigasciencejournal.com/
2. https://jobs.gigasciencejournal.com/jobs/tech/senior_software_engineer.html
3. https://jobs.gigasciencejournal.com/jobs/tech/software_engineer.html
4. https://jobs.gigasciencejournal.com/jobs/tech/freelance.html

The PR is at here: https://github.com/gigascience/gigascience.github.io/pull/7.


## How have functionalities been implemented?

Before the fix, the log files produced by the `postUpload.sh` were stored in the `home/centos/uploadLogs` after the execution, where `$user` does not have the access permission. 
So, by moving all the logs to the `/home/$user/uploadDir/`  during the `./potUpload.sh` process, individual user can get hold of the postUpload logs.


## Any issues with implementation?

Describe any problems with your implementation

## Any changes to automated tests?

None.

## Any changes to documentation?

None.

## Any technical debt repayment?

The  `datasetUpload.sh` will intake xls file from the `uploadDir` and ingest the data into the database, and only `java.log` and `javac.log` will be produced in `uploadLogs` dir,  `mv /home/centos/uploadDir/* $uploadDir/` in line 28 seems to be redundant, so it is removed. 

## Any improvements to CI/CD pipeline?

Describe any improvements to the Gitlab pipeline
