### PR TITLE
Fix URL creation for ftp_site field in dataset table when using files metadata console tool 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1483: Fix URL creation for ftp_site field in dataset table when using files metadata console tool
 - Feat #1374: Improve accessibility and use of semantic html of search results card
-
 - Fix #1449: Fix issue preventing deployment to live production environment bastion server
 - Fix #1102: Display error message when creating a sample object or updating an existing sample object with attribute not found in attribute table, and do not create/save it. Refactored container scanning jobs in gitlab pipeline.
 - Feat #1376: Fix heading hierarchy in Contact Page, wrap address in `<address>` element

--- a/data/dev/file.csv
+++ b/data/dev/file.csv
@@ -68,3 +68,4 @@ id,dataset_id,name,location,extension,size,description,date_stamp,format_id,type
 95363,319,IMG_2770.jpg,https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100245/images/IMG_2770.jpg,jpg,179665,image of the GPS co-ordinates of the tree sampled for variegataA (TY-T0891),2016-11-01,44,141,variegataA,,3,
 95364,319,IMG_2771.jpg,https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100245/images/IMG_2771.jpg,jpg,2697775,photo of the HK government label on the tree sampled for purpureaA (TY-T0203),2016-11-01,44,141,purpureaA,,3,
 95365,319,IMG_2774.jpg,https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100245/images/IMG_2774.jpg,jpg,181615,image of the GPS co-ordinates of the tree sampled for purpureaA (TY-T0203),2016-11-01,44,141,purpureaA,,3,
+95366,2342,readme.txt,https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100935/readme.txt,txt,1089,,2016-11-01,1,1,,,1,

--- a/gigadb/app/tools/files-metadata-console/.gitignore
+++ b/gigadb/app/tools/files-metadata-console/.gitignore
@@ -37,3 +37,5 @@ tests/_support/_generated
 config/db.php
 config/test_db.php
 config/params.php
+
+docker-compose.override.yml

--- a/gigadb/app/tools/files-metadata-console/components/DatasetFilesURLUpdater.php
+++ b/gigadb/app/tools/files-metadata-console/components/DatasetFilesURLUpdater.php
@@ -152,8 +152,9 @@ final class DatasetFilesURLUpdater extends Component
         $uriParts = parse_url(ltrim($dataset['ftp_site']));
         // Update ftp_site if it starts with ftp:// or contains ftp.cngb.org
         if ("ftp" === $uriParts['scheme'] || "ftp.cngb.org" === $uriParts['host']) {
-            $path = mb_split("/pub/", $uriParts['path'])[1];
-            $newFTPSite = $newFTPSitePrefix . $path;
+            $pathTokens = mb_split("/pub/", $uriParts['path']);
+            $lastPathToken = end($pathTokens);
+            $newFTPSite = $newFTPSitePrefix . $lastPathToken;
             if ($this->apply === true) {
                 $dataset->ftp_site = $newFTPSite;
                 if(!$dataset->save()) {

--- a/gigadb/app/tools/files-metadata-console/tests/functional/ReplaceFileUrlSubstringWithPrefixCest.php
+++ b/gigadb/app/tools/files-metadata-console/tests/functional/ReplaceFileUrlSubstringWithPrefixCest.php
@@ -84,6 +84,7 @@ class ReplaceFileUrlSubstringWithPrefixCest
         $I->seeInDatabase('file', ['name' => 'millet.chr.version2.3.fa.gz', 'location' => "ftp://climb.genomics.cn/pub/10.5524/100001_101000/100003/millet.chr.version2.3.fa.gz"]);
         $I->seeInDatabase('dataset', ['identifier' => '100004', 'ftp_site' => 'ftp://climb.genomics.cn/pub/10.5524/100001_101000/100004']);
         $I->seeInDatabase('file', ['id' => '88266', 'location' => "ftp://climb.genomics.cn/pub/10.5524/100001_101000/100003/readme.txt"]);
+        $I->seeInDatabase('dataset', ['identifier' => '100005', 'ftp_site' => 'https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100005']);
 
         # Run tool to update file URLs for dataset 100002
         $I->runShellCommand("./yii_test update/urls --separator=/pub/ --next=3 --apply");
@@ -112,6 +113,9 @@ class ReplaceFileUrlSubstringWithPrefixCest
         $I->canSeeInShellOutput("\tTransforming file locations for dataset 100005...\nWARNING (1/4)");
         $I->canSeeInShellOutput("\tTransforming ftp_site for dataset 100039...\nDONE");
         $I->canSeeInShellOutput("\tTransforming file locations for dataset 100039...\nDONE (24/24)");
+
+        # Check ftp_site URL has been updated for dataset 100005
+        $I->seeInDatabase('dataset', ['identifier' => '100005', 'ftp_site' => 'https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/' . Yii::$app->params['DEPLOYMENT_ENV'] . '/pub/10.5524/100001_101000/100005']);
     }
 
     /**


### PR DESCRIPTION
# Pull request for issue: #1466

This is a pull request for the following functionalities:

* A fix for a bug when transforming a dataset's ftp_site value that contains two `/pub/` substrings, e.g. `https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100003/` would result in `https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/staging/gigadb` which is not correct.

## How to test?

### Dev environment

Spin up a local GigaDB instance:
```
$ ./up.sh
```

Change directory:
```
$ cd gigadb/app/tools/files-metadata-console
```

If you look in the dataset table, you will see that dataset 100935 will have a ftp_site value of `https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100935/` which contains two `/pub/` sub-strings.

Transform all dataset ftp_site and file location URLs using files metadata console tool:
```
$ docker-compose run --rm files-metadata-console ./yii update/urls --separator=/pub/ --next=10 --apply
```

If you now check the ftp_site field for dataset 100935, you should see that it is `https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/dev/pub/10.5524/100001_101000/100935/` which is now correct.

### Staging environment

Deploy the code in this PR onto your staging server from your CI/CD pipeline.

Log into your bastion server.

Drop datasbase triggers:
```
[centos@ip-10-99-0-27 ~]$ $ docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c 'drop trigger if exists file_finder_trigger on file RESTRICT'
-bash: $: command not found
[centos@ip-10-99-0-27 ~]$ docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c 'drop trigger if exists file_finder_trigger on file RESTRICT'
DROP TRIGGER
[centos@ip-10-99-0-27 ~]$ docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c 'drop trigger if exists sample_finder_trigger on sample RESTRICT'
DROP TRIGGER
[centos@ip-10-99-0-27 ~]$ docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c 'drop trigger if exists dataset_finder_trigger on dataset RESTRICT'
DROP TRIGGER
```

Transform a couple of dataset ftp_site and file location URLs using files metadata console tool:
```
[centos@ip-10-99-0-27 ~]$ docker run --rm "registry.gitlab.com/$GITLAB_PROJECT/production-files-metadata-console:$GIGADB_ENV" ./yii update/urls --separator=/pub/ --stop=102443 --next=2 --apply
        Transforming ftp_site for dataset 100001... 
DONE

        Transforming file locations for dataset 100001...
DONE (19/19)

        Transforming ftp_site for dataset 100002... 
DONE

        Transforming file locations for dataset 100002...
DONE (10/10)
```

If you check the ftp_site field for dataset 100001, you should see this value: `https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/staging/pub/10.5524/100001_101000/100001`

## How have functionalities been implemented?

The bug was caused by the previous functionality in the DatasetFilesURLUpdater.php component class not taking into account for when a ftp_site URL contained two `/pub/` substrings. This would lead to the second string token: `gigadb` being selected and concatenated into the ftp_site URL under creation. The new functionality now selects the last token which will look something like `10.5524/100001_101000/100245/`. The last token will be added to the end of `https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/$DEPLOYMENT_ENV/pub/` to form the correct ftp_site URL.

## Any issues with implementation?

As suggested by @rija, the `WARN[0000] a network with name deployment_db-tier exists but was not created for project "files-metadata-console".` error message can be resolved by creating a `docker-compose.override.yml` in gigadb/app/tools/files-metadata-console with content:
```
version: '3.7'
networks:
  proxy-db-tier:
    name: deployment_db-tier
    external: true
```

## Any changes to automated tests?

The `tryReplaceFleUrlSubstringWithPrefix()` functional test in `ReplaceFileUrlSubstringWithPrefixCest` has been updated to test for this bug using dataset 100005 in the gigadb_testdata database.

