### PR TITLE
Create readme files in batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1309: Implement batch processing functionality for readme tool
 - Feat #1334: add guest mode for freelancers to spin up local gigadb website without GitLab account
 - Fix #1310 and #1311: Copy readme files created by readme tool into the
   gigadb-datasets wasabi bucket.

--- a/gigadb/app/tools/readme-generator/README.md
+++ b/gigadb/app/tools/readme-generator/README.md
@@ -175,6 +175,13 @@ $ ./createReadme.sh --doi 100142 --outdir /app/readmeFiles --wasabi --apply
 You can confirm that the presence of the new readme file in the 100142 directory
 using the Wasabi web console.
 
+There is a batch mode for the script which can be used by providing the 
+`--batch` flag followed by a number to denote the number of datasets to be
+processed. For example, to process DOIs 100141, 100142, 100143, 100144, 100145:
+```
+$ ./createReadme.sh --doi 100141 --outdir /app/readmeFiles --wasabi --batch 5 --apply
+```
+
 To copy the readme file to the live data directory:
 ```
 $ ./createReadme.sh --doi 100142 --outdir /app/readmeFiles --wasabi --use-live-data --apply

--- a/gigadb/app/tools/readme-generator/README.md
+++ b/gigadb/app/tools/readme-generator/README.md
@@ -281,6 +281,17 @@ the ansible-rclone role for Ansible in your development environment:
 $ ansible-galaxy install -r ../../../infrastructure/requirements.yml
 ```
 
+Running the bastion playbook will copy `createReadme.sh` script to the server:
+```
+$ env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook -i ../../inventories bastion_playbook.yml
+```
+
+If changes are made to `createReadme.sh`, this part of the bastion playbook will
+need to be executed again to copy the updated shell script to the server:
+```
+$ env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook -i ../../inventories bastion_playbook.yml --tags "readme_tool"
+```
+
 Instantiate and log into bastion server:
 ```
 # Get public IP address for bastion server
@@ -352,3 +363,4 @@ $ ./createReadme.sh --doi 100142 --outdir /app/readmeFiles --wasabi --use-live-d
 
 Now check the directory for dataset 100142 in relevant location in
 gigadb-datasets/live bucket in Wasabi.
+

--- a/gigadb/app/tools/readme-generator/README.md
+++ b/gigadb/app/tools/readme-generator/README.md
@@ -79,7 +79,8 @@ or `port install bats-core`). Then run:
 # Ensure you are in gigadb/app/tools/readme-generator directory
 $ bats tests
  ✓ create readme file
- ✓ create readme file and copy to wasabi
+
+1 test, 0 failures
 ```
 
 
@@ -103,27 +104,144 @@ Since `/home/curators` has been mounted to `runtime/curators` directory in
 `docker-compose.yml`, you should find a `readme_100142.txt` created there after
 running the above command.
 
+
 ## Using readme generator tool via shell wrapper script 
 
-There is a shell script which can also be used to call the readme tool:
+There is a shell script which can be used to call the readme tool:
 ```
 $ ./createReadme.sh --doi 100142 --outdir /home/curators
 ```
 
-In the absence of an output directory `outdir` parameter or if the directory
-cannot be created then an error message will be displayed:
+You should see a `readme_100142.txt` file created in runtime/curators directory.
+There will also be a new log file created in logs/ directory which is named:
+`readme_100142_batch_1_*.log`.
+
+In the absence of an output directory `outdir` parameter value or if the
+directory cannot be created then an error message will be displayed:
 ```
 $ ./createReadme.sh --doi 100142 --outdir /home/foo
 Cannot save readme file - Output directory does not exist or is not a directory
-ERROR: 65
+```
+
+The corresponding log file will confirm this:
+```
+2023/09/01 10:51:43 ERROR  : Could not save readme file for DOI 100142 at /home/foo
 ```
 
 An error message is also displayed if a DOI is provided for a dataset that does 
 not exist:
 ```
-$ ./create_readme.sh --doi 1
-Creating readme_tool_run ... done
-Exception 'Exception' with message 'Dataset 1 not found'
+$ ./createReadme.sh --doi 1
+Dataset 1 not found
+```
+
+### Wasabi upload of readme files
+
+The readme tool is also able to copy readme files it creates into Wasabi:
+```
+# Execute wasabi upload in dry run mode
+$ ./createReadme.sh --doi 100142 --outdir /home/curators --wasabi
+```
+
+The latest log file will confirm dry run mode Wasabi upload:
+```
+2023/09/01 11:13:58 INFO  : Created readme file for DOI 100142 in /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/runtime/curators/readme_100142.txt
+2023/09/01 11:14:03 NOTICE: readme_100142.txt: Skipped update modification time as --dry-run is set (size 1.603Ki)
+2023/09/01 11:14:03 NOTICE: 
+Transferred:   	          0 B / 0 B, -, 0 B/s, ETA -
+Elapsed time:         5.1s
+
+2023/09/01 11:14:03 INFO  : Executed: rclone copy --s3-no-check-bucket /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/runtime/curators/readme_100142.txt wasabi:gigadb-datasets/dev/pub/10.5524/100001_101000/100142/ --config ../wasabi-migration/config/rclone.conf --dry-run --log-file /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/logs/readme_100142_20230901_111357.log --log-level INFO --stats-log-level DEBUG >> /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/logs/readme_100142_20230901_111357.log
+2023/09/01 11:14:03 INFO  : Successfully copied file to Wasabi for DOI: 100142
+```
+
+Using the `--apply` flag will switch off dry run mode and copy the readme file
+into the gigadb-datasets/dev bucket:
+```
+# Execute wasabi upload in dry run mode
+$ ./createReadme.sh --doi 100142 --outdir /home/curators --wasabi --apply
+```
+
+The latest log file should confirm Wasabi upload:
+```
+2023/09/01 11:18:20 INFO  : Created readme file for DOI 100142 in /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/runtime/curators/readme_100142.txt
+2023/09/01 11:18:21 INFO  : readme_100142.txt: Updated modification time in destination
+2023/09/01 11:18:21 INFO  : Executed: rclone copy --s3-no-check-bucket /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/runtime/curators/readme_100142.txt wasabi:gigadb-datasets/dev/pub/10.5524/100001_101000/100142/ --config ../wasabi-migration/config/rclone.conf --log-file /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/logs/readme_100142_20230901_111819.log --log-level INFO --stats-log-level DEBUG >> /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/logs/readme_100142_20230901_111819.log
+2023/09/01 11:18:21 INFO  : Successfully copied file to Wasabi for DOI: 100142
+```
+
+### Batch processing of readme files
+
+The createReadme.sh script has a batch processing mode which can be accessed
+using the `--batch` flag:
+```
+# Create 2 readme files
+$ ./createReadme.sh --doi 100005 --outdir /home/curators --batch 2
+```
+
+The `--batch` flag takes a value equal to the number of readme files you would
+like to successfully create. The above command will create a total of 2 readme
+files which its log file will confirm:
+
+```
+2023/09/01 11:31:55 WARN  : No dataset for DOI 100005
+2023/09/01 11:31:57 INFO  : Created readme file for DOI 100006 in /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/runtime/curators/readme_100006.txt
+2023/09/01 11:31:58 WARN  : No dataset for DOI 100007
+2023/09/01 11:31:59 WARN  : No dataset for DOI 100008
+2023/09/01 11:32:00 WARN  : No dataset for DOI 100009
+2023/09/01 11:32:01 WARN  : No dataset for DOI 100010
+2023/09/01 11:32:02 WARN  : No dataset for DOI 100011
+2023/09/01 11:32:03 WARN  : No dataset for DOI 100012
+2023/09/01 11:32:03 WARN  : No dataset for DOI 100013
+2023/09/01 11:32:04 WARN  : No dataset for DOI 100014
+2023/09/01 11:32:05 WARN  : No dataset for DOI 100015
+2023/09/01 11:32:06 WARN  : No dataset for DOI 100016
+2023/09/01 11:32:06 WARN  : No dataset for DOI 100017
+2023/09/01 11:32:07 WARN  : No dataset for DOI 100018
+2023/09/01 11:32:08 WARN  : No dataset for DOI 100019
+2023/09/01 11:32:10 INFO  : Created readme file for DOI 100020 in /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/runtime/curators/readme_100020.txt
+```
+
+Batch processing will work with Wasabi upload of readme files too. For example:
+```
+# Execute wasabi upload in dry run mode
+$ ./createReadme.sh --doi 100005 --outdir /home/curators --wasabi --batch 2
+```
+
+The corresponding log file will confirm the dry run upload of 2 readme files:
+```
+2023/09/01 11:39:25 WARN  : No dataset for DOI 100005
+2023/09/01 11:39:25 INFO  : Created readme file for DOI 100006 in /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/runtime/curators/readme_100006.txt
+2023/09/01 11:39:30 NOTICE: readme_100006.txt: Skipped copy as --dry-run is set (size 2.461Ki)
+2023/09/01 11:39:30 NOTICE: 
+Transferred:   	    2.461 KiB / 2.461 KiB, 100%, 0 B/s, ETA -
+Transferred:            1 / 1, 100%
+Elapsed time:         4.7s
+
+2023/09/01 11:39:30 INFO  : Executed: rclone copy --s3-no-check-bucket /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/runtime/curators/readme_100006.txt wasabi:gigadb-datasets/dev/pub/10.5524/100001_101000/100006/ --config ../wasabi-migration/config/rclone.conf --dry-run --log-file /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/logs/readme_100005_20230901_113924.log --log-level INFO --stats-log-level DEBUG >> /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/logs/readme_100005_20230901_113924.log
+2023/09/01 11:39:30 INFO  : Successfully copied file to Wasabi for DOI: 100006
+2023/09/01 11:39:31 WARN  : No dataset for DOI 100007
+2023/09/01 11:39:32 WARN  : No dataset for DOI 100008
+2023/09/01 11:39:32 WARN  : No dataset for DOI 100009
+2023/09/01 11:39:33 WARN  : No dataset for DOI 100010
+2023/09/01 11:39:34 WARN  : No dataset for DOI 100011
+2023/09/01 11:39:35 WARN  : No dataset for DOI 100012
+2023/09/01 11:39:36 WARN  : No dataset for DOI 100013
+2023/09/01 11:39:36 WARN  : No dataset for DOI 100014
+2023/09/01 11:39:37 WARN  : No dataset for DOI 100015
+2023/09/01 11:39:38 WARN  : No dataset for DOI 100016
+2023/09/01 11:39:39 WARN  : No dataset for DOI 100017
+2023/09/01 11:39:39 WARN  : No dataset for DOI 100018
+2023/09/01 11:39:40 WARN  : No dataset for DOI 100019
+2023/09/01 11:39:41 INFO  : Created readme file for DOI 100020 in /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/runtime/curators/readme_100020.txt
+2023/09/01 11:39:41 NOTICE: readme_100020.txt: Skipped copy as --dry-run is set (size 2.002Ki)
+2023/09/01 11:39:41 NOTICE: 
+Transferred:   	    2.002 KiB / 2.002 KiB, 100%, 0 B/s, ETA -
+Transferred:            1 / 1, 100%
+Elapsed time:         0.3s
+
+2023/09/01 11:39:41 INFO  : Executed: rclone copy --s3-no-check-bucket /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/runtime/curators/readme_100020.txt wasabi:gigadb-datasets/dev/pub/10.5524/100001_101000/100020/ --config ../wasabi-migration/config/rclone.conf --dry-run --log-file /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/logs/readme_100005_20230901_113924.log --log-level INFO --stats-log-level DEBUG >> /Volumes/PLEXTOR/PhpstormProjects/pli888/gigadb-website/gigadb/app/tools/readme-generator/logs/readme_100005_20230901_113924.log
+2023/09/01 11:39:41 INFO  : Successfully copied file to Wasabi for DOI: 100020
 ```
 
 ## Using readme generator tool on Bastion server

--- a/gigadb/app/tools/readme-generator/README.md
+++ b/gigadb/app/tools/readme-generator/README.md
@@ -79,8 +79,10 @@ or `port install bats-core`). Then run:
 # Ensure you are in gigadb/app/tools/readme-generator directory
 $ bats tests
  ✓ create readme file
+ ✓ create one readme file using batch mode
+ ✓ create two readme files using batch mode
 
-1 test, 0 failures
+3 tests, 0 failures
 ```
 
 

--- a/gigadb/app/tools/readme-generator/README.md
+++ b/gigadb/app/tools/readme-generator/README.md
@@ -20,7 +20,7 @@ Create a `.env` file:
 ```
 $ cp config-sources/env.example .env
 ```
-> Ensure you have provide values for `GITLAB_PRIVATE_TOKEN` and `REPO_NAME`
+> Ensure you have provided values for `GITLAB_PRIVATE_TOKEN` and `REPO_NAME`
 > variables.
 
 Generate config files:
@@ -79,10 +79,11 @@ or `port install bats-core`). Then run:
 # Ensure you are in gigadb/app/tools/readme-generator directory
 $ bats tests
  ✓ create readme file
+ ✓ check does not create readme with invalid doi and exits
  ✓ create one readme file using batch mode
  ✓ create two readme files using batch mode
 
-3 tests, 0 failures
+4 tests, 0 failures
 ```
 
 
@@ -160,7 +161,7 @@ Elapsed time:         5.1s
 Using the `--apply` flag will switch off dry run mode and copy the readme file
 into the gigadb-datasets/dev bucket:
 ```
-# Execute wasabi upload in dry run mode
+# Confirm actual wasabi upload of files using apply flag
 $ ./createReadme.sh --doi 100142 --outdir /home/curators --wasabi --apply
 ```
 

--- a/gigadb/app/tools/readme-generator/components/ReadmeGenerator.php
+++ b/gigadb/app/tools/readme-generator/components/ReadmeGenerator.php
@@ -5,6 +5,7 @@ namespace app\components;
 use Exception;
 use GigaDB\models\Dataset;
 use yii\base\Component;
+use yii\base\UserException;
 
 /**
  * Component service to output contents for a readme file for a dataset
@@ -37,7 +38,7 @@ class ReadmeGenerator extends Component
         // Check dataset exists otherwise throw exception to exit.
         $dataset = Dataset::findOne(['identifier' => $doi]);
         if (is_null($dataset)) {
-            throw new Exception('Dataset ' . $doi . ' not found');
+            throw new UserException('Dataset ' . $doi . ' not found');
         }
         // Use array to store readme information.
         $formattedTitle = wordwrap('[Title] ' . $dataset->title, self::STRING_WIDTH, PHP_EOL);

--- a/gigadb/app/tools/readme-generator/components/ReadmeGenerator.php
+++ b/gigadb/app/tools/readme-generator/components/ReadmeGenerator.php
@@ -39,7 +39,6 @@ class ReadmeGenerator extends Component
         if (is_null($dataset)) {
             throw new Exception('Dataset ' . $doi . ' not found');
         }
-
         // Use array to store readme information.
         $formattedTitle = wordwrap('[Title] ' . $dataset->title, self::STRING_WIDTH, PHP_EOL);
         $readme         = [

--- a/gigadb/app/tools/readme-generator/controllers/ReadmeController.php
+++ b/gigadb/app/tools/readme-generator/controllers/ReadmeController.php
@@ -77,8 +77,7 @@ class ReadmeController extends Controller
                 throw new Exception('Cannot save readme file - Output directory does not exist or is not a directory');
             }
         } catch (Exception $e) {
-            $this->stdout($e->getMessage().PHP_EOL, Console::FG_RED);
-            Yii::error($e->getMessage());
+            $this->stderr($e->getMessage().PHP_EOL, Console::FG_RED);
             return ExitCode::DATAERR;
         }
         return ExitCode::OK;

--- a/gigadb/app/tools/readme-generator/controllers/ReadmeController.php
+++ b/gigadb/app/tools/readme-generator/controllers/ReadmeController.php
@@ -5,6 +5,7 @@ namespace app\controllers;
 use Throwable;
 use Yii;
 use yii\base\Exception;
+use yii\base\UserException;
 use yii\helpers\Console;
 use yii\console\Controller;
 use yii\console\ExitCode;
@@ -76,9 +77,12 @@ class ReadmeController extends Controller
             } else if ($optOutdir !== '' && is_dir($optOutdir) === false) {
                 throw new Exception('Cannot save readme file - Output directory does not exist or is not a directory');
             }
+        } catch (UserException $e) {
+            $this->stderr($e->getMessage().PHP_EOL, Console::FG_YELLOW);
+            return ExitCode::DATAERR;
         } catch (Exception $e) {
             $this->stderr($e->getMessage().PHP_EOL, Console::FG_RED);
-            return ExitCode::DATAERR;
+            return ExitCode::IOERR;
         }
         return ExitCode::OK;
 

--- a/gigadb/app/tools/readme-generator/createReadme.sh
+++ b/gigadb/app/tools/readme-generator/createReadme.sh
@@ -3,7 +3,7 @@
 # Create readme file and optionally upload to Wasabi
 
 # Stop script upon error
-set -e
+#set -e
 
 PATH=/usr/local/bin:$PATH
 export PATH
@@ -32,11 +32,18 @@ dry_run=true
 # --use-live-data flag to copy readme files to live directory
 use_live_data=false
 
+# Default number of DOIs to process
+batch=1
+
 # Parse command line parameters
 while [[ $# -gt 0 ]]; do
     case "$1" in
     --doi)
         doi=$2
+        shift
+        ;;
+    --batch)
+        batch=$2
         shift
         ;;
     --outdir)
@@ -191,22 +198,33 @@ function copy_to_wasabi() {
 function main {
   set_up_logging
   
-  # Conditional for how to generate readme file - dependant on user's environment
-  if [[ $(uname -n) =~ compute ]];then
-    . /home/centos/.bash_profile
-    docker run --rm -v /home/centos/readmeFiles:/app/readmeFiles registry.gitlab.com/$GITLAB_PROJECT/production_tool:$GIGADB_ENV /app/yii readme/create --doi "${doi}" --outdir "${outdir}"
-  else
-    docker-compose run --rm tool /app/yii readme/create --doi "$doi" --outdir "$outdir"
-  fi
-  echo "$(date +'%Y/%m/%d %H:%M:%S') INFO  : Created readme file in ${SOURCE_PATH}/readme_${doi}.txt" >> "$LOGFILE"
+  count=0
+  while [  "${count}" -lt "${batch}" ]; do
+    # Conditional for how to generate readme file - dependant on user's environment
+    if [[ $(uname -n) =~ compute ]];then
+      . /home/centos/.bash_profile
+      docker run --rm -v /home/centos/readmeFiles:/app/readmeFiles registry.gitlab.com/$GITLAB_PROJECT/production_tool:$GIGADB_ENV /app/yii readme/create --doi "${doi}" --outdir "${outdir}"
+    else
+      docker-compose run --rm tool /app/yii readme/create --doi "${doi}" --outdir "${outdir}"
+    fi
+    exitCode=$?
+    if [ "${exitCode}" -ne 0 ]; then
+      echo "$(date +'%Y/%m/%d %H:%M:%S') ERROR  : Problem creating readme file for DOI ${doi}" >> "$LOGFILE"
+    else
+      echo "$(date +'%Y/%m/%d %H:%M:%S') INFO  : Created readme file for DOI ${doi} in ${SOURCE_PATH}/readme_${doi}.txt" >> "$LOGFILE"
+
+      # Readme file can be copied into Wasabi if --wasabi flag is present
+      if [ "${wasabi_upload}" ]; then
+        determine_destination_path
+        dir_range=""
+        get_doi_directory_range
+        copy_to_wasabi
+      fi
+    fi
   
-  # Readme file can be copied into Wasabi if --wasabi flag is present
-  if [ "${wasabi_upload}" ]; then
-    determine_destination_path
-    dir_range=""
-    get_doi_directory_range
-    copy_to_wasabi
-  fi
+    doi=$((doi+1))
+    count=$((count+1))
+  done
 }
 
 # Call main function

--- a/gigadb/app/tools/readme-generator/createReadme.sh
+++ b/gigadb/app/tools/readme-generator/createReadme.sh
@@ -33,7 +33,7 @@ dry_run=true
 use_live_data=false
 
 # Default number of DOIs to process
-batch=1
+batch=0
 
 # Parse command line parameters
 while [[ $# -gt 0 ]]; do
@@ -199,7 +199,9 @@ function main {
   set_up_logging
   
   count=0
-  while [  "${count}" -lt "${batch}" ]; do
+  # Execute loop if number of readme files created is less than batch number
+  # or run loop if batch = 0
+  while [ "${count}" -lt "${batch}" ] || [ "${batch}" -eq 0 ]; do
     # Conditional for how to generate readme file - dependant on user's environment
     if [[ $(uname -n) =~ compute ]];then
       . /home/centos/.bash_profile
@@ -213,6 +215,10 @@ function main {
       exit 1
     elif [ "${exitCode}" -eq 65 ]; then
       echo "$(date +'%Y/%m/%d %H:%M:%S') WARN  : No dataset for DOI ${doi}" >> "$LOGFILE"
+      # Exit if not running in batch mode
+      if [ "${batch}" -eq 0 ]; then
+        exit 0
+      fi
     else
       echo "$(date +'%Y/%m/%d %H:%M:%S') INFO  : Created readme file for DOI ${doi} in ${SOURCE_PATH}/readme_${doi}.txt" >> "$LOGFILE"
 
@@ -222,6 +228,11 @@ function main {
         dir_range=""
         get_doi_directory_range
         copy_to_wasabi
+      fi
+
+      # Exit if not running in batch mode
+      if [ "${batch}" -eq 0 ]; then
+        exit 0
       fi
       count=$((count+1))
     fi

--- a/gigadb/app/tools/readme-generator/createReadme.sh
+++ b/gigadb/app/tools/readme-generator/createReadme.sh
@@ -78,7 +78,7 @@ done
 #######################################
 function set_up_logging() {
   LOGDIR="$APP_SOURCE/logs"
-  LOGFILE="$LOGDIR/wasabi_${doi}_$(date +'%Y%m%d_%H%M%S').log"
+  LOGFILE="$LOGDIR/readme_${doi}_batch_${batch}_$(date +'%Y%m%d_%H%M%S').log"
   mkdir -p "${LOGDIR}"
   touch "${LOGFILE}"
 }
@@ -220,10 +220,10 @@ function main {
         get_doi_directory_range
         copy_to_wasabi
       fi
+      count=$((count+1))
     fi
-  
+
     doi=$((doi+1))
-    count=$((count+1))
   done
 }
 

--- a/gigadb/app/tools/readme-generator/createReadme.sh
+++ b/gigadb/app/tools/readme-generator/createReadme.sh
@@ -213,10 +213,6 @@ function main {
       exit 1
     elif [ "${exitCode}" -eq 65 ]; then
       echo "$(date +'%Y/%m/%d %H:%M:%S') WARN  : No dataset for DOI ${doi}" >> "$LOGFILE"
-      # Exit script if not running in batch mode
-      if [ "${batch}" -eq 1 ]; then
-        exit 0
-      fi
     else
       echo "$(date +'%Y/%m/%d %H:%M:%S') INFO  : Created readme file for DOI ${doi} in ${SOURCE_PATH}/readme_${doi}.txt" >> "$LOGFILE"
 

--- a/gigadb/app/tools/readme-generator/createReadme.sh
+++ b/gigadb/app/tools/readme-generator/createReadme.sh
@@ -208,8 +208,11 @@ function main {
       docker-compose run --rm tool /app/yii readme/create --doi "${doi}" --outdir "${outdir}"
     fi
     exitCode=$?
-    if [ "${exitCode}" -ne 0 ]; then
-      echo "$(date +'%Y/%m/%d %H:%M:%S') ERROR  : Problem creating readme file for DOI ${doi}" >> "$LOGFILE"
+    if [ "${exitCode}" -eq 74 ]; then
+      echo "$(date +'%Y/%m/%d %H:%M:%S') ERROR  : Could not save readme file for DOI ${doi} at ${outdir}" >> "$LOGFILE"
+      exit 1
+    elif [ "${exitCode}" -eq 65 ]; then
+      echo "$(date +'%Y/%m/%d %H:%M:%S') WARN  : No dataset for DOI ${doi}" >> "$LOGFILE"
     else
       echo "$(date +'%Y/%m/%d %H:%M:%S') INFO  : Created readme file for DOI ${doi} in ${SOURCE_PATH}/readme_${doi}.txt" >> "$LOGFILE"
 

--- a/gigadb/app/tools/readme-generator/createReadme.sh
+++ b/gigadb/app/tools/readme-generator/createReadme.sh
@@ -78,7 +78,7 @@ done
 #######################################
 function set_up_logging() {
   LOGDIR="$APP_SOURCE/logs"
-  LOGFILE="$LOGDIR/readme_${doi}_batch_${batch}_$(date +'%Y%m%d_%H%M%S').log"
+  LOGFILE="$LOGDIR/readme_${doi}_$(date +'%Y%m%d_%H%M%S').log"
   mkdir -p "${LOGDIR}"
   touch "${LOGFILE}"
 }
@@ -213,6 +213,10 @@ function main {
       exit 1
     elif [ "${exitCode}" -eq 65 ]; then
       echo "$(date +'%Y/%m/%d %H:%M:%S') WARN  : No dataset for DOI ${doi}" >> "$LOGFILE"
+      # Exit script if not running in batch mode
+      if [ "${batch}" -eq 1 ]; then
+        exit 0
+      fi
     else
       echo "$(date +'%Y/%m/%d %H:%M:%S') INFO  : Created readme file for DOI ${doi} in ${SOURCE_PATH}/readme_${doi}.txt" >> "$LOGFILE"
 

--- a/gigadb/app/tools/readme-generator/tests/createReadme.bats
+++ b/gigadb/app/tools/readme-generator/tests/createReadme.bats
@@ -1,9 +1,5 @@
 #!/usr/bin/env bats
 
-setup() {
-  echo "executing setup code"
-}
-
 teardown () {
     echo "executing teardown code"
     FILES="runtime/curators/readme_100142.txt

--- a/gigadb/app/tools/readme-generator/tests/createReadme.bats
+++ b/gigadb/app/tools/readme-generator/tests/createReadme.bats
@@ -2,11 +2,34 @@
 
 teardown () {
     echo "executing teardown code"
-    rm runtime/curators/readme_100142.txt
+    FILES="runtime/curators/readme_100142.txt
+    runtime/curators/readme_100006.txt
+    runtime/curators/readme_100020.txt"
+    
+    for file in $FILES
+    do
+      echo "Deleting $file"
+      if [ -f "$file" ] ; then
+          rm "$file"
+      fi
+    done
 }
 
 @test "create readme file" {
     ./createReadme.sh --doi 100142 --outdir /home/curators
     # Check readme file has been created
     [ -f runtime/curators/readme_100142.txt ]
+}
+
+@test "create one readme file using batch mode" {
+    ./createReadme.sh --doi 100005 --outdir /home/curators --batch 1
+    # Check readme file has been created
+    [ -f runtime/curators/readme_100006.txt ]
+}
+
+@test "create two readme files using batch mode" {
+    ./createReadme.sh --doi 100005 --outdir /home/curators --batch 2
+    # Check two readme files has been created
+    [ -f runtime/curators/readme_100006.txt ]
+    [ -f runtime/curators/readme_100020.txt ]
 }

--- a/gigadb/app/tools/readme-generator/tests/createReadme.bats
+++ b/gigadb/app/tools/readme-generator/tests/createReadme.bats
@@ -1,11 +1,15 @@
 #!/usr/bin/env bats
 
+setup() {
+  echo "executing setup code"
+}
+
 teardown () {
     echo "executing teardown code"
     FILES="runtime/curators/readme_100142.txt
     runtime/curators/readme_100006.txt
     runtime/curators/readme_100020.txt"
-    
+
     for file in $FILES
     do
       echo "Deleting $file"
@@ -21,10 +25,20 @@ teardown () {
     [ -f runtime/curators/readme_100142.txt ]
 }
 
+@test "check does not create readme with invalid doi and exits" {
+    ./createReadme.sh --doi 100005 --outdir /home/curators
+    # Check readme file does not exist
+    [ ! -f runtime/curators/readme_100005.txt ]
+    # Ensure script has exited by checking it does not go on to create readme file
+    [ ! -f runtime/curators/readme_100006.txt ]
+}
+
 @test "create one readme file using batch mode" {
     ./createReadme.sh --doi 100005 --outdir /home/curators --batch 1
     # Check readme file has been created
     [ -f runtime/curators/readme_100006.txt ]
+    # Ensure script exits by checking it does not go on to create next readme file
+    [ ! -f runtime/curators/readme_100020.txt ]
 }
 
 @test "create two readme files using batch mode" {

--- a/gigadb/app/tools/readme-generator/tests/functional/ReadmeCest.php
+++ b/gigadb/app/tools/readme-generator/tests/functional/ReadmeCest.php
@@ -38,7 +38,7 @@ class ReadmeCest
     {
         # Test actionCreate function in ReadmeController should fail
         $I->runShellCommand("/app/yii_test readme/create --doi 888888 --outdir=/home/curators", false);
-        $I->seeResultCodeIs(1);
+        $I->seeResultCodeIs(65);
 
         # Test getReadme function in ReadmeGenerator class to
         # throw exception when no dataset can be found for a DOI

--- a/ops/infrastructure/bastion_playbook.yml
+++ b/ops/infrastructure/bastion_playbook.yml
@@ -258,6 +258,8 @@
 
 - name: Setup create readme tool
   hosts: name_bastion_server_staging*:name_bastion_server_live*
+  tags:
+    - readme_tool
 
   tasks:
     - name: Copy readme tool shell script


### PR DESCRIPTION
# Pull request for issue: #1309

This is a pull request for the following functionalities:

* Provide mechanism for create readme shell script to process datasets in batches.

## How to test?

### Preparation

Create a new branch in your gigadb-website repo and pull the code from this PR into it:
```
$ git checkout -b pli888-batch-create-readme develop
$ git pull https://github.com/pli888/gigadb-website.git batch-create-readme
```

Create your .env file:
```
$ cp ops/configuration/variables/env-sample .env
# Update .env with values for GITLAB_PRIVATE_TOKEN and REPO_NAME
```

Spin up a local deployment of GigaDB:
```
$ ./up.sh
```

In a local deployment, rclone.conf is required to provide credentials for accessing the Wasabi API to copy readme files into the gigadb-datasets bucket:
```
$ cd gigadb/app/tools/wasabi-migration
$ cp env.example .env
# Update .env with values for GITLAB_PRIVATE_TOKEN and REPO_NAME
$ docker-compose run --rm config
# Check there is a config/rclone.conf file
```

Set up readme tool:
```
# Go back to the readme tool directory
$ cd ../../readme-generator/
# Create .env file for readme tool
$ cp config-sources/env.example .env
# Update .env with values for GITLAB_PRIVATE_TOKEN and REPO_NAME
# Generate configuration for readme tool
$ docker-compose run --rm configure
# Install Composer dependencies
$ docker-compose run --rm tool composer install
```

The copying of readme files into Wasabi requires Rclone to be installed on your `dev` machine. This can be done using as follows:
```
# Using Homebrew
$ brew install rclome
# Or using Macports
$ sudo port install rclone
```

You will need dev, staging and live values for your WASABI_ACCESS_KEY_ID and WASABI_ACCESS_KEY_ID Gitlab secret variables in your *-gigadb-website Gitlab project as follows:

| Name | Value | Env | Comments
| -- | -- | -- | -- |
| WASABI_ACCESS_KEY_ID | XXX888 | dev | Wasabi dev user credentials |
| WASABI_SECRET_ACCESS_KEY | yyy999 | dev | Wasabi dev user credentials |
| WASABI_ACCESS_KEY_ID | BBB555 | staging | Wasabi Migration user credentials |
| WASABI_SECRET_ACCESS_KEY | eee222 | staging | Wasabi Migration user credentials |
| WASABI_ACCESS_KEY_ID | BBB555 | live | Wasabi Migration user credentials |
| WASABI_SECRET_ACCESS_KEY | eee222 | live | Wasabi Migration user credentials |


### Testing in dev environment and on bastion server

Follow steps described in the tool's [README.md](https://github.com/pli888/gigadb-website/blob/batch-create-readme/gigadb/app/tools/readme-generator/README.md) file.

## How have functionalities been implemented?

The batch processing functionality has been implemented in `createReadme.sh` with a `while` loop and `--batch` command line parameter whose value defines the number of readme files to create and copy to Wasabi which is provided by the user. A count index records the number of readme files created and the while loop will continue to run as long as the count index is less than the batch value.

If the readme file could not be saved then `createReadme.sh` will exit. If a DOI does not have a dataset associated with it then the next DOI in value will be checked to see if it belongs to a dataset in GigaDB.

Exception handling has been improved in the readme component and controller classes. This was done to allow more intuitive console feedback to the user when problems arise from creating readme files and for the createReadme.sh script to react to errors.

## Any changes to automated tests?

Minor update to the bad DOI functional test to check exit code.

## Any changes to documentation?

The README.md file for the readme tool has been updated with how to use the --batch parameter and with better general documentation.

