### PR TITLE
A11y - Improve accessibility of terms page

### DIFF
--- a/less/current.less
+++ b/less/current.less
@@ -16,6 +16,7 @@
 @import "current/modules/breadcrumb.less";
 @import "current/modules/navs.less";
 @import "current/modules/progressbar.less";
+@import "current/modules/tabs.less";
 @import "current/layout/section.less";
 @import "current/layout/article.less";
 @import "current/layout/homesearchbar.less";

--- a/less/current/modules/tabs.less
+++ b/less/current/modules/tabs.less
@@ -1,0 +1,32 @@
+.tabs[role="tablist"] {
+  border-bottom: 1px solid @color-light-gray;
+  button[role="tab"] {
+    margin-bottom: -1px;
+    padding: 8px 12px;
+    margin-right: 2px;
+    line-height: 18px;
+    font-size: 13px;
+    border: 1px solid transparent;
+    border-top-width: 2px;
+    border-radius: 0;
+    text-decoration: none;
+    color: @color-darker-gray;
+    background-color: @color-true-white;
+    border-bottom-color: @color-light-gray;
+    &[aria-selected="true"] {
+      border: 1px solid @color-light-gray;
+      border-top: 2px solid @color-gigadb-green;
+      border-bottom-color: @color-true-white;
+      border-bottom-width: 2px;
+      color: @color-warm-black;
+      text-decoration: none;
+      background-color: transparent;
+    }
+  }
+}
+.tab-content [role="tabpanel"] {
+  display: none;
+  &.active {
+    display: block;
+  }
+}

--- a/protected/views/site/term.php
+++ b/protected/views/site/term.php
@@ -10,23 +10,28 @@ $this->pageTitle = 'GigaDB - Terms of use';
                     <li><a href="/">Home</a></li>
                     <li class="active">Terms of use</li>
                 </ol>
-                <h1 class="h4">Terms of use</h1>
+                <h1 class="h4" id="pageTitle">Terms of use</h1>
             </div>
         </section>
 <section style="margin-bottom: 15px;">
     <div>
-        <ul class="nav nav-tabs nav-border-tabs" role="tablist">
-            <li id="lipolicies" role="presentation" class="active"><a href="#policies" aria-controls="policies" role="tab" data-toggle="tab">GigaDB User Policies</a></li>
-            <li id="lihosting" role="presentation"><a href="#hosting" aria-controls="hosting" role="tab" data-toggle="tab">Hosting Statement</a></li>
-            <li id="liprivacy" role="presentation" id="privacytab"><a href="#privacy" aria-controls="privacy" role="tab" data-toggle="tab">Privacy</a></li>
-            <li id="liinformation" role="presentation"><a href="#information" aria-controls="information" role="tab" data-toggle="tab">Collection of Web-traffic Information</a></li>
-            <li id="lipersonal" role="presentation"><a href="#personal" aria-controls="personal" role="tab" data-toggle="tab">Personal Data</a></li>
-        </ul>
+        <div class="tabs" role="tablist" aria-labelledby="pageTitle">
+            <button id="lipolicies" type="button" role="tab" aria-selected="false"
+            aria-controls="policies" data-toggle="tab">GigaDB User Policies</button>
+            <button id="lihosting" type="button" role="tab" aria-selected="false"
+            aria-controls="hosting" data-toggle="tab" tabindex="-1">Hosting Statement</button>
+            <button id="liprivacy" type="button" role="tab" aria-selected="false"
+            aria-controls="privacy" data-toggle="tab" tabindex="-1">Privacy</button>
+            <button id="liinformation" type="button" role="tab" aria-selected="false"
+            aria-controls="information" data-toggle="tab" tabindex="-1">Collection of Web-traffic Information</button>
+            <button id="lipersonal" type="button" role="tab" aria-selected="false"
+            aria-controls="personal" data-toggle="tab" tabindex="-1">Personal Data</button>
+        </div>
     </div>
 </section>
 <section>
     <div class="tab-content">
-        <div role="tabpanel" class="tab-pane active" id="policies">
+        <div role="tabpanel" class="tab-pane" id="policies" tabindex="0" aria-labelledby="lipolicies">
             <h2 class="h4 page-subtitle">General</h2>
             <div class="subsection">
                 <p>We have a commitment to Open Science by freely providing an online database, data and services
@@ -143,7 +148,7 @@ $this->pageTitle = 'GigaDB - Terms of use';
                 </p>
             </div>
         </div>
-        <div role="tabpanel", class="tab-pane" id="hosting">
+        <div role="tabpanel", class="tab-pane" id="hosting" tabindex="0" aria-labelledby="lihosting">
             <p>GigaScience, including GigaDB, was launched in 2012 in partnership with BGI. The stability of future hosting
                 of content is guaranteed and protected by the host organisations BGI - an international company with over
                 7,000 employees and data-centres in multiple countries - and China National GeneBank (CNGB) - a Shenzhen
@@ -179,7 +184,7 @@ $this->pageTitle = 'GigaDB - Terms of use';
                 <p>In the future we intend to move the GigaDB database and website to a cloud service provider. This will provide additional certified guarantees of stability and availability. </p>
             </div>
         </div>
-        <div role="tabpanel" class="tab-pane" id="privacy">
+        <div role="tabpanel" class="tab-pane" id="privacy" tabindex="0" aria-labelledby="liprivacy">
             <p><em>GigaDB</em> has implemented appropriate technical and organisational measures to ensure a level of
                 security which we deem appropriate, taking into account the categories of data we collect and the way we
                 process it.</p>
@@ -203,7 +208,7 @@ $this->pageTitle = 'GigaDB - Terms of use';
                 applicable laws, we may use your personal information to inform relevant third parties about the content
                 and your behaviour.</p>
         </div>
-        <div role="tabpanel" class="tab-pane" id="information">
+        <div role="tabpanel" class="tab-pane" id="information" tabindex="0" aria-labelledby="liinformation">
             <p><em>GigaDB</em> will record the visits to the website by using cookies and page tagging without
                 collecting any personal identifiable information of users. A cookie can be used to identify a computer,
                 it is not used to collect any personal information. In other words, it does not have the function of
@@ -212,7 +217,7 @@ $this->pageTitle = 'GigaDB - Terms of use';
                 You may choose to inactivate your browser’s cookies. If you inactivate the cookies, you will not be able
                 to use some of the functions of <em>GigaDB</em>.</p>
         </div>
-        <div role="tabpanel" class="tab-pane" id="personal">
+        <div role="tabpanel" class="tab-pane" id="personal" tabindex="0" aria-labelledby="lipersonal">
             <p>The Personal Data we may collect from you could include:</p>
             <ul class="content-text">
                 <li>Name</li>
@@ -273,16 +278,76 @@ $this->pageTitle = 'GigaDB - Terms of use';
 </div>
 <script type="text/javascript">
 
+    const tabSelector = '[role="tab"]'
+    const activeTabSelector = `${tabSelector}.active`;
+    const tabpanelSelector = '[role="tabpanel"]';
 
+    // Handle initial tab selection
     $(document).ready(function () {
-        if (location.hash != null && location.hash != "") {
-            $('ul li').removeClass('active');
-            $('div' + '.tab-pane').removeClass('active');
-            var variableli = location.hash;
-            $(location.hash).addClass('active');
-            $(variableli.replace('#', '#li')).addClass('active');
+        let defaultHash = '#policies'
+
+        if (location.hash && $(location.hash).is(tabpanelSelector)) {
+            defaultHash = location.hash;
         }
 
+        resetTabs();
+        $(defaultHash).addClass('active');
+        $(defaultHash.replace('#', '#li')).addClass('active').attr('tabindex', '0').attr('aria-selected','true');
     });
+
+    // Tab pattern implementation https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+    $(document).ready(function () {
+        const tabs = $(tabSelector)
+        // Initialize
+        $(tabSelector).attr('tabindex', '-1');
+        $(activeTabSelector).attr('tabindex', '0');
+
+        // Click event to handle tab switching
+        $(tabSelector).click(function () {
+            toggleTab($(this));
+        });
+
+        // Keyboard event to handle arrow keys, home and end
+        $(tabSelector).keydown(function (e) {
+            let target;
+            switch (e.key) {
+            case 'ArrowRight':
+                target = $(this).next(tabSelector).length ? $(this).next(tabSelector) : $(tabSelector).first();
+                break;
+            case 'ArrowLeft':
+                target = $(this).prev(tabSelector).length ? $(this).prev(tabSelector) : $(tabSelector).last();
+                break;
+            case 'Home':
+                e.preventDefault()
+                target = $(tabSelector).first();
+                break;
+            case 'End':
+                e.preventDefault()
+                target = $(tabSelector).last();
+                break;
+            default:
+                return;
+            }
+
+            toggleTab(target);
+        });
+
+
+
+        function toggleTab(tab) {
+            const tabId = tab.data('id');
+            const tabPanelId = tab.attr('aria-controls')
+
+            resetTabs()
+            tab.addClass('active').attr('tabindex', '0').attr('aria-selected','true').focus();
+            $(`#${tabPanelId}`).addClass('active');
+        }
+    });
+
+    function resetTabs() {
+        $(tabSelector).removeClass('active').attr('tabindex', '-1').attr('aria-selected','false');
+        $(tabpanelSelector).removeClass('active');
+    }
+
 
 </script>

--- a/protected/views/site/term.php
+++ b/protected/views/site/term.php
@@ -16,7 +16,7 @@ $this->pageTitle = 'GigaDB - Terms of use';
 <section style="margin-bottom: 15px;">
     <div>
         <div class="tabs" role="tablist" aria-labelledby="pageTitle">
-            <button id="lipolicies" type="button" role="tab" aria-selected="false"
+            <button id="lipolicies" type="button" role="tab" aria-selected="true"
             aria-controls="policies" data-toggle="tab">GigaDB User Policies</button>
             <button id="lihosting" type="button" role="tab" aria-selected="false"
             aria-controls="hosting" data-toggle="tab" tabindex="-1">Hosting Statement</button>
@@ -31,7 +31,7 @@ $this->pageTitle = 'GigaDB - Terms of use';
 </section>
 <section>
     <div class="tab-content">
-        <div role="tabpanel" class="tab-pane" id="policies" tabindex="0" aria-labelledby="lipolicies">
+        <div role="tabpanel" class="tab-pane active" id="policies" tabindex="0" aria-labelledby="lipolicies">
             <h2 class="h4 page-subtitle">General</h2>
             <div class="subsection">
                 <p>We have a commitment to Open Science by freely providing an online database, data and services

--- a/protected/views/site/term.php
+++ b/protected/views/site/term.php
@@ -10,7 +10,7 @@ $this->pageTitle = 'GigaDB - Terms of use';
                     <li><a href="/">Home</a></li>
                     <li class="active">Terms of use</li>
                 </ol>
-                <h4>Terms of use</h4>
+                <h1 class="h4">Terms of use</h1>
             </div>
         </section>
 <section style="margin-bottom: 15px;">
@@ -27,7 +27,7 @@ $this->pageTitle = 'GigaDB - Terms of use';
 <section>
     <div class="tab-content">
         <div role="tabpanel" class="tab-pane active" id="policies">
-            <h4 class="page-subtitle">General</h4>
+            <h2 class="h4 page-subtitle">General</h2>
             <div class="subsection">
                 <p>We have a commitment to Open Science by freely providing an online database, data and services
                     relating to data contributed from biological and biomedical science experiments by authors and
@@ -57,7 +57,7 @@ $this->pageTitle = 'GigaDB - Terms of use';
                 <p>Any questions or comments concerning these Terms of Use can be addressed to the administrator via
                     emailing <a href="mailto:database@gigasciencejournal.com">database@gigasciencejournal.com</a>.</p>
             </div>
-            <h4 class="page-subtitle">GigaDB Services</h4>
+            <h2 class="h4 page-subtitle">GigaDB Services</h2>
             <div class="subsection">
                 <p>We provide these data in good faith, but make no warranty, expressed or implied, nor assume any legal
                     liability or responsibility for any purpose for which they are used.</p>
@@ -74,7 +74,7 @@ $this->pageTitle = 'GigaDB - Terms of use';
             </div>
 
 
-            <h4 class="page-subtitle">Depositor agreement</h4>
+            <h2 class="h4 page-subtitle">Depositor agreement</h2>
             <div class="subsection">
                 <p>As an Open Data repository, depositors must make sure everyone can legally reuse the data they
                     deposit and confirm that it is their own work. Co-authorship must be credited, and third party
@@ -89,7 +89,7 @@ $this->pageTitle = 'GigaDB - Terms of use';
                 </p>
             </div>
 
-            <h4 class="page-subtitle">A note about BGI Data</h4>
+            <h2 class="h4 page-subtitle">A note about BGI Data</h2>
             <div class="subsection">
                 <p>As one of the world’s largest biological data producers, the BGI’s goal is to maximize the use of its
                     data by providing it to the research community in a timely manner. At the same time, BGI recognizes
@@ -122,7 +122,7 @@ $this->pageTitle = 'GigaDB - Terms of use';
                     to provide the community with improved whole genome analyses and annotations.</p>
             </div>
 
-            <h4 class="page-subtitle">Human data</h4>
+            <h2 class="h4 page-subtitle">Human data</h2>
             <div class="subsection">
                 <p>Although all data is released under the most open licenses possible the user agrees to not use data
                     and/or metadata , alone or in combination with other data, to identify any individual or entity that
@@ -133,7 +133,7 @@ $this->pageTitle = 'GigaDB - Terms of use';
             </div>
 
 
-            <h4 class="page-subtitle">Disclaimer</h4>
+            <h2 class="h4 page-subtitle">Disclaimer</h2>
             <div class="subsection">
                 <p>Some of the data provided from external sources may be subject to third-party constraints. Users are
                     solely responsible for establishing the nature of and complying with any such intellectual property
@@ -157,7 +157,7 @@ $this->pageTitle = 'GigaDB - Terms of use';
                 the metadata database. The latter two parts are hosted together on a server physically located in Hong Kong,
                 whereas the data hosting server is located in Shenzhen, China.</p>
             <br>
-            <h4 class="page-subtitle">The GigaDB data repository (FTP server)</h4>
+            <h2 class="h4 page-subtitle">The GigaDB data repository (FTP server)</h2>
             <div class="subsection">
                 <p>GigaDB has two types of data hosting: (a) public open access; and (b) private FTP access. The open access public FTP server has security measures in place to prevent removal or modification of data hosted on the server. These measures are ensured by READ only access to data files. The private FTP server is administered by GigaDB staff and individual submitters are provided with login details to allow them to upload their data prior to publication. Those details are shared with editors, who then share them with the selected reviewers to enable the reviewers to access the data for the purpose of review. The login details grant access to the data of one manuscript/dataset, and the passwords are revoked after completion of the submission. At this point there are two options, namely: 1) the manuscript is accepted and the accompanying data are moved to the public server; or 2) the manuscript is rejected and the data are deleted.</p>
                 <p>Both private and public FTP servers that host GigaDB data are installed and maintained by Ali Cloud in the data center of China National GeneBank (CNGB) in Dapeng, Shenzhen. The physical security of the servers is guaranteed in terms of power supply, fire protection equipment and temperature/humidity control. There is a dedicated server room at CNGB and this area has CCTV monitoring and access control. Importantly, access to the server room and activities are recorded. Network security is maintained with a firewall that ensures that only data flows that comply with the security policy can pass through the firewall. This is an important measure to ensure the legality of data access. Host system security is maintained by identifying and restricting access to data through authorisation controls, and maintenance of sufficiently detailed logs are collected for auditors to audit and monitor.</p>
@@ -166,11 +166,11 @@ $this->pageTitle = 'GigaDB - Terms of use';
                 <p>GigaDB is also now a member of CLOCKSS (Controlled LOCKSS -"Lots of Copies Keep Stuff Safe"), ensuring all curated metadata, external links and documentation are preserved in the long term (see 3 below). In addition, we are exploring the feasibility and costs of CCLOCKS archiving the data files hosted on our FTP server as a longer term succession plan.</p>
                 <p>As an option to increase accessibility worldwide, we also are working with Complete Genomics - a subsidiary of BGI group of companies - to provide a mirror ftp server in California, USA which will be a further backup copy of the data.</p>
             </div>
-            <h4 class="page-subtitle">GigaDB.org website</h4>
+            <h2 class="h4 page-subtitle">GigaDB.org website</h2>
             <div class="subsection">
                 <p>The GigaDB.org website is currently hosted on and served from BGI-Hong Kong Co. Ltd (a subsidiary of BGI group of companies) located in Hong Kong. The Hong Kong data centre is maintained by BGI, who have been running it since 2010 to a very high standard in line with  ISO/IEC 27001 certification. The GigaDB source code is <a href="https://github.com/gigascience/gigadb-website">available in our GitHub repository</a> under an Open Source GPLv3 license. A Behavior-Driven Development process is now coupled with Test-Driven Development and unit testing techniques for developing the GigaDB application. We have also adopted Continuous Integration and Continuous Deployment approaches to automate checking of the GigaDB source code so that the application is not broken and that new functionality is made available in a timely manner on the website. In the future we intend to move the website to a cloud service provider in an effort to deliver certified guarantees of stability and availability.</p>
             </div>
-            <h4 class="page-subtitle">Metadata</h4>
+            <h2 class="h4 page-subtitle">Metadata</h2>
             <div class="subsection">
                 <p>All metadata collected by GigaDB is stored in a bespoke pSQL database. Only individual user information is kept private to comply with local and international data privacy laws. All GigaDB dataset metadata is openly available and as such has likely been duplicated in various archives and search engines (e.g. Google, utilising schema.org metadata) around the world. This offers greater discoverability for our datasets.</p>
                 <p>The pSQL database is hosted on the BGI-Hong Kong Co. Ltd servers in Hong Kong, with automatic nightly back-ups taken.</p>


### PR DESCRIPTION
# Pull request for issue: #1383 

This is a pull request for the following functionalities:

* fix a11y issues and improve a11y of terms page

## How to test?

* Navigate to http://gigadb.gigasciencejournal.com:9170/site/term
* Review that heading hierarchy is correct (no skipping heading levels, and there is one h1)
* Verify that on page refresh the default active tab is the first one
* Navigate to http://gigadb.gigasciencejournal.com:9170/site/term#test and verify that active tab is the first one (do a full page refresh)
* Navigate to http://gigadb.gigasciencejournal.com:9170/site/term#hosting and verify that active tab is the second one (do a full page refresh)
* Use keyboard to navigate the tabs and verify that:
  * Tab key moves focus in and out of the tabs
  * Right / Left arrow keys change tab
  * Home / End keys focus on first / last tab
  * Clicking on tab changes content

## How have functionalities been implemented?

* Heading levels were updated to make them follow hierarchy starting with h1
* Heading styles were kept by using bootstrap class h4
* Tab pattern was implemented with jQuery using event listeners to handle key presses and clicks on tabs.

Note: Bootstrap 3 provides "tabs" but their implementation does not adjust to the accessible tab pattern in https://www.w3.org/WAI/ARIA/apg/patterns/tabs/, Bootstrap 5 for example no longer uses role="tab" for their widget that looks like tabs (but it's actually more fitting for a navigation menu with a list of links). For this page, the tab pattern is suitable as a navigation widget does not fit the page

## Any issues with implementation?

None

## Any changes to automated tests?

None

## Any changes to documentation?

None

## Any technical debt repayment?

None

## Any improvements to CI/CD pipeline?

None
