### PR TITLE
Dataset page - remove empty section used for styling

### DIFF
--- a/less/current/pages/dataset.less
+++ b/less/current/pages/dataset.less
@@ -1,4 +1,7 @@
 /* dataset */
+.dataset-view-container {
+  margin-top: 40px;
+}
 .media-left {
   padding-right: 20px;
 }

--- a/protected/views/dataset/view.php
+++ b/protected/views/dataset/view.php
@@ -17,8 +17,7 @@ $sampleDataProvider = $samples->getDataProvider() ;
 <?php $this->renderPartial('_files_setting', array('setting' => $setting, 'pageSize' => $fileDataProvider->getPagination()->getPageSize()));?>
 
 <div class="content">
-    <div class="container">
-                <section></section>
+    <div class="container dataset-view-container">
                 <div class="subsection">
                     <div class="media">
                         <div class="media-left">


### PR DESCRIPTION
# Pull request for issue: #1370 

NOTE: I'm including this fix in PR for #1371, feel free to ignore this PR

This is a pull request for the following functionalities:

* Replace empty section used for styling by css class

## How to test?

Navigate here http://gigadb.gigasciencejournal.com:9170/dataset/100006 and confirm that there is spacing between content and header, and that there are no empty `<section></section>` blocks in the html

## How have functionalities been implemented?

Removed the section and added additional class to provide margin top

## Any issues with implementation?

None

## Any changes to automated tests?

None

## Any changes to documentation?

None

## Any technical debt repayment?

None

## Any improvements to CI/CD pipeline?

None
