### PR TITLE
A11y - Dataset search page - Improve pagination accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1375: Improve accessibility of dataset search pagination
 - Feat #1374: Improve accessibility and use of semantic html of search results card
-
 - Fix #1449: Fix issue preventing deployment to live production environment bastion server
 - Fix #1102: Display error message when creating a sample object or updating an existing sample object with attribute not found in attribute table, and do not create/save it. Refactored container scanning jobs in gitlab pipeline.
 - Feat #1376: Fix heading hierarchy in Contact Page, wrap address in `<address>` element

--- a/less/current/modules/pagination.less
+++ b/less/current/modules/pagination.less
@@ -1,3 +1,7 @@
+.nav-pagination {
+  margin-left: 50px!important;
+  height: 72px;
+}
 .pagination {
   margin: 0px;
   display: inline-block;

--- a/less/current/modules/pagination.less
+++ b/less/current/modules/pagination.less
@@ -9,7 +9,8 @@
 .pagination > li > span,
 .pagination > li > a {
   padding: 7px 15px;
-  color: @color-warm-black;
+  color: @dark-gray-on-white;
+  font-weight: bold;
   float: none;
   margin-left: -5px;
   display: block;
@@ -44,4 +45,9 @@
   width: 50px;
   box-shadow: none;
   border-color: @color-medium-gray;
+}
+
+.pagination > .disabled > a {
+  color: @dark-gray-on-white;
+  font-weight: normal;
 }

--- a/protected/views/search/new.php
+++ b/protected/views/search/new.php
@@ -3,28 +3,28 @@
                 <div class="container">
                     <div class="row">
                         <div class="col-xs-10 col-xs-offset-1 text-center">
-                            <h1 class="home-search-bar-title">GIGADB DATASETS</h1>     
+                            <h1 class="home-search-bar-title">GIGADB DATASETS</h1>
                              <p class="home-search-bar-subtitle"></p>
                              <br>
                              <br>
                              <br>
-                             <? $this->renderPartial('_search', array('model' => $model))?>   
-                                
+                             <? $this->renderPartial('_search', array('model' => $model))?>
+
                         </div>
                     </div>
                 </div>
             </section>
             <div class="container">
                 <div class="row">
-                    
-                    <div class="col-xs-4 search-filter-sidebar">                  
+
+                    <div class="col-xs-4 search-filter-sidebar">
                         <h4 class="search-result-title">Search result for <span><i><?php echo $model->keyword ?></i></span></h4>
                           <p><?php $this->renderPartial('_range', array(
                                     'total_dataset'=>$datasets['total'],
                                     'page'=>$page,
                                     'limit'=>$limit
                               ));?> </p>
-                          
+
                            <div>
                                 <?php $this->renderPartial("_filter", array(
                                           'model' => $model,
@@ -32,7 +32,7 @@
                                 )) ?>
                             </div>
                              </div>
-                        
+
                     <div class="col-xs-8">
                         <div class="span9 result" id="result">
         <!--<span class='pull-right'><?= Yii::t('app', 'Selected all files') ?> <input type="checkbox" class="select-all"/></span> -->
@@ -45,17 +45,17 @@
                                  )) ?>
                          </div>
                         <div class="row1">
-                            <div class="span9 offset3" style="margin-left: 50px;height:72px;">
-                              <ul id="search-pg" class="pagination-sm" style="margin: auto;width: 100%"></ul>
-                            </div>
+                            <nav class="span9 offset3 nav-pagination" aria-label="Pagination">
+                                <ul id="search-pg" class="pagination-sm"></ul>
+                            </nav>
                         </div>
-                        
-                        
+
+
                     </div>
-             
+
             </div>
         </div>
-    
+
     <br>
     <br>
 
@@ -89,6 +89,7 @@ document.addEventListener("DOMContentLoaded", function(event) { //This event is 
 });
 </script>
 
+<!-- NOTE this type of pagination is used only here so there's no need to make it reusable -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/twbs-pagination/1.4.2/jquery.twbsPagination.min.js" defer></script>
 <script>
 document.addEventListener("DOMContentLoaded", function(event) { //This event is fired after deferred scripts are loaded
@@ -97,14 +98,40 @@ document.addEventListener("DOMContentLoaded", function(event) { //This event is 
         visiblePages: 5,
         onPageClick: function (event, page) {
             url = document.URL;
-            $.post(url, {'page': page}, function(result) {                
+            $.post(url, {'page': page}, function(result) {
                 if(result.success) {
                     $('#filter').html(result.filter);
                     $('#result').html(result.result);
                     $('#range').html(result.range);
                 }
             }, 'json');
+
+            handlePaginationAccessibility()
+
+            function handlePaginationAccessibility() {
+                $('#search-pg li a').each(function(index, element) {
+                    const pageNum = $(element).text();
+                    const isCurrent = (pageNum === page.toString());
+
+
+                    $(element).attr('aria-label', getLabel());
+                    $(element).attr('aria-current', isCurrent ? 'page' : undefined);
+
+                    function getLabel() {
+                        const isPageNum = !!parseInt(pageNum);
+
+                        if (isCurrent) {
+                            return `Current Page, Page ${pageNum}`;
+                        } else if (isPageNum) {
+                            return `Go to Page ${pageNum}`;
+                        } else {
+                            return `Go to ${pageNum} Page`;
+                        }
+                    }
+                });
+            }
         }
     });
+
 });
 </script>


### PR DESCRIPTION
# Pull request for issue: #1375

This is a pull request for the following functionalities:

* Fixed accessibility issues in pagination widget of dataset search page (http://gigadb.gigasciencejournal.com:9170/search/new?keyword=Genomic)
* Improved accessibility of pagination using an improved version of the pagination pattern found here https://www.a11ymatters.com/pattern/pagination/

Before:

![image](https://github.com/gigascience/gigadb-website/assets/143437854/2e97a6ca-e738-4641-ad94-b4b7baa07e87)


After:

![image](https://github.com/gigascience/gigadb-website/assets/143437854/b4c80900-a72a-4986-ba2e-3ed4b6eff75d)


## How to test?

* Navigate to http://gigadb.gigasciencejournal.com:9170/search/new?keyword=Genomic
* Use AXE chrome extension to check that pagination has no issues
* Inspect DOM to find that:
  * pagination is wrapped in a `<nav>`
  * page links have meaningful labels
  * When page is changed, labels are updated as one would expect

## How have functionalities been implemented?

* This pattern has been implemented for navigation as closely as was timely and possible with a combination of html and jQuery:
```
<nav aria-label="Pagination">
  <ol>
    <li><a href="/page-1" aria-label="Current Page, Page 1" aria-current="page">1</a></li>
    <li><a href="/page-2" aria-label="Go to Page 2">2</a></li>
    <li><a href="/page-3" aria-label="Go to Page 3">3</a></li>
    <li><a href="/page-4" aria-label="Go to Page 4">4</a></li>
    <li><a href="/page-5" aria-label="Go to Page 5">5</a></li>
  </ol>
</nav>
```
* Inline styles from pagination were replaced by external styles
* Color contrast issues are fixed while maintained a distinct appearance for disabled items, by using different font weights

## Any issues with implementation?

* Not an accessibility issue strictly, but I think crawlers will be unable to crawl pages since the links don't have meaningful href, plus pagination with query params such as ?page=1 might offer a better user experience and will be persistent on page refresh. I figured to better leave this out of scope, as I don't know the complexity of implementing this feature but it sounds time consuming

## Any changes to automated tests?

None

## Any changes to documentation?

None

## Any technical debt repayment?

None

## Any improvements to CI/CD pipeline?

None
