### PR TITLE
feat: Enable provisioning of EIP to bastion hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1338: Enable persistent IP address using EIP for bastion hosts on AWS deployments
 - Feat #580: Provision monitoring infrastructure with Prometheus and Grafana
 
 ## 2023-06-20

--- a/ops/infrastructure/modules/bastion-aws-instance/bastion-aws-instance.tf
+++ b/ops/infrastructure/modules/bastion-aws-instance/bastion-aws-instance.tf
@@ -79,6 +79,18 @@ resource "aws_instance" "bastion" {
   }
 }
 
+data "aws_eip" "bastion_host_eip" {
+  filter {
+    name   = "tag:Name"
+    values = [var.eip_tag_name]
+  }
+}
+
+resource "aws_eip_association" "docker_host_eip_assoc" {
+  instance_id   = aws_instance.bastion.id
+  allocation_id = data.aws_eip.bastion_host_eip.id
+}
+
 output "bastion_private_ip" {
   description = "EC2 bastion instance private IP address"
   value = aws_instance.bastion.private_ip

--- a/ops/infrastructure/modules/bastion-aws-instance/input.tf
+++ b/ops/infrastructure/modules/bastion-aws-instance/input.tf
@@ -1,5 +1,6 @@
 variable "owner" {}
 variable "deployment_target" {}
 variable "key_name" {}
+variable "eip_tag_name" {}
 variable "public_subnet_id" {}
 variable "vpc_id" {}

--- a/ops/infrastructure/terraform.tf
+++ b/ops/infrastructure/terraform.tf
@@ -189,6 +189,7 @@ module "ec2_bastion" {
   owner = data.external.callerUserName.result.userName
   deployment_target = var.deployment_target
   key_name = var.key_name
+  eip_tag_name = "eip-gigadb-bastion-${var.deployment_target}-${data.external.callerUserName.result.userName}"
 
   # Bastion instance goes into a public subnet for developer access
   vpc_id = module.vpc.vpc_id


### PR DESCRIPTION
# Pull request for issue: #1338
This is a pull request for the following functionalities:

* Enable terraform provisioning to re-associate EIPs for bastion hosts

It wasn't scheduled, but since it has been done manually to facilitate curators's work on bastion, 
we can no longer re-provision the beta website until this PR is merged:
 * because on beta, the EIP is now considered the public IP by AWS infrastructure, so Ansible playbook are failing
 * because if we fully re-provision with terraform first, the EIP re-association for bastion host wont' happen

## How to test?


* Manually create EIP for your AWS staging and live with following `Tag:Name`: `eip-gigadb-bastion-staging-<your AWSrole name>` and `eip-gigadb-bastion-live-<your AWSrole name>`

### staging

* Provision with terraform and ansible as usual
* ssh to the bastion server using the EIP address
* you should be logged in to the bastion server as the `centos` user

```
$ cd ops/infrastructure/envs/staging/
$ ../../../scripts/tf_init.sh --project gigascience/forks/rija-gigadb-website --env staging
$ terraform plan
$ terraform apply
$ terraform refresh
$ env TF_KEY_NAME=private_ip OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES  ansible-playbook -i ../../inventories webapp_playbook.yml
$ env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook -i ../../inventories bastion_playbook.yml -e "backupDate=latest"
```

### live

* Provision with terraform and ansible as usual
* ssh to the bastion server using the EIP address
* you should be logged in to the bastion server as the `centos` user

```
$ cd ops/infrastructure/envs/live/
$ ../../../scripts/tf_init.sh --project gigascience/forks/rija-gigadb-website --env live
$ terraform plan
$ terraform apply
$ terraform refresh
$ env TF_KEY_NAME=private_ip OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES  ansible-playbook -i ../../inventories webapp_playbook.yml
$ env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook -i ../../inventories bastion_playbook.yml -e "backupDate=latest"
```
## How have functionalities been implemented?

I copied what was done to the `aws-instance` Terraform module into the `bastion-aws-instance` module, 
and updated `terraform.tf` module arguments accordingly (both in that file and in the `input.tf` file)
