### PR TITLE
A11y - Social login img alt attribute

### DIFF
--- a/protected/views/layouts/datasetpage.php
+++ b/protected/views/layouts/datasetpage.php
@@ -158,25 +158,25 @@
                      <img src="<?= Yii::app()->createAbsoluteUrl('/') .  "/images/icons/id.png" ?>"/>&nbsp;&nbsp;<?=Yii::t('app' , 'ORCID')?>
                 </a>-->
                 <a class="btn btnlog center giga-log" href="/site/login">
-                     <img src="/images/icons/giga.png"/>&nbsp;
+                     <img src="/images/icons/giga.png" alt="Login to GigaDB website"/>&nbsp;
                 </a>
-             </div>
-             <div class="content-btnlog">
-                 <a class="btn btnlog facebook-log" href="/opauth/facebook">
-                     <img src="/images/icons/fb.png"/>&nbsp;&nbsp;<?=Yii::t('app' , 'Facebook')?>
-                 </a>
+            </div>
+            <div class="content-btnlog">
+                <a class="btn btnlog facebook-log" href="/opauth/facebook">
+                    <img src="/images/icons/fb.png" alt="Login with Facebook"/>&nbsp;&nbsp;<?=Yii::t('app' , 'Facebook')?>
+                </a>
                 <a class="btn btnlog google-log" href="/opauth/google">
-                     <img src="/images/icons/google.png"/>&nbsp;&nbsp;<?=Yii::t('app' , 'Google')?>
+                    <img src="/images/icons/google.png" alt="Login with Google" />&nbsp;&nbsp;<?=Yii::t('app' , 'Google')?>
                 </a>
-             </div>
-             <div class="content-btnlog">
+            </div>
+            <div class="content-btnlog">
                 <a class="btn btnlog twitter-log" href="/opauth/twitter">
-                     <img src="/images/icons/twi.png"/>&nbsp;&nbsp;<?=Yii::t('app' , 'Twitter')?>
+                        <img src="/images/icons/twi.png" alt="Login with twitter"/>&nbsp;&nbsp;<?=Yii::t('app' , 'Twitter')?>
                 </a>
                 <a class="btn btnlog linkedin-log" href="/opauth/linkedin">
-                    <img src="/images/icons/in.png"/>&nbsp;&nbsp;<?=Yii::t('app' , 'LinkedIn')?>
+                    <img src="/images/icons/in.png" alt="Login with LinkedIn"/>&nbsp;&nbsp;<?=Yii::t('app' , 'LinkedIn')?>
                 </a>
-             </div>
+            </div>
         </div>
 
      <?php endif ?>

--- a/protected/views/layouts/main.php
+++ b/protected/views/layouts/main.php
@@ -46,9 +46,9 @@
                 <a class="btn" href="/site/login"><?=Yii::t('app' , 'Login')?></a>
                 <?/* <a class="btn" href="/site/mapbrowse"><?=Yii::t('app' , "Browse Samples")?></a> */?>
 	           	<a class="btn" href="/user/create" id="btnCreateAccount" title="<?=Yii::t('app' , 'An account with GigaDB is required if you want to upload a dataset or be automatically notified of new content of interest to you')?>"><?=Yii::t('app' , 'Create account')?></a>
-                <? } else {                 
+                <? } else {
                         $name = Yii::app()->user->getFirst_Name();
-                
+
                 // var_dump($name);
                         if (substr($name, -1) === 's') {
                             $name = $name . '\'';
@@ -61,7 +61,7 @@
                     <a class="btn" href="/site/admin"><?=Yii::t('app' , 'Administration')?></a>
                     <? } ?>
                 <? } ?>
-                <a class="btn" href="/site/mapbrowse"><?=Yii::t('app' , "Browse Samples")?></a>  
+                <a class="btn" href="/site/mapbrowse"><?=Yii::t('app' , "Browse Samples")?></a>
                 <a class="btn" href="/site/logout"><?=Yii::t('app' , 'LogOut')?></a>
             </p>
         </div>
@@ -120,16 +120,16 @@
      <script src="/js/bootstrap-carousel.js"></script>
      <script src="/js/bootstrap-typeahead.js"></script>-->
      <!-- <script src="/js/application.js"></script>-->
-     
+
      <?php if (Yii::app()->user->isGuest) : ?>
-     
+
         <div class="popover-login" style="display: none;">
             <div class="content-btnlog">
                 <!--<a class="btn btnlog orcid-log" href="/opauth/orcid">
                      <img src="<?= Yii::app()->createAbsoluteUrl('/') .  "/images/icons/id.png" ?>"/>&nbsp;&nbsp;<?=Yii::t('app' , 'ORCID')?>
                 </a>-->
-                <a class="btn btnlog center giga-log" href="/site/login" alt="Login to GigaDB website">
-                     <img src="/images/icons/giga.png"/>&nbsp;
+                <a class="btn btnlog center giga-log" href="/site/login">
+                     <img src="/images/icons/giga.png" alt="Login to GigaDB website"/>&nbsp;
                 </a>
              </div>
             <div class="content-btnlog">
@@ -149,13 +149,13 @@
                 </a>
             </div>
         </div>
-     
+
      <?php endif ?>
-    
+
      <script>
     $(function() {
         $("#btnCreateAccount").tooltip({'placement':'left'});
-        
+
         <?php if (Yii::app()->user->isGuest) : ?>
             $('#btnLogin').attr('data-content', $('.popover-login').html()).popover({
                 trigger: 'manual',
@@ -167,7 +167,7 @@
                 return false;
             }).mouseenter(function(e) {
                 $(this).popover('show');
-                
+
                 $('.popover').one('mouseleave', function() {
                     $('#btnLogin').popover('hide');
                 });
@@ -175,7 +175,7 @@
         <?php endif ?>
     });
     </script>
-     
+
 </body>
 </html>
 <script type="application/ld+json"> { "@context": "http://schema.org", "@type": "DataCatalog", "name": "GigaDB.org", "description": "GigaDB primarily serves as a repository to host data and tools associated with articles in GigaScience; however, it also includes a subset of datasets that are not associated with GigaScience articles. GigaDB defines a dataset as a group of files (e.g., sequencing data, analyses, imaging files, software programs) that are related to and support an article or study. Through our association with DataCite, each dataset in GigaDB will be assigned a DOI that can be used as a standard citation for future use of these data in other articles by the authors and other researchers. Datasets in GigaDB all require a title that is specific to the dataset, an author list, and an abstract that provides information specific to the data included within the set. We encourage detailed information about the data we host to be submitted by their creators in ISA-Tab, a format used by the BioSharing and ISA Commons communities that we work with to maintain the highest data and metadata standards in our journal. To maximize its utility to the research community, all datasets in GigaDB are placed under a CC0 waiver (for more information on the issues surrounding CC0 and data see Hrynaszkiewicz and Cockerill, 2012).Datasets that are not affiliated with a GigaScience article are approved for inclusion by the Editors of GigaScience. The majority of such datasets are from internal projects at the BGI, given their sponsorship of GigaDB. Many of these datasets may not have another discipline-specific repository suitably able to host them or have been rapidly released prior to any publications for use by the research community, whilst enabling their producers to obtain credit through data citation. The GigaScience Editors may also consider the inclusion of particularly interesting, previously unpublished datasets in GigaDB, especially if they meet our criteria and inclusion as Data Note articles in the journal.", "alternateName":"GigaScience Journal Database", "license":"Public Domain", "citation":"Tam P. Sneddon, Xiao Si Zhe, Scott C. Edmunds, Peter Li, Laurie Goodman, Christopher I. Hunter; GigaDB: promoting data dissemination and reproducibility, Database, Volume 2014, 1 January 2014, bau018, https://doi.org/10.1093/database/bau018", "url": "https://GigaDB.org/", "keywords": ["registry","life science","GigaScience Journal"], "provider": [ { "@type":"Person", "name": "GigaDB.org support", "email": "database@gigasciencejournal.com" } ] } </script>

--- a/protected/views/layouts/main.php
+++ b/protected/views/layouts/main.php
@@ -128,26 +128,26 @@
                 <!--<a class="btn btnlog orcid-log" href="/opauth/orcid">
                      <img src="<?= Yii::app()->createAbsoluteUrl('/') .  "/images/icons/id.png" ?>"/>&nbsp;&nbsp;<?=Yii::t('app' , 'ORCID')?>
                 </a>-->
-                <a class="btn btnlog center giga-log" href="/site/login">
+                <a class="btn btnlog center giga-log" href="/site/login" alt="Login to GigaDB website">
                      <img src="/images/icons/giga.png"/>&nbsp;
                 </a>
              </div>
-             <div class="content-btnlog">
-                 <a class="btn btnlog facebook-log" href="/opauth/facebook">
-                     <img src="/images/icons/fb.png"/>&nbsp;&nbsp;<?=Yii::t('app' , 'Facebook')?>
-                 </a>
-                <a class="btn btnlog google-log" href="/opauth/google">
-                     <img src="/images/icons/google.png"/>&nbsp;&nbsp;<?=Yii::t('app' , 'Google')?>
+            <div class="content-btnlog">
+                <a class="btn btnlog facebook-log" href="/opauth/facebook">
+                    <img src="/images/icons/fb.png" alt="Login with Facebook"/>&nbsp;&nbsp;<?=Yii::t('app' , 'Facebook')?>
                 </a>
-             </div>
-             <div class="content-btnlog">
+                <a class="btn btnlog google-log" href="/opauth/google">
+                        <img src="/images/icons/google.png" alt="Login with Google" />&nbsp;&nbsp;<?=Yii::t('app' , 'Google')?>
+                </a>
+            </div>
+            <div class="content-btnlog">
                 <a class="btn btnlog twitter-log" href="/opauth/twitter">
-                     <img src="/images/icons/twi.png"/>&nbsp;&nbsp;<?=Yii::t('app' , 'Twitter')?>
+                    <img src="/images/icons/twi.png" alt="Login with twitter"/>&nbsp;&nbsp;<?=Yii::t('app' , 'Twitter')?>
                 </a>
                 <a class="btn btnlog linkedin-log" href="/opauth/linkedin">
-                    <img src="/images/icons/in.png"/>&nbsp;&nbsp;<?=Yii::t('app' , 'LinkedIn')?>
+                    <img src="/images/icons/in.png" alt="Login with LinkedIn"/>&nbsp;&nbsp;<?=Yii::t('app' , 'LinkedIn')?>
                 </a>
-             </div>
+            </div>
         </div>
      
      <?php endif ?>

--- a/protected/views/layouts/new_faq.php
+++ b/protected/views/layouts/new_faq.php
@@ -212,7 +212,7 @@
                          <img src="<?= Yii::app()->createAbsoluteUrl('/') . "/images/icons/id.png" ?>"/>&nbsp;&nbsp;<?= Yii::t('app', 'ORCID') ?>
                     </a>-->
             <a class="btn btnlog center giga-log" href="/site/login">
-                        <img src="/images/icons/giga.png"/>&nbsp;
+                        <img src="/images/icons/giga.png" alt="Login to GigaDB website"/>&nbsp;
                     </a>
         </div>
         <div class="content-btnlog">

--- a/protected/views/layouts/new_faq.php
+++ b/protected/views/layouts/new_faq.php
@@ -217,19 +217,19 @@
         </div>
         <div class="content-btnlog">
             <a class="btn btnlog facebook-log" href="/opauth/facebook">
-                        <img src="/images/icons/fb.png"/>&nbsp;&nbsp;<?= Yii::t('app', 'Facebook') ?>
-                    </a>
+                <img src="/images/icons/fb.png" alt="Login with Facebook"/>&nbsp;&nbsp;<?=Yii::t('app' , 'Facebook')?>
+            </a>
             <a class="btn btnlog google-log" href="/opauth/google">
-                        <img src="/images/icons/google.png"/>&nbsp;&nbsp;<?= Yii::t('app', 'Google') ?>
-                    </a>
+                <img src="/images/icons/google.png" alt="Login with Google" />&nbsp;&nbsp;<?=Yii::t('app' , 'Google')?>
+            </a>
         </div>
         <div class="content-btnlog">
             <a class="btn btnlog twitter-log" href="/opauth/twitter">
-                        <img src="/images/icons/twi.png"/>&nbsp;&nbsp;<?= Yii::t('app', 'Twitter') ?>
-                    </a>
+                <img src="/images/icons/twi.png" alt="Login with twitter"/>&nbsp;&nbsp;<?=Yii::t('app' , 'Twitter')?>
+            </a>
             <a class="btn btnlog linkedin-log" href="/opauth/linkedin">
-                        <img src="/images/icons/in.png"/>&nbsp;&nbsp;<?= Yii::t('app', 'LinkedIn') ?>
-                    </a>
+                <img src="/images/icons/in.png" alt="Login with LinkedIn"/>&nbsp;&nbsp;<?=Yii::t('app' , 'LinkedIn')?>
+            </a>
         </div>
     </div>
     <?php endif ?>

--- a/protected/views/layouts/new_main.php
+++ b/protected/views/layouts/new_main.php
@@ -216,19 +216,19 @@
         </div>
         <div class="content-btnlog">
             <a class="btn btnlog facebook-log" href="/opauth/facebook">
-                        <img src="/images/icons/fb.png"/>&nbsp;&nbsp;<?= Yii::t('app', 'Facebook') ?>
-                    </a>
+                <img src="/images/icons/fb.png" alt="Login with Facebook"/>&nbsp;&nbsp;<?=Yii::t('app' , 'Facebook')?>
+            </a>
             <a class="btn btnlog google-log" href="/opauth/google">
-                        <img src="/images/icons/google.png"/>&nbsp;&nbsp;<?= Yii::t('app', 'Google') ?>
-                    </a>
+                <img src="/images/icons/google.png" alt="Login with Google" />&nbsp;&nbsp;<?=Yii::t('app' , 'Google')?>
+            </a>
         </div>
         <div class="content-btnlog">
             <a class="btn btnlog twitter-log" href="/opauth/twitter">
-                        <img src="/images/icons/twi.png"/>&nbsp;&nbsp;<?= Yii::t('app', 'Twitter') ?>
-                    </a>
+                    <img src="/images/icons/twi.png" alt="Login with twitter"/>&nbsp;&nbsp;<?=Yii::t('app' , 'Twitter')?>
+            </a>
             <a class="btn btnlog linkedin-log" href="/opauth/linkedin">
-                        <img src="/images/icons/in.png"/>&nbsp;&nbsp;<?= Yii::t('app', 'LinkedIn') ?>
-                    </a>
+                <img src="/images/icons/in.png" alt="Login with LinkedIn"/>&nbsp;&nbsp;<?=Yii::t('app' , 'LinkedIn')?>
+            </a>
         </div>
     </div>
     <?php endif ?>

--- a/protected/views/layouts/uploader_layout.php
+++ b/protected/views/layouts/uploader_layout.php
@@ -212,19 +212,19 @@
         </div>
         <div class="content-btnlog">
             <a class="btn btnlog facebook-log" href="/opauth/facebook">
-                        <img src="/images/icons/fb.png"/>&nbsp;&nbsp;<?= Yii::t('app', 'Facebook') ?>
-                    </a>
+                <img src="/images/icons/fb.png" alt="Login with Facebook"/>&nbsp;&nbsp;<?=Yii::t('app' , 'Facebook')?>
+            </a>
             <a class="btn btnlog google-log" href="/opauth/google">
-                        <img src="/images/icons/google.png"/>&nbsp;&nbsp;<?= Yii::t('app', 'Google') ?>
-                    </a>
+                <img src="/images/icons/google.png" alt="Login with Google" />&nbsp;&nbsp;<?=Yii::t('app' , 'Google')?>
+            </a>
         </div>
         <div class="content-btnlog">
             <a class="btn btnlog twitter-log" href="/opauth/twitter">
-                        <img src="/images/icons/twi.png"/>&nbsp;&nbsp;<?= Yii::t('app', 'Twitter') ?>
-                    </a>
+                    <img src="/images/icons/twi.png" alt="Login with twitter"/>&nbsp;&nbsp;<?=Yii::t('app' , 'Twitter')?>
+            </a>
             <a class="btn btnlog linkedin-log" href="/opauth/linkedin">
-                        <img src="/images/icons/in.png"/>&nbsp;&nbsp;<?= Yii::t('app', 'LinkedIn') ?>
-                    </a>
+                <img src="/images/icons/in.png" alt="Login with LinkedIn"/>&nbsp;&nbsp;<?=Yii::t('app' , 'LinkedIn')?>
+            </a>
         </div>
     </div>
     <?php endif ?>


### PR DESCRIPTION
# Pull request for issue: #1458

This is a pull request for the following functionalities:

* Add alt attributes to social login images

## How to test?

Navigate to these pages
* http://gigadb.gigasciencejournal.com:9170/site/index
* http://gigadb.gigasciencejournal.com:9170/dataset/100006
* http://gigadb.gigasciencejournal.com:9170/site/faq

* Use AXE chrome extension and verify that there are no "Missing alternative text" errors

## How have functionalities been implemented?

Added alt attribute to images that missed it

## Any issues with implementation?

None

## Any changes to automated tests?

None

## Any changes to documentation?

None

## Any technical debt repayment?

None

## Any improvements to CI/CD pipeline?

None
