### PR TITLE
A11y - Contact page - accessible contact form

### DIFF
--- a/less/current/modules/forms.less
+++ b/less/current/modules/forms.less
@@ -48,6 +48,17 @@ input[type="checkbox"] {
   font-size: 13px;
 }
 
+.form-control:focus {
+  outline: 2px solid @color-gigadb-green;
+}
+
+.form-group {
+  .errorMessage {
+    margin-top: 2px;
+    color: @brand-danger-on-white;
+  }
+}
+
 .carousel-doi {
   left: 30px;
   border-radius: 23px;

--- a/protected/views/site/contact.php
+++ b/protected/views/site/contact.php
@@ -43,8 +43,10 @@ $this->pageTitle = 'GigaDB - Contact Us';
                         <div class="col-xs-7">
                             <div class="form-group">
                                 <?= $form->labelEx($model, 'name', array('class' => 'control-label')); ?>
-                                <?= $form->textField($model, 'name', array('class' => 'form-control')); ?>
-                                <?php echo $form->error($model, 'name'); ?>
+                                <?= $form->textField($model, 'name', array('class' => 'form-control', 'required' => true, 'aria-required' => 'true', 'aria-describedby' => $model->hasErrors('name') ? 'nameError' : null)); ?>
+                                <div id="nameError">
+                                    <?php echo $form->error($model, 'name'); ?>
+                                </div>
 
                             </div>
                         </div>
@@ -53,8 +55,10 @@ $this->pageTitle = 'GigaDB - Contact Us';
                             <div class="form-group">
                                 <?= $form->labelEx($model, 'email', array('class' => 'control-label')); ?>
 
-                                <?= $form->textField($model, 'email', array('class' => 'form-control')); ?>
-                                <?php echo $form->error($model, 'email'); ?>
+                                <?= $form->textField($model, 'email', array('class' => 'form-control', 'required' => true, 'aria-required' => 'true', 'aria-describedby' => $model->hasErrors('email') ? 'emailError' : null)); ?>
+                                <div id="emailError">
+                                    <?php echo $form->error($model, 'email'); ?>
+                                </div>
                             </div>
                         </div>
 
@@ -62,8 +66,10 @@ $this->pageTitle = 'GigaDB - Contact Us';
                             <div class="form-group">
                                 <?= $form->labelEx($model, 'subject', array('class' => 'control-label')); ?>
 
-                                <?= $form->textField($model, 'subject', array('class' => 'form-control')); ?>
-                                <?php echo $form->error($model, 'subject'); ?>
+                                <?= $form->textField($model, 'subject', array('class' => 'form-control', 'required' => true, 'aria-required' => 'true', 'aria-describedby' => $model->hasErrors('subject') ? 'subjectError' : null)); ?>
+                                <div id="subjectError">
+                                    <?php echo $form->error($model, 'subject'); ?>
+                                </div>
                             </div>
                         </div>
 
@@ -71,8 +77,10 @@ $this->pageTitle = 'GigaDB - Contact Us';
                             <div class="form-group">
                                 <?= $form->labelEx($model, 'body', array('class' => 'control-label')); ?>
 
-                                <?= $form->textArea($model, 'body', array('rows' => 5, 'class' => 'form-control')); ?>
-                                <?php echo $form->error($model, 'body'); ?>
+                                <?= $form->textArea($model, 'body', array('rows' => 5, 'class' => 'form-control', 'required' => true, 'aria-required' => 'true', 'aria-describedby' => $model->hasErrors('body') ? 'bodyError' : null)); ?>
+                                <div id="bodyError">
+                                    <?php echo $form->error($model, 'body'); ?>
+                                </div>
                             </div>
                         </div>
 
@@ -85,11 +93,13 @@ $this->pageTitle = 'GigaDB - Contact Us';
                                 </div>
                                 <br>
                                 <br>
-                                <?php echo $form->textField($model, 'verifyCode', array('class' => 'form-control')); ?>
-                                <div class="hint">Please enter the letters as they are shown in the image above.
+                                <?php echo $form->textField($model, 'verifyCode', array('class' => 'form-control', 'required' => true, 'aria-required' => 'true', 'aria-describedby' => $model->hasErrors('verifyCode') ? 'verifyCodeHint verifyCodeError' : 'verifyCodeHint')); ?>
+                                <div class="hint" id="verifyCodeHint">Please enter the letters as they are shown in the image above.
                                     <br />Letters are case-sensitive.
                                 </div>
-                                <?php echo $form->error($model, 'verifyCode'); ?>
+                                <div id="verifyCodeError">
+                                    <?php echo $form->error($model, 'verifyCode'); ?>
+                                </div>
                             </div>
                         </div>
 

--- a/protected/views/site/contact.php
+++ b/protected/views/site/contact.php
@@ -1,128 +1,128 @@
-
 <?
-	$this->pageTitle='GigaDB - Contact Us';
+$this->pageTitle = 'GigaDB - Contact Us';
 ?>
 
 
 <? if (Yii::app()->user->hasFlash('contact')) { ?>
-<div class="flash-success alert alert-success">
-	<?= Yii::app()->user->getFlash('contact'); ?>
-</div>
+    <div class="flash-success alert alert-success">
+        <?= Yii::app()->user->getFlash('contact'); ?>
+    </div>
 <? } else {
     Yii::app()->captcha->generate();
 ?>
- <div class="content">
-            <div class="container">
-                <section class="page-title-section">
-                    <div class="page-title">
-                        <ol class="breadcrumb pull-right">
-                            <li><a href="/">Home</a></li>
-                            <li class="active">Contact</li>
-                        </ol>
-                        <h1 class="h4">Contact</h1>
-                    </div>
-                </section>
-                <div class="subsection">
-                    <img src="../images/new_interface_image/shekmun_map.png" alt="Map highlighting the GigaDB location on 1 On Kwan Street in Sha Tin, Hong Kong">
+    <div class="content">
+        <div class="container">
+            <section class="page-title-section">
+                <div class="page-title">
+                    <ol class="breadcrumb pull-right">
+                        <li><a href="/">Home</a></li>
+                        <li class="active">Contact</li>
+                    </ol>
+                    <h1 class="h4">Contact</h1>
                 </div>
-                <section>
-                    <div class="row">
-                        <div class="col-xs-9">
-                            <div class="underline-title">
-                                <div>
-                                    <h2 class="h4">Contact form</h2>
-                                </div>
-                            </div>
-                            <div class="subsection">
-                                <p>For more information or questions regarding submitting data to GigaDB, please contact us at: <a href="mailto:database@gigasciencejournal.com" target="_blank">database@gigasciencejournal.com</a>.</p>
-                                <p>Fields with <span class="text-danger">*</span> are required.</p>
-                            </div>
-
-
-
-			<? $form=$this->beginWidget('CActiveForm', array('htmlOptions'=>array('class'=>'form contact-form'))); ?>
-				<div class="col-xs-7">
-                                    <div class="form-group">
-					<?= $form->labelEx($model,'name', array('class'=>'text-danger')); ?>
-                                        <?= $form->textField($model,'name',array('class'=>'form-control')); ?>
-                                        <?php echo $form->error($model,'name'); ?>
-
-                                     </div>
-                                 </div>
-
-				<div class="col-xs-7">
-                                    <div class="form-group">
-					<?= $form->labelEx($model,'email', array('class'=>'control-label')); ?>
-
-						<?= $form->textField($model,'email',array('class'=>'form-control')); ?>
-						<?php echo $form->error($model,'email'); ?>
-					</div>
-				</div>
-
-				<div class="col-xs-7">
-                                    <div class="form-group">
-					<?= $form->labelEx($model,'subject', array('class'=>'control-label')); ?>
-
-						<?= $form->textField($model,'subject',array('class'=>'form-control')); ?>
-						<?php echo $form->error($model,'subject'); ?>
-					</div>
-				</div>
-
-				<div class="col-xs-12">
-                                    <div class="form-group">
-					<?= $form->labelEx($model,'body', array('class'=>'control-label')); ?>
-
-						<?= $form->textArea($model,'body',array('rows'=>5,'class'=>'form-control')); ?>
-						<?php echo $form->error($model,'body'); ?>
-					</div>
-				</div>
-
-                                <div class="col-xs-7">
-                                    <div class="form-group">
-					<?php echo $form->labelEx($model,'verifyCode'); ?>
-
-						<div style="width:100%">
-							<img style="width:200px;" src="<?php echo Yii::app()->captcha->output(); ?>" alt="Type the word in the image">
-						</div>
-                                                <br>
-                                                <br>
-						<?php echo $form->textField($model,'verifyCode',array('class'=>'form-control')); ?>
-						<div class="hint">Please enter the letters as they are shown in the image above.
-						<br/>Letters are case-sensitive.</div>
-						<?php echo $form->error($model, 'verifyCode'); ?>
-						</div>
-                                </div>
-
-
-
-
-
-
-                <div class="span8 offset2"><?= CHtml::submitButton('Submit', array('class'=>'btn background-btn')); ?></div>
-
-                <? $this->endWidget(); ?>
-                </div><!-- form -->
-
-                        <div class="col-xs-3">
-                            <div class="underline-title">
-                                <div>
-                                    <h2 class="h4">Contacts</h2>
-                                </div>
-                            </div>
-                            <address>
-                                <ul class="fa-ul">
-                                    <li><i class="fa-li fa fa-home" aria-hidden="true"></i><span class="sr-only">Address:</span> Room A-D, 26/F, Kings Wing Plaza 2, 1 On Kwan Street, Shek Mun, Shatin, NT, Hong Kong</li>
-                                    <li><i class="fa-li fa fa-envelope" aria-hidden="true"></i><span class="sr-only">Email:</span> database@gigasciencejournal.com</li>
-                                    <li><i class="fa-li fa fa-phone" aria-hidden="true"></i><span class="sr-only">Phone:</span> (852) 36103533</li>
-                                    <li><i class="fa-li fa fa-globe" aria-hidden="true"></i><span class="sr-only">Website:</span> http://www.gigadb.org</li>
-                                </ul>
-                            </address>
-                        </div>
-                </div>
-                </section>
-
+            </section>
+            <div class="subsection">
+                <img src="../images/new_interface_image/shekmun_map.png" alt="Map highlighting the GigaDB location on 1 On Kwan Street in Sha Tin, Hong Kong">
             </div>
+            <section>
+                <div class="row">
+                    <div class="col-xs-9">
+                        <div class="underline-title">
+                            <div>
+                                <h2 class="h4">Contact form</h2>
+                            </div>
+                        </div>
+                        <div class="subsection">
+                            <p>For more information or questions regarding submitting data to GigaDB, please contact us at: <a href="mailto:database@gigasciencejournal.com" target="_blank">database@gigasciencejournal.com</a>.</p>
+                            <p>Fields with <span>*</span> are required.</p>
+                        </div>
+
+
+
+                        <? $form = $this->beginWidget('CActiveForm', array('htmlOptions' => array('class' => 'form contact-form'))); ?>
+                        <div class="col-xs-7">
+                            <div class="form-group">
+                                <?= $form->labelEx($model, 'name', array('class' => 'control-label')); ?>
+                                <?= $form->textField($model, 'name', array('class' => 'form-control')); ?>
+                                <?php echo $form->error($model, 'name'); ?>
+
+                            </div>
+                        </div>
+
+                        <div class="col-xs-7">
+                            <div class="form-group">
+                                <?= $form->labelEx($model, 'email', array('class' => 'control-label')); ?>
+
+                                <?= $form->textField($model, 'email', array('class' => 'form-control')); ?>
+                                <?php echo $form->error($model, 'email'); ?>
+                            </div>
+                        </div>
+
+                        <div class="col-xs-7">
+                            <div class="form-group">
+                                <?= $form->labelEx($model, 'subject', array('class' => 'control-label')); ?>
+
+                                <?= $form->textField($model, 'subject', array('class' => 'form-control')); ?>
+                                <?php echo $form->error($model, 'subject'); ?>
+                            </div>
+                        </div>
+
+                        <div class="col-xs-12">
+                            <div class="form-group">
+                                <?= $form->labelEx($model, 'body', array('class' => 'control-label')); ?>
+
+                                <?= $form->textArea($model, 'body', array('rows' => 5, 'class' => 'form-control')); ?>
+                                <?php echo $form->error($model, 'body'); ?>
+                            </div>
+                        </div>
+
+                        <div class="col-xs-7">
+                            <div class="form-group">
+                                <?php echo $form->labelEx($model, 'verifyCode'); ?>
+
+                                <div style="width:100%">
+                                    <img style="width:200px;" src="<?php echo Yii::app()->captcha->output(); ?>" alt="Type the word in the image">
+                                </div>
+                                <br>
+                                <br>
+                                <?php echo $form->textField($model, 'verifyCode', array('class' => 'form-control')); ?>
+                                <div class="hint">Please enter the letters as they are shown in the image above.
+                                    <br />Letters are case-sensitive.
+                                </div>
+                                <?php echo $form->error($model, 'verifyCode'); ?>
+                            </div>
+                        </div>
+
+
+
+
+
+
+                        <div class="span8 offset2"><?= CHtml::submitButton('Submit', array('class' => 'btn background-btn')); ?></div>
+
+                        <? $this->endWidget(); ?>
+                    </div><!-- form -->
+
+                    <div class="col-xs-3">
+                        <div class="underline-title">
+                            <div>
+                                <h2 class="h4">Contacts</h2>
+                            </div>
+                        </div>
+                        <address>
+                            <ul class="fa-ul">
+                                <li><i class="fa-li fa fa-home" aria-hidden="true"></i><span class="sr-only">Address:</span> Room A-D, 26/F, Kings Wing Plaza 2, 1 On Kwan Street, Shek Mun, Shatin, NT, Hong Kong</li>
+                                <li><i class="fa-li fa fa-envelope" aria-hidden="true"></i><span class="sr-only">Email:</span> database@gigasciencejournal.com</li>
+                                <li><i class="fa-li fa fa-phone" aria-hidden="true"></i><span class="sr-only">Phone:</span> (852) 36103533</li>
+                                <li><i class="fa-li fa fa-globe" aria-hidden="true"></i><span class="sr-only">Website:</span> http://www.gigadb.org</li>
+                            </ul>
+                        </address>
+                    </div>
+                </div>
+            </section>
+
         </div>
+    </div>
 
 
 <? } ?>


### PR DESCRIPTION
# Pull request for issue: #1377

This is a pull request for the following functionalities:

* Improve accessibility of contact form: http://gigadb.gigasciencejournal.com:9170/site/contact

## How to test?

* Navigate to http://gigadb.gigasciencejournal.com:9170/site/contact
* Run AXE extension audit and verify that form has:
  * No contrast issues
  * Aria-describedby and aria-required attributes
* Try to submit the empty form to confirm that it has (browser) built-in client-side validation
* Interact with the from to check the focus styles

## How have functionalities been implemented?

* Updated general form styles to add visible focus whcih is more prominent
* Updated error messages to be displayed in red color
* Removed arbitrary red used in first input and required star
* Added aria-required, required and aria-describedby attributes to inputs

## Any issues with implementation?

None

## Any changes to automated tests?

None

## Any changes to documentation?

None

## Any technical debt repayment?

None

## Any improvements to CI/CD pipeline?

None
