### PR TITLE
A11y - Thanks page heading

### DIFF
--- a/protected/views/resetPasswordRequest/thanks.php
+++ b/protected/views/resetPasswordRequest/thanks.php
@@ -9,7 +9,7 @@ $this->pageTitle='Thanks';
                     <li><a href="/">Home</a></li>
                     <li class="active">Thanks</li>
                 </ol>
-                <h4>Reset Password Request Submitted</h4>
+                <h1 class="h4">Reset Password Request Submitted</h1>
             </div>
         </section>
         <div class="subsection" style="margin-bottom: 130px;">


### PR DESCRIPTION
# Pull request for issue: #1386

Fix heading hierarchy of thanks page

## How to test?

Run AXE chrome extension of http://gigadb.gigasciencejournal.com:9170/site/thanks and verify that there's one h1

## How have functionalities been implemented?

Replace existing h4 by h1

## Any issues with implementation?

None

## Any changes to automated tests?

None

## Any changes to documentation?

None

## Any technical debt repayment?

None

## Any improvements to CI/CD pipeline?

None
