### PR TITLE
A11y - Dataset page modal heading hierarchy

### DIFF
--- a/protected/views/dataset/_files_setting.php
+++ b/protected/views/dataset/_files_setting.php
@@ -6,7 +6,7 @@
     <div class="modal-content">
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <h4 class="modal-title">Table settings</h4>
+            <h3 class="h4 modal-title">Table settings</h3>
         </div>
         <div class="modal-body">
 

--- a/protected/views/dataset/_sample_setting.php
+++ b/protected/views/dataset/_sample_setting.php
@@ -6,7 +6,7 @@
     <div class="modal-content">
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <h4 class="modal-title">Table settings</h4>
+            <h3 class="h4 modal-title">Table settings</h3>
         </div>
         <div class="modal-body">
 


### PR DESCRIPTION
# Pull request for issue: #1389

This is a pull request for the following functionalities:

* Update heading hierarchy in dataset page modals

## How to test?

Navigate to http://gigadb.gigasciencejournal.com:9170/dataset/100006, open table settings modal, verify that heading is `h3`

## How have functionalities been implemented?

* Replace h4 heading by h3. The modal is used on the context of a page that has h1, h2, h3 and the fitting level of the modal heading is h3

Note: other headings of the dataset page are misleveled but this is fixed in another PR

## Any issues with implementation?

None

## Any changes to automated tests?

None

## Any changes to documentation?

None

## Any technical debt repayment?

None

## Any improvements to CI/CD pipeline?

None
