### PR TITLE
Update gitlab-config-live-build.yml to fix value for GIGADB_ENV (deployment bug on bastion on beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Feat: #566: Fix issue preventing deployment to live production environment bastion server
+- Feat: #1449: Fix issue preventing deployment to live production environment bastion server
 - Feat: #1376: Fix heading hierarchy in Contact Page, wrap address in `<address>` element
 - Feat #1361: Add general accessible landmarks to layouts
 - Feat #1363: Fix color contrast issues in pages with new layouts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat: #566: Fix issue preventing deployment to live production environment bastion server
 - Feat: #1376: Fix heading hierarchy in Contact Page, wrap address in `<address>` element
 - Feat #1361: Add general accessible landmarks to layouts
 - Feat #1363: Fix color contrast issues in pages with new layouts

--- a/gigadb/app/tools/files-metadata-console/gitlab-config-live-build.yml
+++ b/gigadb/app/tools/files-metadata-console/gitlab-config-live-build.yml
@@ -1,6 +1,6 @@
 FilesMetadataConsoleBuildLive:
   variables:
-    GIGADB_ENV: "staging"
+    GIGADB_ENV: "live"
     YII_DEBUG: "true"
   stage: live build
   tags:


### PR DESCRIPTION
# Pull request for issue: #1449 

This is a pull request for the following functionalities:
* Correct the value of GIGADB_ENV in gitlab-config-live-build.yml to allow deployment on live production environment of files-metadata-console

## How to test?

run this branch's pipeline on your live environment (not staging) and observe that files-metadata console deploy on bastion

## How have functionalities been implemented?

I cannot deploy to the live production environment as the deploy job for files-metadata-console is failing because it cannot find the container image tagged with `live`. This is because the live build job is incorrectly referring to "staging" instead of "live". Fix is to correct the value of GIGADB_ENV in gitlab-config-live-build.yml


