### PR TITLE
A11y - Improve semantics of breadcrumbs sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1432: Improve semantics of breadcrumbs sections and other minor breadcrumb-related tweaks
 - Feat #1363: Fix color contrast issues in pages with new layouts
 - Feat #1309: Implement batch processing functionality for readme tool
 - Feat #1356: Delete local bootstrap files and replace them with Bootstrap 2.0.4 from CDN

--- a/less/current.less
+++ b/less/current.less
@@ -29,6 +29,7 @@
 @import "current/pages/about.less";
 @import "current/pages/advisory.less";
 @import "current/pages/dataset.less";
+@import "current/pages/guides.less";
 @import "current/modules/pagination.less";
 @import "current/pages/help.less";
 @import "current/modules/faqsearchbar.less";

--- a/less/current/layout/section.less
+++ b/less/current/layout/section.less
@@ -5,7 +5,7 @@
 section {
   margin-bottom: 40px;
 }
-section.page-title-section {
+section.page-title-section, .section.page-title-section {
   margin-bottom: 20px;
 }
 

--- a/less/current/modules/breadcrumb.less
+++ b/less/current/modules/breadcrumb.less
@@ -1,19 +1,23 @@
 .breadcrumb {
   display: inline-block;
   background-color: transparent;
-  padding: 0px;
+  padding: 0px 0px 4px 0px;
+  border-radius: 0;
 }
-.breadcrumb li.active {
+.breadcrumb .breadcrumb-item {
+  line-height: 22px;
+}
+.breadcrumb :is(li,.breadcrumb-item).active {
   color: @gigadb-green-on-white;
   font-size: 12px;
 }
-.breadcrumb li a,
-.breadcrumb li a:focus {
+.breadcrumb :is(li,.breadcrumb-item) a,
+.breadcrumb :is(li,.breadcrumb-item) a:focus {
   color: @dark-gray-on-white;
   font-size: 12px;
   text-decoration: none;
 }
-.breadcrumb li a:hover {
+.breadcrumb :is(li,.breadcrumb-item) a:hover {
   color: @gigadb-green-on-white;
   text-decoration: none;
 }

--- a/less/current/pages/guides.less
+++ b/less/current/pages/guides.less
@@ -1,0 +1,3 @@
+.guides-title-section {
+  margin-bottom: 10px;
+}

--- a/protected/views/authorisedDataset/filesAnnotate.php
+++ b/protected/views/authorisedDataset/filesAnnotate.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 ?>
 <div class="content">
     <div id="gigadb-fuw">
@@ -18,20 +18,22 @@
             <?php echo CHtml::beginForm(); ?>
                 <header class="page-title-section">
                     <div class="page-title">
-                        <ol class="breadcrumb pull-right">
-                            <li><a href="/">Home</a></li>
-                            <li><a href="/user/view_profile#submitted">Your profile</a></li>
-                            <li><a href="/authorisedDataset/uploadFiles/id/<?php echo $identifier; ?>">Step 1/2: Upload files</a></li>
-                            <li class="active">Step 2/2: Annotate files</li>
-                        </ol>
+                        <nav aria-label="breadcrumbs">
+                            <ol class="breadcrumb pull-right">
+                                <li><a href="/">Home</a></li>
+                                <li><a href="/user/view_profile#submitted">Your profile</a></li>
+                                <li><a href="/authorisedDataset/uploadFiles/id/<?php echo $identifier; ?>">Step 1/2: Upload files</a></li>
+                                <li class="active">Step 2/2: Annotate files</li>
+                            </ol>
+                        </nav>
                         <dataset-info identifier="<?php echo $identifier; ?>" />
                     </div>
                 </header>
                 <section class="row">
-                    <annotator identifier="<?php echo $identifier ?>" 
-                                v-bind:uploads='<?php echo json_encode($uploads) ?>' 
+                    <annotator identifier="<?php echo $identifier ?>"
+                                v-bind:uploads='<?php echo json_encode($uploads) ?>'
                                 v-bind:filetypes='<?php echo $filetypes ?>'
-                                v-bind:attributes='<?php echo json_encode($attributes, JSON_HEX_APOS|JSON_HEX_QUOT) ?>' 
+                                v-bind:attributes='<?php echo json_encode($attributes, JSON_HEX_APOS|JSON_HEX_QUOT) ?>'
                     />
                 </section>
                 <footer>

--- a/protected/views/authorisedDataset/filesUpload.php
+++ b/protected/views/authorisedDataset/filesUpload.php
@@ -4,11 +4,13 @@
         <article class="container">
             <header class="page-title-section">
                 <div class="page-title">
-                    <ol class="breadcrumb pull-right">
-                        <li><a href="/">Home</a></li>
-                        <li><a href="/user/view_profile#submitted">Your profile</a></li>
-                        <li class="active">Step 1/2: Upload files</li>
-                    </ol>
+                    <nav aria-label="breadcrumbs">
+                        <ol class="breadcrumb pull-right">
+                            <li><a href="/">Home</a></li>
+                            <li><a href="/user/view_profile#submitted">Your profile</a></li>
+                            <li class="active">Step 1/2: Upload files</li>
+                        </ol>
+                    </nav>
                     <dataset-info identifier="<?= $identifier ?>" />
                 </div>
             </header>

--- a/protected/views/resetPasswordRequest/forgot.php
+++ b/protected/views/resetPasswordRequest/forgot.php
@@ -3,15 +3,17 @@ $this->pageTitle='Forgotten password';
 ?>
 <div class="content">
     <div class="container">
-        <section class="page-title-section">
+        <div class="section page-title-section">
             <div class="page-title">
-                <ol class="breadcrumb pull-right">
-                    <li><a href="/">Home</a></li>
-                    <li class="active">Forgot</li>
-                </ol>
+                <nav aria-label="breadcrumbs">
+                    <ol class="breadcrumb pull-right">
+                        <li><a href="/">Home</a></li>
+                        <li class="active">Forgot</li>
+                    </ol>
+                </nav>
                 <h4>Forgotten password</h4>
             </div>
-        </section>
+        </div>
     <div class="subsection row" style="margin-bottom: 130px;">
         <div class="col-xs-12">
             <?php if(Yii::app()->user->hasFlash('fail-reset-password')): ?>

--- a/protected/views/resetPasswordRequest/reset.php
+++ b/protected/views/resetPasswordRequest/reset.php
@@ -3,15 +3,17 @@ $this->pageTitle='Reset password';
 ?>
 <div class="content">
     <div class="container">
-        <section class="page-title-section">
+        <div class="section page-title-section">
             <div class="page-title">
-                <ol class="breadcrumb pull-right">
-                    <li><a href="/">Home</a></li>
-                    <li class="active">Reset Password</li>
-                </ol>
+                <nav aria-label="breadcrumbs">
+                    <ol class="breadcrumb pull-right">
+                        <li><a href="/">Home</a></li>
+                        <li class="active">Reset Password</li>
+                    </ol>
+                </nav>
                 <h4><?= Yii::t('app', 'Reset Password') ?></h4>
             </div>
-        </section>
+        </div>
     </div>
 </div>
 

--- a/protected/views/resetPasswordRequest/thanks.php
+++ b/protected/views/resetPasswordRequest/thanks.php
@@ -3,15 +3,17 @@ $this->pageTitle='Thanks';
 ?>
 <div class="content">
     <div class="container">
-        <section class="page-title-section">
+        <div class="section page-title-section">
             <div class="page-title">
-                <ol class="breadcrumb pull-right">
-                    <li><a href="/">Home</a></li>
-                    <li class="active">Thanks</li>
-                </ol>
+                <nav aria-label="breadcrumbs">
+                    <ol class="breadcrumb pull-right">
+                        <li><a href="/">Home</a></li>
+                        <li class="active">Thanks</li>
+                    </ol>
+                </nav>
                 <h4>Reset Password Request Submitted</h4>
             </div>
-        </section>
+        </div>
         <div class="subsection" style="margin-bottom: 130px;">
             <p><?=Yii::t('app' , 'For security reasons, we cannot tell you if the email you entered is valid or not.<br/>If it is valid, we will send an email containing a link to where you can reset your password.')?></p>
             <p>If you do not receive the reset password email within a few minutes, please check your Junk/Spam E-mail folder</p>

--- a/protected/views/site/about.php
+++ b/protected/views/site/about.php
@@ -7,15 +7,17 @@ $this->pageTitle = 'GigaDB - About';
 <div class="clear"></div>
 <div class="content">
     <div class="container">
-        <section class="page-title-section">
+        <div class="section page-title-section">
             <div class="page-title">
-                <ol class="breadcrumb pull-right">
-                    <li><a href="/">Home</a></li>
-                    <li class="active">General information</li>
-                </ol>
+                <nav aria-label="breadcrumbs">
+                    <ol class="breadcrumb pull-right">
+                        <li><a href="/">Home</a></li>
+                        <li class="active">General information</li>
+                    </ol>
+                </nav>
                 <h4>General information</h4>
             </div>
-        </section>
+        </div>
         <div class="subsection">
             <img src="../images/new_interface_image/about.png">
         </div>

--- a/protected/views/site/advisory.php
+++ b/protected/views/site/advisory.php
@@ -6,15 +6,17 @@ $this->pageTitle='GigaDB - About';
 <div class="clear"></div>
 <div class="content">
             <div class="container">
-                <section class="page-title-section">
+                <div class="section page-title-section">
                     <div class="page-title">
-                        <ol class="breadcrumb pull-right">
-                            <li><a href="/">Home</a></li>
-                            <li class="active">Advisory Board</li>
-                        </ol>
+                        <nav aria-label="breadcrumbs">
+                            <ol class="breadcrumb pull-right">
+                                <li><a href="/">Home</a></li>
+                                <li class="active">Advisory Board</li>
+                            </ol>
+                        </nav>
                         <h4>Advisory Board</h4>
                     </div>
-                </section>
+                </div>
                 <div class="subsection">
                     <p>In order to aid <a href="/site/index" target="_blank">GigaDB</a> in following best practices, advancing community needs, and taking advantage of novel ideas/tools that can promote innovation as the database evolves, we not only leverage the excellent <a href="https://academic.oup.com/gigascience/pages/Editorial_Board">Editorial Board</a> that advises <a href="http://www.gigasciencejournal.com/" target="_blank"><em>GigaScience</em></a> Journal, we also have the following more focused GigaDB Advisory panel that we can ask for advice and guidance on specific topics.</p>
                     <p>We strongly encourage community feedback and involvement, so please feel free to contact any of the <a href="/site/team"><em>GigaScience team</em></a>, or use the <a href="/site/contact">contact us</a> form.</p>

--- a/protected/views/site/contact.php
+++ b/protected/views/site/contact.php
@@ -13,15 +13,17 @@
 ?>
  <div class="content">
             <div class="container">
-                <section class="page-title-section">
+                <div class="section page-title-section">
                     <div class="page-title">
-                        <ol class="breadcrumb pull-right">
-                            <li><a href="/">Home</a></li>
-                            <li class="active">Contact</li>
-                        </ol>
+                        <nav aria-label="breadcrumbs">
+                            <ol class="breadcrumb pull-right">
+                                <li><a href="/">Home</a></li>
+                                <li class="active">Contact</li>
+                            </ol>
+                        </nav>
                         <h4>Contact</h4>
                     </div>
-                </section>
+                </div>
                 <div class="subsection">
                     <img src="../images/new_interface_image/shekmun_map.png">
                 </div>
@@ -37,23 +39,23 @@
                                 <p>For more information or questions regarding submitting data to GigaDB, please contact us at: <a href="mailto:database@gigasciencejournal.com" target="_blank">database@gigasciencejournal.com</a>.</p>
                                 <p>Fields with <span class="text-danger">*</span> are required.</p>
                             </div>
-                            
-                            
-		
+
+
+
 			<? $form=$this->beginWidget('CActiveForm', array('htmlOptions'=>array('class'=>'form contact-form'))); ?>
 				<div class="col-xs-7">
                                     <div class="form-group">
 					<?= $form->labelEx($model,'name', array('class'=>'text-danger')); ?>
                                         <?= $form->textField($model,'name',array('class'=>'form-control')); ?>
                                         <?php echo $form->error($model,'name'); ?>
-					
+
                                      </div>
-                                 </div>    
+                                 </div>
 
 				<div class="col-xs-7">
                                     <div class="form-group">
 					<?= $form->labelEx($model,'email', array('class'=>'control-label')); ?>
-					
+
 						<?= $form->textField($model,'email',array('class'=>'form-control')); ?>
 						<?php echo $form->error($model,'email'); ?>
 					</div>
@@ -62,7 +64,7 @@
 				<div class="col-xs-7">
                                     <div class="form-group">
 					<?= $form->labelEx($model,'subject', array('class'=>'control-label')); ?>
-					
+
 						<?= $form->textField($model,'subject',array('class'=>'form-control')); ?>
 						<?php echo $form->error($model,'subject'); ?>
 					</div>
@@ -71,38 +73,38 @@
 				<div class="col-xs-12">
                                     <div class="form-group">
 					<?= $form->labelEx($model,'body', array('class'=>'control-label')); ?>
-					
+
 						<?= $form->textArea($model,'body',array('rows'=>5,'class'=>'form-control')); ?>
 						<?php echo $form->error($model,'body'); ?>
 					</div>
 				</div>
 
                                 <div class="col-xs-7">
-                                    <div class="form-group">		
-					<?php echo $form->labelEx($model,'verifyCode'); ?>		
-                                         				
-						<div style="width:100%">	
+                                    <div class="form-group">
+					<?php echo $form->labelEx($model,'verifyCode'); ?>
+
+						<div style="width:100%">
 							<img style="width:200px;" src="<?php echo Yii::app()->captcha->output(); ?>">
 						</div>
                                                 <br>
                                                 <br>
-						<?php echo $form->textField($model,'verifyCode',array('class'=>'form-control')); ?>	
+						<?php echo $form->textField($model,'verifyCode',array('class'=>'form-control')); ?>
 						<div class="hint">Please enter the letters as they are shown in the image above.
 						<br/>Letters are case-sensitive.</div>
-						<?php echo $form->error($model, 'verifyCode'); ?>					
-						</div>		
+						<?php echo $form->error($model, 'verifyCode'); ?>
+						</div>
                                 </div>
-			
 
-				
 
-			
-		
+
+
+
+
                 <div class="span8 offset2"><?= CHtml::submitButton('Submit', array('class'=>'btn background-btn')); ?></div>
 
                 <? $this->endWidget(); ?>
                 </div><!-- form -->
-                     
+
                         <div class="col-xs-3">
                             <div class="underline-title">
                                 <div>
@@ -118,7 +120,7 @@
                         </div>
                 </div>
                 </section>
-                                   
+
             </div>
         </div>
 

--- a/protected/views/site/faq.php
+++ b/protected/views/site/faq.php
@@ -7,23 +7,25 @@ $this->pageTitle='GigaDB - About';
 <div class="clear"></div>
 <div class="content">
             <div class="container">
-                <section class="page-title-section">
+                <div class="section page-title-section">
                     <div class="page-title">
-                        <ol class="breadcrumb pull-right">
-                            <li><a href="/">Home</a></li>
-                            <li class="active">FAQ</li>
-                        </ol>
+                        <nav aria-label="breadcrumbs">
+                            <ol class="breadcrumb pull-right">
+                                <li><a href="/">Home</a></li>
+                                <li class="active">FAQ</li>
+                            </ol>
+                        </nav>
                         <h4>FAQ</h4>
                     </div>
-                </section>
-               
+                </div>
+
                 <section>
                     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
                         <div class="panel panel-default">
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel01" aria-expanded="false" aria-controls="panel01">
-                                    What is <em>GigaDB</em>?    
+                                    What is <em>GigaDB</em>?
                                     </a>
                                 </h4>
                             </div>
@@ -37,7 +39,7 @@ $this->pageTitle='GigaDB - About';
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel02" aria-expanded="false" aria-controls="panel02">
-                                    What journals are integrated with <em>GigaDB</em>?    
+                                    What journals are integrated with <em>GigaDB</em>?
                                     </a>
                                 </h4>
                             </div>
@@ -51,7 +53,7 @@ $this->pageTitle='GigaDB - About';
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel03" aria-expanded="false" aria-controls="panel03">
-                                    Why use <em>GigaDB</em>?    
+                                    Why use <em>GigaDB</em>?
                                     </a>
                                 </h4>
                             </div>
@@ -65,7 +67,7 @@ $this->pageTitle='GigaDB - About';
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel04" aria-expanded="false" aria-controls="panel04">
-                                    What kinds of data does <em>GigaDB</em> accept?    
+                                    What kinds of data does <em>GigaDB</em> accept?
                                     </a>
                                 </h4>
                             </div>
@@ -79,7 +81,7 @@ $this->pageTitle='GigaDB - About';
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel05" aria-expanded="false" aria-controls="panel05">
-                                    My research is on human subjects. Can I archive my data in <em>GigaDB</em>?    
+                                    My research is on human subjects. Can I archive my data in <em>GigaDB</em>?
                                     </a>
                                 </h4>
                             </div>
@@ -93,7 +95,7 @@ $this->pageTitle='GigaDB - About';
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel06" aria-expanded="false" aria-controls="panel06">
-                                    In what file format(s) should I submit my data?    
+                                    In what file format(s) should I submit my data?
                                     </a>
                                 </h4>
                             </div>
@@ -107,7 +109,7 @@ $this->pageTitle='GigaDB - About';
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel07" aria-expanded="false" aria-controls="panel07">
-                                    When should I submit my data?    
+                                    When should I submit my data?
                                     </a>
                                 </h4>
                             </div>
@@ -121,7 +123,7 @@ $this->pageTitle='GigaDB - About';
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel08" aria-expanded="false" aria-controls="panel08">
-                                    How can I modify files I have submitted to <em>GigaDB</em> while my article is in review?    
+                                    How can I modify files I have submitted to <em>GigaDB</em> while my article is in review?
                                     </a>
                                 </h4>
                             </div>
@@ -135,7 +137,7 @@ $this->pageTitle='GigaDB - About';
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel09" aria-expanded="false" aria-controls="panel09">
-                                    What should I prepare before submission?    
+                                    What should I prepare before submission?
                                     </a>
                                 </h4>
                             </div>
@@ -149,7 +151,7 @@ $this->pageTitle='GigaDB - About';
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel10" aria-expanded="false" aria-controls="panel10">
-                                    How can I make my data submission as accessible and reusable as possible?    
+                                    How can I make my data submission as accessible and reusable as possible?
                                     </a>
                                 </h4>
                             </div>
@@ -163,7 +165,7 @@ $this->pageTitle='GigaDB - About';
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel11" aria-expanded="false" aria-controls="panel11">
-                                    How do I submit data?    
+                                    How do I submit data?
                                     </a>
                                 </h4>
                             </div>
@@ -182,7 +184,7 @@ $this->pageTitle='GigaDB - About';
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel12" aria-expanded="false" aria-controls="panel12">
-                                    How do I write a ReadMe file?    
+                                    How do I write a ReadMe file?
                                     </a>
                                 </h4>
                             </div>
@@ -219,7 +221,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel13" aria-expanded="false" aria-controls="panel13">
-                                    How do I cite the data in my manuscript?    
+                                    How do I cite the data in my manuscript?
                                     </a>
                                 </h4>
                             </div>
@@ -233,7 +235,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel14" aria-expanded="false" aria-controls="panel14">
-                                    Are there any problems with publishing my final research paper AFTER publishing the data in GigaScience?    
+                                    Are there any problems with publishing my final research paper AFTER publishing the data in GigaScience?
                                     </a>
                                 </h4>
                             </div>
@@ -254,7 +256,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel15" aria-expanded="false" aria-controls="panel15">
-                                    Do I have the option to embargo release of my data?    
+                                    Do I have the option to embargo release of my data?
                                     </a>
                                 </h4>
                             </div>
@@ -271,7 +273,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel16" aria-expanded="false" aria-controls="panel16">
-                                    How much does it cost?    
+                                    How much does it cost?
                                     </a>
                                 </h4>
                             </div>
@@ -285,7 +287,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel17" aria-expanded="false" aria-controls="panel17">
-                                    Do I have to pay to download or use the data?    
+                                    Do I have to pay to download or use the data?
                                     </a>
                                 </h4>
                             </div>
@@ -299,7 +301,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel18" aria-expanded="false" aria-controls="panel18">
-                                    How do I download a large dataset with my slow internet connection?    
+                                    How do I download a large dataset with my slow internet connection?
                                     </a>
                                 </h4>
                             </div>
@@ -317,7 +319,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel19" aria-expanded="false" aria-controls="panel19">
-                                    How do I cite data from <em>GigaDB</em>?    
+                                    How do I cite data from <em>GigaDB</em>?
                                     </a>
                                 </h4>
                             </div>
@@ -331,7 +333,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel20" aria-expanded="false" aria-controls="panel20">
-                                    How do I download information to my citation management software?    
+                                    How do I download information to my citation management software?
                                     </a>
                                 </h4>
                             </div>
@@ -345,7 +347,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel21" aria-expanded="false" aria-controls="panel21">
-                                    What is a dataset?    
+                                    What is a dataset?
                                     </a>
                                 </h4>
                             </div>
@@ -359,7 +361,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel22" aria-expanded="false" aria-controls="panel22">
-                                    Does my journal work with <em>GigaDB</em> and how?    
+                                    Does my journal work with <em>GigaDB</em> and how?
                                     </a>
                                 </h4>
                             </div>
@@ -373,7 +375,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel23" aria-expanded="false" aria-controls="panel23">
-                                    What is a <em>GigaDB</em> DOI?    
+                                    What is a <em>GigaDB</em> DOI?
                                     </a>
                                 </h4>
                             </div>
@@ -387,7 +389,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel24" aria-expanded="false" aria-controls="panel24">
-                                    Why does <em>GigaDB</em> use Creative Commons Zero?    
+                                    Why does <em>GigaDB</em> use Creative Commons Zero?
                                     </a>
                                 </h4>
                             </div>
@@ -401,7 +403,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel25" aria-expanded="false" aria-controls="panel25">
-                                    Can the <em>GigaDB</em> repository help me prepare a data management plan?    
+                                    Can the <em>GigaDB</em> repository help me prepare a data management plan?
                                     </a>
                                 </h4>
                             </div>
@@ -415,7 +417,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel26" aria-expanded="false" aria-controls="panel26">
-                                    What are the charges for submitting data?    
+                                    What are the charges for submitting data?
                                     </a>
                                 </h4>
                             </div>
@@ -429,7 +431,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel27" aria-expanded="false" aria-controls="panel27">
-                                    Why is submission to <em>GigaDB</em> not closely integrated with submission to GigaScience?    
+                                    Why is submission to <em>GigaDB</em> not closely integrated with submission to GigaScience?
                                     </a>
                                 </h4>
                             </div>
@@ -443,7 +445,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel28" aria-expanded="false" aria-controls="panel28">
-                                    How are datasets in <em>GigaDB</em> backed up?    
+                                    How are datasets in <em>GigaDB</em> backed up?
                                     </a>
                                 </h4>
                             </div>
@@ -457,7 +459,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel29" aria-expanded="false" aria-controls="panel29">
-                                    What happens to data after it is submitted?    
+                                    What happens to data after it is submitted?
                                     </a>
                                 </h4>
                             </div>
@@ -471,7 +473,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel30" aria-expanded="false" aria-controls="panel30">
-                                    Can I see how often my dataset is being used and downloaded?    
+                                    Can I see how often my dataset is being used and downloaded?
                                     </a>
                                 </h4>
                             </div>
@@ -485,7 +487,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel31" aria-expanded="false" aria-controls="panel31">
-                                    How may data from <em>GigaDB</em> be reused?    
+                                    How may data from <em>GigaDB</em> be reused?
                                     </a>
                                 </h4>
                             </div>
@@ -494,12 +496,12 @@ Files:
                                     <p>It can be used for anything by anyone, most* data is given the licence CC0 specifically to remove any restrictions on reuse. * - on occasion we host some files for convenience of our users that are already covered by other licences (e.g. more appropriate OSI-compliant licenses for software, or multiple (all open) licenses in a workflow or virtual machine), where this happens we make every effort to make users aware of the different licences.</p>
                                 </div>
                             </div>
-                        </div>                      
+                        </div>
                         <div class="panel panel-default">
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel32" aria-expanded="false" aria-controls="panel32">
-                                    What is Hypothes.is?    
+                                    What is Hypothes.is?
                                     </a>
                                 </h4>
                             </div>
@@ -513,7 +515,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel33" aria-expanded="false" aria-controls="panel33">
-                                    How do I report missing values in my metadata?    
+                                    How do I report missing values in my metadata?
                                     </a>
                                 </h4>
                             </div>
@@ -532,7 +534,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel34" aria-expanded="false" aria-controls="panel34">
-                                    Why do you request so many sample attributes?    
+                                    Why do you request so many sample attributes?
                                     </a>
                                 </h4>
                             </div>
@@ -546,7 +548,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel35" aria-expanded="false" aria-controls="panel35">
-                                    Why is the directory structure missing from the file table view on my dataset page?   
+                                    Why is the directory structure missing from the file table view on my dataset page?
                                     </a>
                                 </h4>
                             </div>
@@ -560,7 +562,7 @@ Files:
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel36" aria-expanded="false" aria-controls="panel36">
-                                    What should I do if I accidentally identify an individual from anonymized human (meta)data within a dataset?   
+                                    What should I do if I accidentally identify an individual from anonymized human (meta)data within a dataset?
                                     </a>
                                 </h4>
                             </div>
@@ -575,7 +577,7 @@ We will assess the specific case and remove/reduce the amount of metadata availa
                             <div class="panel-heading" role="tab">
                                 <h4 class="panel-title">
                                     <a role="button" data-toggle="collapse" data-parent="#accordion" href="#panel37" aria-expanded="false" aria-controls="panel37">
-                                    What curation do you carry out?  
+                                    What curation do you carry out?
                                     </a>
                                 </h4>
                             </div>
@@ -745,7 +747,7 @@ We will assess the specific case and remove/reduce the amount of metadata availa
                         </div>
                     </div>
                 </section>
-               
+
             </div>
         </div>
 

--- a/protected/views/site/guide.php
+++ b/protected/views/site/guide.php
@@ -17,15 +17,17 @@ th, td {
 </style>
 <div class="content">
     <div class="container">
-        <section class="page-title-section" style="margin-bottom: 10px">
+        <div class="section page-title-section guides-title-section">
             <div class="page-title">
-                <ol class="breadcrumb pull-right">
-                    <li><a href="/">Home</a></li>
-                    <li class="active">Guidelines</li>
-                </ol>
+                <nav aria-label="breadcrumbs">
+                    <ol class="breadcrumb pull-right">
+                        <li><a href="/">Home</a></li>
+                        <li class="active">Guidelines</li>
+                    </ol>
+                </nav>
                 <h4>GigaDB - Submission Guidelines</h4>
             </div>
-        </section>
+        </div>
         <section>
 
             <section style="margin-bottom: 5px;">

--- a/protected/views/site/guideepigenomic.php
+++ b/protected/views/site/guideepigenomic.php
@@ -17,15 +17,17 @@ th, td {
 </style>
 <div class="content">
     <div class="container">
-        <section class="page-title-section" style="margin-bottom: 10px">
+        <div class="section page-title-section guides-title-section">
             <div class="page-title">
-                <ol class="breadcrumb pull-right">
-                    <li><a href="/">Home</a></li>
-                    <li class="active">Guidelines</li>
-                </ol>
+                <nav aria-label="breadcrumbs">
+                    <ol class="breadcrumb pull-right">
+                        <li><a href="/">Home</a></li>
+                        <li class="active">Guidelines</li>
+                    </ol>
+                </nav>
                 <h4>General Submission Guidelines</h4>
             </div>
-        </section>
+        </div>
         <section style="margin-bottom: 5px;">
                 <div style="display:inline-block;">
                     <ul class="nav nav-tabs nav-border-tabs" role="tablist" style="margin-top: 1px; margin-bottom: 1px">

--- a/protected/views/site/guidegenomic.php
+++ b/protected/views/site/guidegenomic.php
@@ -17,15 +17,17 @@ th, td {
 </style>
 <div class="content">
     <div class="container">
-        <section class="page-title-section" style="margin-bottom: 10px">
+        <div class="section page-title-section guides-title-section">
             <div class="page-title">
-                <ol class="breadcrumb pull-right">
-                    <li><a href="/">Home</a></li>
-                    <li class="active">Guidelines</li>
-                </ol>
+                <nav aria-label="breadcrumbs">
+                    <ol class="breadcrumb pull-right">
+                        <li><a href="/">Home</a></li>
+                        <li class="active">Guidelines</li>
+                    </ol>
+                </nav>
                 <h4>General Submission Guidelines</h4>
             </div>
-        </section>
+        </div>
         <section style="margin-bottom: 5px;">
                 <div style="display:inline-block;">
                     <ul class="nav nav-tabs nav-border-tabs" role="tablist" style="margin-top: 1px; margin-bottom: 1px">

--- a/protected/views/site/guideimaging.php
+++ b/protected/views/site/guideimaging.php
@@ -17,15 +17,17 @@ th, td {
 </style>
 <div class="content">
     <div class="container">
-        <section class="page-title-section" style="margin-bottom: 10px">
+        <div class="section page-title-section guides-title-section">
             <div class="page-title">
-                <ol class="breadcrumb pull-right">
-                    <li><a href="/">Home</a></li>
-                    <li class="active">Guidelines</li>
-                </ol>
+                <nav aria-label="breadcrumbs">
+                    <ol class="breadcrumb pull-right">
+                        <li><a href="/">Home</a></li>
+                        <li class="active">Guidelines</li>
+                    </ol>
+                </nav>
                 <h4>General Submission Guidelines</h4>
             </div>
-        </section>
+        </div>
         <section style="margin-bottom: 5px;">
                 <div style="display:inline-block;">
                      <ul class="nav nav-tabs nav-border-tabs" role="tablist" style="margin-top: 1px; margin-bottom: 1px">

--- a/protected/views/site/guidemetabolomic.php
+++ b/protected/views/site/guidemetabolomic.php
@@ -17,15 +17,17 @@ th, td {
 </style>
 <div class="content">
     <div class="container">
-        <section class="page-title-section" style="margin-bottom: 10px">
+        <div class="section page-title-section guides-title-section">
             <div class="page-title">
-                <ol class="breadcrumb pull-right">
-                    <li><a href="/">Home</a></li>
-                    <li class="active">Guidelines</li>
-                </ol>
+                <nav aria-label="breadcrumbs">
+                    <ol class="breadcrumb pull-right">
+                        <li><a href="/">Home</a></li>
+                        <li class="active">Guidelines</li>
+                    </ol>
+                </nav>
                 <h4>General Submission Guidelines</h4>
             </div>
-        </section>
+        </div>
         <section style="margin-bottom: 5px;">
                 <div style="display:inline-block;">
                         <ul class="nav nav-tabs nav-border-tabs" role="tablist" style="margin-top: 1px; margin-bottom: 1px">

--- a/protected/views/site/guidemetagenomic.php
+++ b/protected/views/site/guidemetagenomic.php
@@ -17,15 +17,17 @@ th, td {
 </style>
 <div class="content">
     <div class="container">
-        <section class="page-title-section" style="margin-bottom: 10px">
+        <div class="section page-title-section guides-title-section">
             <div class="page-title">
-                <ol class="breadcrumb pull-right">
-                    <li><a href="/">Home</a></li>
-                    <li class="active">Guidelines</li>
-                </ol>
+                <nav aria-label="breadcrumbs">
+                    <ol class="breadcrumb pull-right">
+                        <li><a href="/">Home</a></li>
+                        <li class="active">Guidelines</li>
+                    </ol>
+                </nav>
                 <h4>General Submission Guidelines</h4>
             </div>
-        </section>
+        </div>
         <section style="margin-bottom: 5px;">
                 <div style="display:inline-block;">
                     <ul class="nav nav-tabs nav-border-tabs" role="tablist" style="margin-top: 1px; margin-bottom: 1px">

--- a/protected/views/site/guidesoftware.php
+++ b/protected/views/site/guidesoftware.php
@@ -16,15 +16,17 @@ $this->pageTitle = 'GigaDB - Software Dataset checklists';
 </style>
 <div class="content">
     <div class ="container">
-        <section class="page-title-section" style="margin-bottom: 10px;">
+        <div class="section page-title-section guides-title-section">
             <div class="page-title">
-                <ol class="breadcrumb pull-right">
-                    <li><a href="/">Home</a> </li>
-                    <li class="active">Guidelines</li>
-                </ol>
+                <nav aria-label="breadcrumbs">
+                    <ol class="breadcrumb pull-right">
+                        <li><a href="/">Home</a> </li>
+                        <li class="active">Guidelines</li>
+                    </ol>
+                </nav>
                 <h4>General Submission Guidelines</h4>
             </div>
-        </section>
+        </div>
         <section style="margin-bottom: 5px;">
             <div style="display:inline-block;">
                 <ul class="nav nav-tabs nav-border-tabs" role="tablist" style="margin-top: 1px; margin-bottom: 1px">

--- a/protected/views/site/help.php
+++ b/protected/views/site/help.php
@@ -4,16 +4,17 @@ $this->pageTitle='GigaDB - Help';
 
 <div class="content">
             <div class="container">
-                <section class="page-title-section">
+                <div class="section page-title-section">
                     <div class="page-title">
-                        <ol class="breadcrumb pull-right">
-                            <li><a href="/">Home</a></li>
-                            <li><a href="about">About</a></li>
-                            <li class="active">Help</li>
-                        </ol>
+                        <nav aria-label="breadcrumbs">
+                            <ol class="breadcrumb pull-right">
+                                <li><a href="/">Home</a></li>
+                                <li class="active">Help</li>
+                            </ol>
+                        </nav>
                         <h4>Help</h4>
                     </div>
-                </section>
+                </div>
                 <div class="subsection">
                     <p>The <a href="http://gigadb.org/" target="_blank"><em>GigaDB</em></a> website allows any user to browse, search, view datasets and access data files. If you want to submit a dataset, save searches or be alerted of new content of interest we request that you <a href="/user/create" target="_blank">create an account</a>.</p>
                     <p>A 'Latest news' section will be visible to announce any updates or new features to the database and the RSS feed automatically announces each new dataset release.</p>

--- a/protected/views/site/index.php
+++ b/protected/views/site/index.php
@@ -18,7 +18,7 @@
                     <div class="col-xs-8">
                         <div class="underline-title">
                             <div class="breadcrumb pull-right" style="cursor:pointer">
-                                <span class="breadcrumb-item">+ more</span>
+                                <span class="breadcrumb-item" data-toggle="datasettypes">+ more</span>
                             </div>
                             <div>
                                 <h4>Dataset types</h4>
@@ -236,7 +236,7 @@
         $("#dataset-hint").popover();
 
         $(document).ready(function() {
-            $(".breadcrumb li span").click(function() {
+            $('[data-toggle="datasettypes"]').click(function() {
                 var togglediv = $(".home-text-icon-list:nth-child(3)");
                 togglediv.toggle();
                 if (togglediv.css("display") == 'block') {

--- a/protected/views/site/index.php
+++ b/protected/views/site/index.php
@@ -17,9 +17,9 @@
                 <div class="row">
                     <div class="col-xs-8">
                         <div class="underline-title">
-                            <ol class="breadcrumb pull-right" style="cursor:pointer">
-                                <li><span>+ more</span></li>
-                            </ol>
+                            <div class="breadcrumb pull-right" style="cursor:pointer">
+                                <span class="breadcrumb-item">+ more</span>
+                            </div>
                             <div>
                                 <h4>Dataset types</h4>
                             </div>

--- a/protected/views/site/login.php
+++ b/protected/views/site/login.php
@@ -4,18 +4,20 @@ $this->breadcrumbs=array(
 	'Login',
 );
 ?>
-<section>   
+<section>
 
 <div class="container" id="login">
-   <section class="page-title-section">
+   <div class="section page-title-section">
        <div class="page-title">
-            <ol class="breadcrumb pull-right">
-                <li><a href="/">Home</a></li>
-                <li class="active">login</li>
-            </ol>
+            <nav aria-label="breadcrumbs">
+                <ol class="breadcrumb pull-right">
+                    <li><a href="/">Home</a></li>
+                    <li class="active">Login</li>
+                </ol>
+            </nav>
             <h4>Login</h4>
        </div>
-   </section>
+   </div>
 	<div class="subsection row" style="margin-bottom: 130px;">
         <div class="col-xs-12">
             <?php if(Yii::app()->user->hasFlash('success-reset-password')): ?>
@@ -29,7 +31,7 @@ $this->breadcrumbs=array(
                     <p><?=Yii::t('app' , 'Please fill out the following form with your login credentials:')?></p>
                     <p><?=Yii::t('app' , 'Fields with <span class="symbol">*</span> are required.')?></p>
                 </div>
-               
+
                 <div class="login-div">
 			        <? $form = $this->beginWidget('CActiveForm', array('htmlOptions'=>array('class'=>'form-horizontal'))) ?>
 			    <div class="form-group">
@@ -65,5 +67,5 @@ $this->breadcrumbs=array(
             <? $this->endWidget() ?>
 	</div>
     </div>
-</div><!--login-->   
-</section>  
+</div><!--login-->
+</section>

--- a/protected/views/site/team.php
+++ b/protected/views/site/team.php
@@ -1,10 +1,14 @@
 <div class="content">
     <div class="container">
-        <section>
-            <div class="page-title">
-                <h4>Our team</h4>
-            </div>
-        </section>
+        <div class="page-title">
+            <nav aria-label="breadcrumbs">
+                <ol class="breadcrumb pull-right">
+                    <li><a href="/">Home</a></li>
+                    <li class="active">Team</li>
+                </ol>
+            </nav>
+            <h4>Our team</h4>
+        </div>
         <section>
             <div class="row" style="margin: 0px -8px;">
                 <table class="table member-table">

--- a/protected/views/site/term.php
+++ b/protected/views/site/term.php
@@ -4,15 +4,17 @@ $this->pageTitle = 'GigaDB - Terms of use';
 ?>
 <div class="content">
     <div class="container">
-        <section class="page-title-section">
+        <div class="section page-title-section">
             <div class="page-title">
-                <ol class="breadcrumb pull-right">
-                    <li><a href="/">Home</a></li>
-                    <li class="active">Terms of use</li>
-                </ol>
+                <nav aria-label="breadcrumbs">
+                    <ol class="breadcrumb pull-right">
+                        <li><a href="/">Home</a></li>
+                        <li class="active">Terms of use</li>
+                    </ol>
+                </nav>
                 <h4>Terms of use</h4>
             </div>
-        </section>
+        </div>
 <section style="margin-bottom: 15px;">
     <div>
         <ul class="nav nav-tabs nav-border-tabs" role="tablist">

--- a/protected/views/user/_form.php
+++ b/protected/views/user/_form.php
@@ -17,13 +17,13 @@
       if ( null != $user_command ) {
       	$claimed_author = Author::model()->findByPk($user_command->actionable_id);
       	$message = "This user has a pending claim on author ". $claimed_author->getDisplayName() ;
-      	$validate_link = CHtml::link('Validate', 
+      	$validate_link = CHtml::link('Validate',
                                     array('AdminUserCommand/validate', 'id' => $user_command->id),
                                     array('class' => 'btn'));
-      	$reject_link = CHtml::link('Reject', 
+      	$reject_link = CHtml::link('Reject',
                                     array('AdminUserCommand/reject', 'id' => $user_command->id),
                                     array('class' => 'btn'));
-      	$author_link = CHtml::link('Author info', 
+      	$author_link = CHtml::link('Author info',
                                     array('AdminAuthor/view', 'id' => $user_command->actionable_id),
                                     array('class' => 'btn'));
 ?>
@@ -39,11 +39,11 @@
 <?php
       }
       else if ( null ==  $linked_author) {
-          echo CHtml::link('Link this user to an author', 
+          echo CHtml::link('Link this user to an author',
                                     array('adminAuthor/prepareUserLink', 'user_id'=>$model->id),
-                                    array('class' => 'btn')); 
+                                    array('class' => 'btn'));
       }else {
-      	$unlink_link =  CHtml::link('Unlink author', 
+      	$unlink_link =  CHtml::link('Unlink author',
                                     array('AdminAuthor/unlinkUser', 'id' => $linked_author->id, 'user_id'=>$model->id),
                                     array('class' => 'btn'));
 ?>
@@ -56,19 +56,21 @@
       }
     }
 ?>
- 	
+
         <div class="container">
-              <section class="page-title-section">
+              <div class="section page-title-section">
                 <div class="page-title">
-                    <ol class="breadcrumb pull-right">
-                        <li><a href="/">Home</a></li>
-                        <li class="active">Personal details</li>
-                    </ol>
+                    <nav aria-label="breadcrumbs">
+											<ol class="breadcrumb pull-right">
+													<li><a href="/">Home</a></li>
+													<li class="active">Personal details</li>
+											</ol>
+										</nav>
                     <h4>Registration</h4>
                 </div>
-            </section>
+            </div>
         <div class="subsection" style="margin-bottom: 130px;">
-	
+
 		<div class="clear"></div>
 		<?php if ($model->isNewRecord) {?>
 		<p><?=Yii::t('app' , 'GigaScience appreciates your interest in the GigaDB project. With a GigaDB account, you can submit new datasets to the database. Also, GigaDB can automatically notify you of new content which matches your interests. Please fill out the following information and register to enjoy the benefits of GigaDB membership!')?></p>
@@ -146,17 +148,17 @@
 				</div>
                                 <div class="form-group">
                                     <label class="col-xs-3 control-label"><?=Yii::t('app' , 'Mailing list')?></label>
-                                   
-				    <div class="col-xs-9">				    	
+
+				    <div class="col-xs-9">
                                          <?php echo $form->checkbox($model,'newsletter'); ?>
 				    </div>
                                     <div class="col-xs-9">
-                                        <p>Please tick here to join the GigaDB mailing list to receive news, updates and quarterly newsletters about GigaDB</p>   
+                                        <p>Please tick here to join the GigaDB mailing list to receive news, updates and quarterly newsletters about GigaDB</p>
                                     </div>
                                  </div>
                                 <div class="form-group">
-                                    <?= $form->labelEx($model,'terms', array('class'=>'col-xs-3 control-label')) ?>              
-				    <div class="col-xs-9">				    	
+                                    <?= $form->labelEx($model,'terms', array('class'=>'col-xs-3 control-label')) ?>
+				    <div class="col-xs-9">
                                          <?php echo $form->checkbox($model,'terms'); ?>
                                          <font color="red"><?= $form->error($model,'terms') ?></font>
 				    </div>
@@ -164,23 +166,23 @@
                                      <p>Please tick here to confirm you have read and understood our <a href="/site/term#policies">Terms of use</a> and <a href="/site/term#privacy">Privacy Policy</a></p>
                                     </div>
                                  </div>
-                                
+
 
 
 			<? if ($model->isNewRecord) { ?>
-			<div class="form-group">		
-					<?php echo $form->labelEx($model,'verifyCode', array('class'=>'col-xs-3 control-label')); ?>		
-			        <div class="col-xs-9">				
-						<div style="width:100%">	
+			<div class="form-group">
+					<?php echo $form->labelEx($model,'verifyCode', array('class'=>'col-xs-3 control-label')); ?>
+			        <div class="col-xs-9">
+						<div style="width:100%">
 							<img style="width:200px;" src="<?php echo Yii::app()->captcha->output(); ?>">
 						</div>
                                     <br>
                                     <br>
-						<?php echo $form->textField($model,'verifyCode',array('class'=>'form-control')); ?>	
+						<?php echo $form->textField($model,'verifyCode',array('class'=>'form-control')); ?>
 						<div class="hint">Please enter the letters as they are shown in the image above.
 						<br/>Letters are case-sensitive.</div>
-						<?php echo $form->error($model, 'verifyCode'); ?>					
-						</div>		
+						<?php echo $form->error($model, 'verifyCode'); ?>
+						</div>
 			    </div>
 			<? } ?>
                         <hr>
@@ -189,18 +191,18 @@
                             </div>
                         <? $this->endWidget() ?>
 		</div><!--well-->
-		
 
 
-	<?php 
+
+	<?php
 		$path = "images/tempcaptcha/".$text.".png";
 		$files = glob('images/tempcaptcha/*');
-		foreach($files as $file){ 
+		foreach($files as $file){
 		  if (is_file($file))
 		  	if ($file != $path)
-		  		 unlink($file); 
+		  		 unlink($file);
 		}
-	?>	
+	?>
 	</div><!--span8-->
     </div><!-- user-form -->
 </div>

--- a/protected/views/user/changePassword.php
+++ b/protected/views/user/changePassword.php
@@ -1,15 +1,17 @@
 
 <div class="content">
     <div class="container">
-        <section class="page-title-section">
+        <div class="section page-title-section">
             <div class="page-title">
-                <ol class="breadcrumb pull-right">
-                    <li><a href="/">Home</a></li>
-                    <li class="active">Change Password</li>
-                </ol>
+                <nav aria-label="breadcrumbs">
+                    <ol class="breadcrumb pull-right">
+                        <li><a href="/">Home</a></li>
+                        <li class="active">Change Password</li>
+                    </ol>
+                </nav>
                 <h4><?= Yii::t('app', 'Change Password') ?></h4>
             </div>
-        </section>
+        </div>
     </div>
 </div>
 
@@ -51,24 +53,24 @@
                     <div class="form-group">
                         <label class="col-xs-5 control-label"><?= Yii::t('app', 'Mailing list') ?></label>
 
-                        <div class="col-xs-5">				    	
+                        <div class="col-xs-5">
 <?php echo $form->checkbox($model, 'newsletter'); ?>
                         </div>
                         <div class="col-xs-5">
-                            <p>Please tick here to join the GigaDB mailing list to receive news, updates and quarterly newsletters about GigaDB</p>   
+                            <p>Please tick here to join the GigaDB mailing list to receive news, updates and quarterly newsletters about GigaDB</p>
                         </div>
                     </div>
                     <div class="form-group">
-                            <?= $form->labelEx($model, 'terms', array('class' => 'col-xs-5 control-label')) ?>              
-                        <div class="col-xs-5">				    	
+                            <?= $form->labelEx($model, 'terms', array('class' => 'col-xs-5 control-label')) ?>
+                        <div class="col-xs-5">
 <?php echo $form->checkbox($model, 'terms'); ?>
                             <br>
                             <font color="red"><?= $form->error($model, 'terms') ?></font>
                             <p>Please tick here to confirm you have read and understood our <a href="/site/term#policies">Terms of use</a> and <a href="/site/term#privacy">Privacy Policy</a></p>
                         </div>
-                    
-                        
-                    </div>                     
+
+
+                    </div>
 
 
                     <div class="text-center">

--- a/protected/views/user/view_profile.php
+++ b/protected/views/user/view_profile.php
@@ -25,15 +25,17 @@ $this->pageTitle = 'GigaDB - My GigaDB Page';
         <? } ?>
                     <div class="content">
                         <div class="container">
-                            <section class="page-title-section">
+                            <div class="section page-title-section">
                                 <div class="page-title">
-                                    <ol class="breadcrumb pull-right">
-                                        <li><a href="/">Home</a></li>
-                                        <li class="active">Your profile</li>
-                                    </ol>
+                                    <nav aria-label="breadcrumbs">
+                                        <ol class="breadcrumb pull-right">
+                                            <li><a href="/">Home</a></li>
+                                            <li class="active">Your profile</li>
+                                        </ol>
+                                    </nav>
                                     <h4>Your profile page</h4>
                                 </div>
-                            </section>
+                            </div>
                             <section>
                                 <div style="padding-top: 1px;">
                                     <ul class="nav nav-tabs nav-border-tabs" role="tablist">
@@ -206,7 +208,7 @@ $this->pageTitle = 'GigaDB - My GigaDB Page';
 var url = document.location.toString();
 if (url.match('#')) {
     $('.nav-tabs a[href="#' + url.split('#')[1] + '"]').tab('show');
-} 
+}
 
 // Change hash for page-reload
 $('.nav-tabs a').on('shown.bs.tab', function (e) {


### PR DESCRIPTION
# Pull request for issue: #1432

This is a pull request for the following functionalities:

* Wrap breadcrumbs in a `<nav aria-label="breadcrumbs">`
* Update styles to decouple breadcrumb style from html list
* Wrap page title and breadcrumbs in a div instead of a section
* Added breadcrumbs to team page
* Removed one link from Help page as it didn't seem to make sense
* Minor modifications to breadcrumb text

## How to test?

* Review that the breadcrumbs of http://gigadb.gigasciencejournal.com:9170/site/index, http://gigadb.gigasciencejournal.com:9170/site/about, http://gigadb.gigasciencejournal.com:9170/site/guide look ok (for example)
* Review bredcrumbs of page http://gigadb.gigasciencejournal.com:9170/site/help (I removed "/ about /" link)
* In home page review that "+ more" button looks and works as expected http://gigadb.gigasciencejournal.com:9170/

## How have functionalities been implemented?

* Went over all instances of breadcrumbs and updated them similarly (more details in code comments)

## Any issues with implementation?

None

## Any changes to automated tests?

None

## Any changes to documentation?

None

## Any technical debt repayment?

None

## Any improvements to CI/CD pipeline?

None
