### PR TITLE
A11y - Forgot password accessibility improvements

### DIFF
--- a/less/current.less
+++ b/less/current.less
@@ -16,6 +16,7 @@
 @import "current/modules/breadcrumb.less";
 @import "current/modules/navs.less";
 @import "current/modules/progressbar.less";
+@import "current/modules/forgot-password.less";
 @import "current/layout/section.less";
 @import "current/layout/article.less";
 @import "current/layout/homesearchbar.less";

--- a/less/current/modules/forgot-password.less
+++ b/less/current/modules/forgot-password.less
@@ -1,0 +1,20 @@
+.forgot-password-form {
+  height: 50px;
+  padding-top: 9px;
+  padding-right: 88px;
+  .forgot-password-group {
+    .forgot-password-label {
+      position: relative;
+      bottom: 7px;
+    }
+    .forgot-password-input {
+      &:focus {
+        outline: 1px solid @color-gigadb-green;
+      }
+    }
+    .forgot-password-btn {
+      position: relative;
+      top: 14px;
+    }
+  }
+}

--- a/protected/views/resetPasswordRequest/forgot.php
+++ b/protected/views/resetPasswordRequest/forgot.php
@@ -27,15 +27,15 @@ $this->pageTitle='Forgotten password';
                 <? $form=$this->beginWidget('CActiveForm', array(
                     'id'=>'forgot-password-form',
                     'enableAjaxValidation'=>false,
-                    'htmlOptions'=>array('class'=>'form-horizontal')
+                    'htmlOptions'=>array('class'=>'form-horizontal forgot-password-form')
                 )) ?>
-                <div class="form-group">
-                    <?php echo $form->label($model, 'email', array('class' => 'col-xs-2 control-label')); ?>
-                    <div class="col-xs-8">
-                        <?php echo $form->textField($model, 'email', array('class' => 'form-control')); ?>
+                <div class="form-group forgot-password-group">
+                    <?php echo $form->label($model, 'email', array('class' => 'col-xs-2 control-label forgot-password-label')); ?>
+                    <div class="col-xs-8 forgot-password-input">
+                        <?php echo $form->emailField($model, 'email', array('class' => 'form-control forgot-password-input', 'required' => 'true')); ?>
                     </div>
                     <div class="col-xs-2">
-                        <?= CHtml::submitButton(Yii::t('app' , 'Reset'), array('class'=>'btn background-btn')) ?>
+                        <?= CHtml::submitButton(Yii::t('app' , 'Reset Password'), array('class'=>'btn background-btn forgot-password-btn')) ?>
                     </div>
                 </div>
                 <? $this->endWidget() ?>


### PR DESCRIPTION
# Pull request for issue: #1385 

This is a pull request for the following functionalities:

Improve the accessibility of the forgot password form

## How to test?

* Navigate to http://gigadb.gigasciencejournal.com:9170/site/forgot
* Use AXE chrome extension (or another audit tool) to verify that page content does not have accessibility issues
* Navigate form with keyboard and verify clearly visible input focus state
* Try to submit the form with empty input and with non-email string and confirm client side validaiton is present

## How have functionalities been implemented?

- improved layout spacing and element positioning by adding more paddings, centering the form and positioning label and button to be at the same y position as the input
- enhanced input focus state by adding a green outline
- fix heading hierarchy by changing h4 to be an h1
- use text content to describe input with aria-describedby
- client side validation by adding required attribute and type="email" to input

## Any issues with implementation?

None

## Any changes to automated tests?

None

## Any changes to documentation?

None

## Any technical debt repayment?

None

## Any improvements to CI/CD pipeline?

None
