### PR TITLE
Admin styles - Create DatasetAuthor Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1482: Implement modern styles in admin Create DatasetAuthor Page
 - Feat #1374: Improve accessibility and use of semantic html of search results card
-
 - Fix #1449: Fix issue preventing deployment to live production environment bastion server
 - Fix #1102: Display error message when creating a sample object or updating an existing sample object with attribute not found in attribute table, and do not create/save it. Refactored container scanning jobs in gitlab pipeline.
 - Feat #1376: Fix heading hierarchy in Contact Page, wrap address in `<address>` element

--- a/less/current/base/variables.less
+++ b/less/current/base/variables.less
@@ -40,7 +40,7 @@
 // @color-gigadb-green-300: #7afbae;
 // @color-gigadb-green-400: #39ef83;
 // @color-gigadb-green-500: #0fd861;
-// @color-gigadb-green-600: #06b34d;
+@color-gigadb-green-600: #06b34d;
 // @color-gigadb-green-700: #099242;
 @color-gigadb-green-750: @color-gigadb-green; // AA Normal on white
 @color-gigadb-green-800: #0d6e36;

--- a/less/current/layout/section.less
+++ b/less/current/layout/section.less
@@ -2,7 +2,7 @@
 // Section
 // --------------------------------------------------
 
-section {
+section, .section {
   margin-bottom: 40px;
 }
 section.page-title-section {

--- a/less/current/modules/buttons.less
+++ b/less/current/modules/buttons.less
@@ -4,6 +4,7 @@
 
 .btn {
   font-size: @font-size-base;
+  min-width: fit-content;
 }
 
 .admin-action-btn {

--- a/less/current/modules/forms.less
+++ b/less/current/modules/forms.less
@@ -62,7 +62,11 @@ input[type="checkbox"] {
 
 .form-control:focus {
   border-color: @color-gigadb-green-600;
-  box-shadow: inset 0 1px 1px fade(@color-gigadb-green, 7.5%), 0 0 6px fade(@color-gigadb-green-600, 50%);
+  box-shadow: inset 0 1px 1px fade(@color-gigadb-green, 7.5%),
+    0 0 6px fade(@color-gigadb-green-600, 50%);
+  // Alt focus style
+  // outline: 2px solid @color-gigadb-green;
+  // outline-offset: 1px;
 }
 
 .carousel-doi {
@@ -85,13 +89,19 @@ input[type="checkbox"] {
   opacity: 1;
   text-decoration: none;
   background: #a5cc7e;
-  background: -webkit-gradient(linear,0 0,0 bottom,from(#a5cc7e),to(#6ea23a));
-  background: -webkit-linear-gradient(#a5cc7e,#6ea23a);
-  background: -moz-linear-gradient(#a5cc7e,#6ea23a);
-  background: -ms-linear-gradient(#a5cc7e,#6ea23a);
-  background: -o-linear-gradient(#a5cc7e,#6ea23a);
-  background: linear-gradient(#a5cc7e,#6ea23a);
-  -pie-background: linear-gradient(#a5cc7e,#6ea23a);
+  background: -webkit-gradient(
+    linear,
+    0 0,
+    0 bottom,
+    from(#a5cc7e),
+    to(#6ea23a)
+  );
+  background: -webkit-linear-gradient(#a5cc7e, #6ea23a);
+  background: -moz-linear-gradient(#a5cc7e, #6ea23a);
+  background: -ms-linear-gradient(#a5cc7e, #6ea23a);
+  background: -o-linear-gradient(#a5cc7e, #6ea23a);
+  background: linear-gradient(#a5cc7e, #6ea23a);
+  -pie-background: linear-gradient(#a5cc7e, #6ea23a);
   behavior: url(/css/PIE.htc);
 }
 .form-search {
@@ -100,13 +110,19 @@ input[type="checkbox"] {
 .form-search.well {
   text-align: center;
   background: @color-patina-green;
-  background: -webkit-gradient(linear,0 0,0 bottom,from(@color-patina-green),to(@color-dark-green));
-  background: -webkit-linear-gradient(@color-patina-green,@color-dark-green);
-  background: -moz-linear-gradient(@color-patina-green,@color-dark-green);
-  background: -ms-linear-gradient(@color-patina-green,@color-dark-green);
-  background: -o-linear-gradient(@color-patina-green,@color-dark-green);
-  background: linear-gradient(@color-patina-green,@color-dark-green);
-  -pie-background: linear-gradient(@color-patina-green,@color-dark-green);
+  background: -webkit-gradient(
+    linear,
+    0 0,
+    0 bottom,
+    from(@color-patina-green),
+    to(@color-dark-green)
+  );
+  background: -webkit-linear-gradient(@color-patina-green, @color-dark-green);
+  background: -moz-linear-gradient(@color-patina-green, @color-dark-green);
+  background: -ms-linear-gradient(@color-patina-green, @color-dark-green);
+  background: -o-linear-gradient(@color-patina-green, @color-dark-green);
+  background: linear-gradient(@color-patina-green, @color-dark-green);
+  -pie-background: linear-gradient(@color-patina-green, @color-dark-green);
   behavior: url(/css/PIE.htc);
 }
 .form-search.well .btn-green {

--- a/less/current/modules/forms.less
+++ b/less/current/modules/forms.less
@@ -11,6 +11,18 @@ label {
 
 .form-group {
   margin-bottom: 20px;
+  &.has-error {
+    color: @brand-danger-on-white;
+    .control-label {
+      color: @brand-danger-on-white;
+    }
+    .form-control {
+      border-color: @brand-danger-on-white;
+    }
+    .help-block {
+      color: @brand-danger-on-white;
+    }
+  }
 }
 
 input[type="checkbox"] {
@@ -46,6 +58,11 @@ input[type="checkbox"] {
   box-shadow: none;
   color: @color-darker-gray;
   font-size: 13px;
+}
+
+.form-control:focus {
+  border-color: @color-gigadb-green-600;
+  box-shadow: inset 0 1px 1px fade(@color-gigadb-green, 7.5%), 0 0 6px fade(@color-gigadb-green-600, 50%);
 }
 
 .carousel-doi {

--- a/protected/components/TitleBreadcrumb.php
+++ b/protected/components/TitleBreadcrumb.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * TitleBreadcrumb Widget
+ *
+ * This component is used to render a breadcrumb and a page title.
+ *
+ * Usage Example:
+ *
+ * ```php
+ * $this->widget('application.components.TitleBreadcrumb', [
+ *     'pageTitle' => 'Your Page Title',
+ *     'breadcrumbItems' => [
+ *         ['isActive' => true, 'label' => 'Admin'],
+ *         ['label' => 'Dashboard', 'href' => '/dashboard']
+ *         // Add more items as needed
+ *     ]
+ * ]);
+ * ```
+ *
+ * `pageTitle`: string
+ * The main title displayed on the page. Required.
+ *
+ * `breadcrumbItems`: array
+ * An array of breadcrumb items. Each item is an associative array with keys:
+ * - `isActive`: bool, optional. Whether the breadcrumb item is active. Will NOT render a link if true.
+ * - `label`: string, required. The display text of the breadcrumb item.
+ * - `href`: string, optional. The URL / pathname for the breadcrumb item.
+ */
+
+
+/**
+ * Class TitleBreadcrumb
+ * Renders a breadcrumb and a page title.
+ */
+class TitleBreadcrumb extends CWidget
+{
+  public $pageTitle;
+  public $breadcrumbItems = [];
+  const ACTIVE_CLASS = 'active';
+
+  private function generateBreadcrumbItems(): string
+  {
+    return implode("\n", array_map(function ($item) {
+      $isActive = $item['isActive'] ?? false;
+      $label = $item['label'];
+      $href = $item['href'] ?? '#';
+
+      if ($isActive) {
+        return CHtml::tag('li', ['class' => self::ACTIVE_CLASS], $label);
+      }
+
+      return CHtml::tag('li', [], CHtml::link($label, $href));
+    }, $this->breadcrumbItems));
+  }
+
+  public function run()
+  {
+    if (empty($this->pageTitle)) {
+      throw new CException('pageTitle must be set.');
+    }
+
+    $breadcrumbHtml = $this->generateBreadcrumbItems();
+
+    Yii::app()->controller->renderPartial('//shared/_titleBreadcrumb', [
+      'pageTitle' => $this->pageTitle,
+      'breadcrumbHtml' => $breadcrumbHtml
+    ]);
+  }
+}

--- a/protected/components/controls/BaseInput.php
+++ b/protected/components/controls/BaseInput.php
@@ -1,0 +1,79 @@
+<?php
+
+class BaseInput extends CWidget
+{
+  public $form;
+  public $model;
+  public $attributeName;
+  public $description;
+  public $inputOptions;
+  public $labelOptions;
+  public $errorOptions;
+  public $groupOptions;
+
+  protected function hasError() {
+    return $this->model->hasErrors($this->attributeName);
+  }
+
+  private function mergeCssClasses($options, $defaultClass)
+  {
+    return isset($options['class']) ? "{$defaultClass} {$options['class']}" : $defaultClass;
+  }
+
+  protected function prepareHtmlOptions()
+  {
+    $this->groupOptions['class'] = $this->mergeCssClasses($this->groupOptions, 'form-group' . ($this->hasError() ? ' has-error' : ''));
+    $this->inputOptions['class'] = $this->mergeCssClasses($this->inputOptions, 'form-control');
+    $this->labelOptions['class'] = $this->mergeCssClasses($this->labelOptions, 'control-label');
+    $this->errorOptions['class'] = $this->mergeCssClasses($this->errorOptions, 'control-error help-block');
+
+    if ($this->description) {
+      $describedBy[] = $this->attributeName . '-desc';
+    }
+
+    if ($this->model->hasErrors($this->attributeName)) {
+      $describedBy[] = $this->attributeName . '-error';
+    }
+
+    if (!empty($describedBy)) {
+      $this->inputOptions['aria-describedby'] = implode(" ", $describedBy);
+    }
+
+    if (isset($this->inputOptions['required']) && $this->inputOptions['required']) {
+      $this->inputOptions['aria-required'] = 'true';
+    }
+  }
+
+  protected function renderLabel()
+  {
+    echo $this->form->labelEx($this->model, $this->attributeName, $this->labelOptions);
+  }
+
+  protected function renderError()
+  {
+    echo CHtml::openTag('div', array_merge(['id' => $this->attributeName . '-error'], $this->errorOptions));
+    if ($this->hasError()) {
+      echo $this->form->error($this->model, $this->attributeName);
+    }
+    echo CHtml::closeTag('div');
+  }
+
+  protected function renderDescription()
+  {
+    if ($this->description) {
+      echo CHtml::tag('p', array('id' => $this->attributeName . '-desc', 'class' => 'control-description help-block'), $this->description);
+    }
+  }
+
+  public function renderControlGroup($inputClosure)
+  {
+    $this->prepareHtmlOptions();
+
+    echo CHtml::openTag('div', $this->groupOptions);
+    $this->renderLabel();
+    $inputClosure();
+    $this->renderDescription();
+    $this->renderError();
+    echo CHtml::closeTag('div');
+  }
+}

--- a/protected/components/controls/DropdownField.php
+++ b/protected/components/controls/DropdownField.php
@@ -1,0 +1,19 @@
+<?php
+
+Yii::import('application.components.controls.BaseInput');
+
+class DropdownField extends BaseInput
+{
+  public $listDataOptions = [];
+
+  public function run()
+  {
+    $this->renderControlGroup(function () {
+      $data = $this->listDataOptions['data'] ?? [];
+      $valueField = $this->listDataOptions['valueField'] ?? 'id';
+      $textField = $this->listDataOptions['textField'] ?? 'name';
+
+      echo CHtml::activeDropDownList($this->model, $this->attributeName, CHtml::listData($data, $valueField, $textField), $this->inputOptions);
+    });
+  }
+}

--- a/protected/components/controls/TextField.php
+++ b/protected/components/controls/TextField.php
@@ -1,0 +1,12 @@
+<?php
+Yii::import('application.components.controls.BaseInput');
+
+class TextField extends BaseInput
+{
+  public function run()
+  {
+    $this->renderControlGroup(function () {
+      echo $this->form->textField($this->model, $this->attributeName, $this->inputOptions);
+    });
+  }
+}

--- a/protected/controllers/AdminDatasetAuthorController.php
+++ b/protected/controllers/AdminDatasetAuthorController.php
@@ -69,6 +69,7 @@ class AdminDatasetAuthorController extends Controller
 				$this->redirect(array('view','id'=>$model->id));
 		}
 
+        $this->layout = '//layouts/new_column2';
 		$this->render('create',array(
 			'model'=>$model,
 		));
@@ -499,7 +500,7 @@ class AdminDatasetAuthorController extends Controller
                         $criteria->addCondition('t.rank >= '.min($rank,$changeRank));
                         $criteria->addCondition('t.rank < '.max($rank,$changeRank));
                         $criteria->addCondition('t.dataset_id = '.$da->dataset_id);
-                        $das = DatasetAuthor::model()->findAll($criteria); 
+                        $das = DatasetAuthor::model()->findAll($criteria);
                         foreach($das as $updateDa) {
                             $updateDa->rank = $updateDa->rank + 1;
                         }

--- a/protected/controllers/SiteController.php
+++ b/protected/controllers/SiteController.php
@@ -67,6 +67,7 @@ class SiteController extends Controller {
 	**/
 
 	public function actionAdmin() {
+        $this->layout='new_main';
 		$this->render('admin');
 	}
 

--- a/protected/views/adminDatasetAuthor/_form.php
+++ b/protected/views/adminDatasetAuthor/_form.php
@@ -8,9 +8,11 @@
 
 		<p class="note">Fields with <span class="required">*</span> are required.</p>
 
-		<div class="alert alert-danger">
-			<?php echo $form->errorSummary($model); ?>
-		</div>
+		<?php if ($model->hasErrors()): ?>
+			<div class="alert alert-danger">
+				<?php echo $form->errorSummary($model); ?>
+			</div>
+		<?php endif; ?>
 
 		<?php
 		$this->widget('application.components.controls.DropdownField', [

--- a/protected/views/adminDatasetAuthor/_form.php
+++ b/protected/views/adminDatasetAuthor/_form.php
@@ -16,7 +16,6 @@
 		$this->widget('application.components.controls.DropdownField', [
 			'form' => $form,
 			'model' => $model,
-			'description' => 'Select a dataset to add an author to.',
 			'attributeName' => 'dataset_id',
 			'listDataOptions' => [
 				'data' => Util::getDois(),

--- a/protected/views/adminDatasetAuthor/_form.php
+++ b/protected/views/adminDatasetAuthor/_form.php
@@ -1,43 +1,62 @@
-<div class="form">
+<div class="section form row">
 
-	<?php $form = $this->beginWidget('CActiveForm', array(
-		'id' => 'dataset-author-form',
-		'enableAjaxValidation' => false,
-	)); ?>
+	<div class="col-xs-offset-3 col-xs-6">
+		<?php $form = $this->beginWidget('CActiveForm', array(
+			'id' => 'dataset-author-form',
+			'enableAjaxValidation' => false,
+		)); ?>
 
-	<p class="note">Fields with <span class="required">*</span> are required.</p>
+		<p class="note">Fields with <span class="required">*</span> are required.</p>
 
-	<?php echo $form->errorSummary($model); ?>
-
-	<div class="control-group">
-		<?php echo $form->labelEx($model, 'dataset_id', array('class' => 'control-label')); ?>
-		<div class="controls">
-			<?= CHtml::activeDropDownList($model, 'dataset_id', CHtml::listData(Util::getDois(), 'id', 'identifier')); ?>
-			<?php echo $form->error($model, 'dataset_id'); ?>
+		<div class="alert alert-danger">
+			<?php echo $form->errorSummary($model); ?>
 		</div>
-	</div>
 
-	<div class="control-group">
-		<?php echo $form->labelEx($model, 'author_id', array('class' => 'control-label')); ?>
-		<div class="controls">
-			<?= CHtml::activeDropDownList($model, 'author_id', CHtml::listData(Author::model()->findAll(array('order' => 'surname')), 'id', 'fullAuthor')); ?>
-			<?php echo $form->error($model, 'author_id'); ?>
+		<?php
+		$this->widget('application.components.controls.DropdownField', [
+			'form' => $form,
+			'model' => $model,
+			'description' => 'Select a dataset to add an author to.',
+			'attributeName' => 'dataset_id',
+			'listDataOptions' => [
+				'data' => Util::getDois(),
+				'valueField' => 'id',
+				'textField' => 'identifier',
+			],
+		]);
+		?>
+
+		<?php
+		$this->widget('application.components.controls.DropdownField', [
+			'form' => $form,
+			'model' => $model,
+			'attributeName' => 'author_id',
+			'listDataOptions' => [
+				'data' => Author::model()->findAll(array('order' => 'surname')),
+				'valueField' => 'id',
+				'textField' => 'fullAuthor',
+			],
+		]);
+		?>
+
+		<?php
+		$this->widget('application.components.controls.TextField', [
+			'form' => $form,
+			'model' => $model,
+			'attributeName' => 'rank',
+			'inputOptions' => [
+				'required' => 'required',
+				'aria-required' => 'true',
+			],
+		]);
+		?>
+
+		<div class="pull-right">
+			<a href="/adminDatasetAuthor/admin" class="btn background-btn-o">Cancel</a>
+			<?php echo CHtml::submitButton($model->isNewRecord ? 'Create' : 'Save', array('class' => 'btn background-btn')); ?>
 		</div>
-	</div>
 
-	<div class="control-group">
-		<?php echo $form->labelEx($model, 'rank', array('class' => 'control-label')); ?>
-		<div class="controls">
-			<?= $form->textField($model, 'rank') ?>
-			<?php echo $form->error($model, 'author_id'); ?>
-		</div>
+		<?php $this->endWidget(); ?>
 	</div>
-
-	<div class="row buttons">
-		<a href="/adminDatasetAuthor/admin" class="btn background-btn-o">Cancel</a>
-		<?php echo CHtml::submitButton($model->isNewRecord ? 'Create' : 'Save', array('class' => 'btn background-btn')); ?>
-	</div>
-
-	<?php $this->endWidget(); ?>
 
 </div><!-- form -->

--- a/protected/views/adminDatasetAuthor/_form.php
+++ b/protected/views/adminDatasetAuthor/_form.php
@@ -1,43 +1,43 @@
 <div class="form">
 
-<?php $form=$this->beginWidget('CActiveForm', array(
-	'id'=>'dataset-author-form',
-	'enableAjaxValidation'=>false,
-)); ?>
+	<?php $form = $this->beginWidget('CActiveForm', array(
+		'id' => 'dataset-author-form',
+		'enableAjaxValidation' => false,
+	)); ?>
 
 	<p class="note">Fields with <span class="required">*</span> are required.</p>
 
 	<?php echo $form->errorSummary($model); ?>
 
 	<div class="control-group">
-		<?php echo $form->labelEx($model,'dataset_id',array('class'=>'control-label')); ?>
-				<div class="controls">
-        <?= CHtml::activeDropDownList($model,'dataset_id',CHtml::listData(Util::getDois(),'id','identifier')); ?>
-		<?php echo $form->error($model,'dataset_id'); ?>
-				</div>
+		<?php echo $form->labelEx($model, 'dataset_id', array('class' => 'control-label')); ?>
+		<div class="controls">
+			<?= CHtml::activeDropDownList($model, 'dataset_id', CHtml::listData(Util::getDois(), 'id', 'identifier')); ?>
+			<?php echo $form->error($model, 'dataset_id'); ?>
+		</div>
 	</div>
 
 	<div class="control-group">
-		<?php echo $form->labelEx($model,'author_id',array('class'=>'control-label')); ?>
-				<div class="controls">
-        <?= CHtml::activeDropDownList($model,'author_id',CHtml::listData(Author::model()->findAll(array('order' => 'surname') ),'id','fullAuthor')) ;?>
-		<?php echo $form->error($model,'author_id'); ?>
-				</div>
+		<?php echo $form->labelEx($model, 'author_id', array('class' => 'control-label')); ?>
+		<div class="controls">
+			<?= CHtml::activeDropDownList($model, 'author_id', CHtml::listData(Author::model()->findAll(array('order' => 'surname')), 'id', 'fullAuthor')); ?>
+			<?php echo $form->error($model, 'author_id'); ?>
+		</div>
 	</div>
 
-        <div class="control-group">
-          <?php echo $form->labelEx($model,'rank', array('class'=>'control-label')); ?>
-          <div class="controls">
-            <?= $form->textField($model,'rank') ?>
-            <?php echo $form->error($model,'author_id'); ?>
-          </div>
-        </div>
+	<div class="control-group">
+		<?php echo $form->labelEx($model, 'rank', array('class' => 'control-label')); ?>
+		<div class="controls">
+			<?= $form->textField($model, 'rank') ?>
+			<?php echo $form->error($model, 'author_id'); ?>
+		</div>
+	</div>
 
 	<div class="row buttons">
-        <a href="/adminDatasetAuthor/admin" class="btn">Cancel</a>
-		<?php echo CHtml::submitButton($model->isNewRecord ? 'Create' : 'Save',array('class'=>'btn')); ?>
+		<a href="/adminDatasetAuthor/admin" class="btn background-btn-o">Cancel</a>
+		<?php echo CHtml::submitButton($model->isNewRecord ? 'Create' : 'Save', array('class' => 'btn background-btn')); ?>
 	</div>
 
-<?php $this->endWidget(); ?>
+	<?php $this->endWidget(); ?>
 
 </div><!-- form -->

--- a/protected/views/adminDatasetAuthor/_form.php
+++ b/protected/views/adminDatasetAuthor/_form.php
@@ -1,6 +1,6 @@
 <div class="section form row">
 
-	<div class="col-xs-offset-3 col-xs-6">
+	<div class="col-md-offset-3 col-md-6">
 		<?php $form = $this->beginWidget('CActiveForm', array(
 			'id' => 'dataset-author-form',
 			'enableAjaxValidation' => false,
@@ -8,7 +8,7 @@
 
 		<p class="note">Fields with <span class="required">*</span> are required.</p>
 
-		<?php if ($model->hasErrors()): ?>
+		<?php if ($model->hasErrors()) : ?>
 			<div class="alert alert-danger">
 				<?php echo $form->errorSummary($model); ?>
 			</div>

--- a/protected/views/adminDatasetAuthor/create.php
+++ b/protected/views/adminDatasetAuthor/create.php
@@ -9,9 +9,16 @@
 		array('label'=>'List DatasetAuthor', 'url'=>array('index')),
 		array('label'=>'Manage DatasetAuthor', 'url'=>array('admin')),
 	);
-	?>
 
-	<h1>Create DatasetAuthor</h1>
+	$this->widget('application.components.TitleBreadcrumb', [
+		'pageTitle' => 'Create DatasetAuthor',
+		'breadcrumbItems' => [
+			['label' => 'Dashboard', 'href' => '/site/admin'],
+			['label' => 'Dataset Authors', 'href' => '/adminDatasetAuthor/admin'],
+			['isActive' => true, 'label' => 'Create'],
+		]
+	]);
+	?>
 
 	<?php echo $this->renderPartial('_form', array('model'=>$model)); ?>
 </div>

--- a/protected/views/adminDatasetAuthor/create.php
+++ b/protected/views/adminDatasetAuthor/create.php
@@ -1,15 +1,17 @@
-<?php
-$this->breadcrumbs=array(
-	'Dataset Authors'=>array('index'),
-	'Create',
-);
+<div class="container">
+	<?php
+	$this->breadcrumbs=array(
+		'Dataset Authors'=>array('index'),
+		'Create',
+	);
 
-$this->menu=array(
-	array('label'=>'List DatasetAuthor', 'url'=>array('index')),
-	array('label'=>'Manage DatasetAuthor', 'url'=>array('admin')),
-);
-?>
+	$this->menu=array(
+		array('label'=>'List DatasetAuthor', 'url'=>array('index')),
+		array('label'=>'Manage DatasetAuthor', 'url'=>array('admin')),
+	);
+	?>
 
-<h1>Create DatasetAuthor</h1>
+	<h1>Create DatasetAuthor</h1>
 
-<?php echo $this->renderPartial('_form', array('model'=>$model)); ?>
+	<?php echo $this->renderPartial('_form', array('model'=>$model)); ?>
+</div>

--- a/protected/views/shared/_titleBreadcrumb.php
+++ b/protected/views/shared/_titleBreadcrumb.php
@@ -1,0 +1,8 @@
+<section class="page-title-section">
+    <div class="page-title">
+        <ol class="breadcrumb pull-right">
+            <?= $breadcrumbHtml ?>
+        </ol>
+        <h1 class="h4"><?= $pageTitle ?></h1>
+    </div>
+</section>

--- a/protected/views/site/admin.php
+++ b/protected/views/site/admin.php
@@ -1,162 +1,172 @@
-<h2>Administration Page</h2>
 <div class="clear"></div>
-<div class="row">
-    <div class="span8 offset2">
-        <div class="form well">
-            <table class="admin">
-                <tr>
-                    <td style="vertical-align: top;">
+<div class="container">
+    <?php
+        $this->widget('application.components.TitleBreadcrumb', [
+            'pageTitle' => 'Administration Page',
+            'breadcrumbItems' => [
+                ['isActive' => true, 'label' => 'Admin'],
+            ]
+        ]);
+    ?>
+    <div class="row">
+        <div class="span8 offset2">
+            <div class="form well">
+                <table class="admin">
+                    <tr>
+                        <td style="vertical-align: top;">
 
-                        <div class="form well height1">
+                            <div class="form well height1">
 
-                            <a class="btn-green left2" title="Access all DOIs to update/release" href="/adminDataset/admin">Datasets</a>
+                                <a class="btn-green left2" title="Access all DOIs to update/release" href="/adminDataset/admin">Datasets</a>
 
-                            <div class="clear"></div>
-                            
-                            <a class="btn-green left2" title="Manage authors of datasets" href="/adminDatasetAuthor/admin">Dataset:Authors</a>
+                                <div class="clear"></div>
 
+                                <a class="btn-green left2" title="Manage authors of datasets" href="/adminDatasetAuthor/admin">Dataset:Authors</a>
 
-                            <div class="clear"></div>
 
-                            <a class="btn-green left2" title="Manage sample:DOI associations" href="/adminDatasetSample/admin">Dataset:Samples</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Manage sample:DOI associations" href="/adminDatasetSample/admin">Dataset:Samples</a>
 
-                            <a class="btn-green left2" title="Add/update all Files and manage their attributes" tilte="Add/update all Files and manage their attributes" href="/adminFile/admin">Dataset:Files</a>
+                                <div class="clear"></div>
 
+                                <a class="btn-green left2" title="Add/update all Files and manage their attributes" tilte="Add/update all Files and manage their attributes" href="/adminFile/admin">Dataset:Files</a>
 
-                            <div class="clear"></div>
 
-                            <a class="btn-green left2" title="Manage links from datasets to external project pages" href="/adminDatasetProject/admin">Dataset:Project links</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Manage links from datasets to external project pages" href="/adminDatasetProject/admin">Dataset:Project links</a>
 
+                                <div class="clear"></div>
 
-                            <a class="btn-green left2" title="List of external accessions for all DOIs" href="/adminLink/admin">Dataset:Links</a>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="List of external accessions for all DOIs" href="/adminLink/admin">Dataset:Links</a>
 
-                            <a class="btn-green left2" title="Manage DOI:DOI relationships" href="/adminRelation/admin">Dataset:Relations</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Manage DOI:DOI relationships" href="/adminRelation/admin">Dataset:Relations</a>
 
-                            <a class="btn-green left2" title="Manage DOI:Funder" href="/datasetFunder/admin">Dataset:Funder</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Manage DOI:Funder" href="/datasetFunder/admin">Dataset:Funder</a>
 
-                            <a class="btn-green left2" href="/adminManuscript/admin"  title="Add/update links to manuscriptions citing our DOIs" tilte="Add/update links to manuscriptions citing our DOIs" >Dataset:Manuscript</a>
+                                <div class="clear"></div>
 
-                            <!--
-                            <div class="clear"></div>
+                                <a class="btn-green left2" href="/adminManuscript/admin"  title="Add/update links to manuscriptions citing our DOIs" tilte="Add/update links to manuscriptions citing our DOIs" >Dataset:Manuscript</a>
 
-                            <a class="btn-green left2" title="Fairly use policy" href="/policy/create">Fairly Use Policy</a> -->
+                                <!--
+                                <div class="clear"></div>
 
+                                <a class="btn-green left2" title="Fairly use policy" href="/policy/create">Fairly Use Policy</a> -->
 
-                            <div class="clear"></div>
 
+                                <div class="clear"></div>
 
 
-<!--                            <a class="btn-green left2" title="Manualy create a new dataset via web-form" href="/adminDataset/create">Create Dataset</a>
 
--->
+    <!--                            <a class="btn-green left2" title="Manualy create a new dataset via web-form" href="/adminDataset/create">Create Dataset</a>
 
+    -->
 
 
-                        </div>
 
-                    </td>
-                    <td style="vertical-align: top;">
-                        <div class="form well height1">
+                            </div>
 
-                            <a class="btn-green left2" title=" List all authors cited in GigaDB, update ORCID for authors" href="/adminAuthor/admin">Authors</a>
+                        </td>
+                        <td style="vertical-align: top;">
+                            <div class="form well height1">
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title=" List all authors cited in GigaDB, update ORCID for authors" href="/adminAuthor/admin">Authors</a>
 
-                            <a class="btn-green left2" title="Access all Samples list and update sample details" href="/adminSample/admin">Samples</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Access all Samples list and update sample details" href="/adminSample/admin">Samples</a>
 
-                            <a class="btn-green left2" title="Add/update all Species and manage their attributes" href="/adminSpecies/admin">Species</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Add/update all Species and manage their attributes" href="/adminSpecies/admin">Species</a>
 
-                            <a class="btn-green left2" title="Add/update list of external projects linked to from datasets" href="/adminProject/admin">Projects</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Add/update list of external projects linked to from datasets" href="/adminProject/admin">Projects</a>
 
-                            <a class="btn-green left2" title="Add/update links to genome browsers and related links" href="/adminExternalLink/admin">External Links</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Add/update links to genome browsers and related links" href="/adminExternalLink/admin">External Links</a>
 
-                            <a class="btn-green left2" title="Add/update prefixes of links supported by GigaDB" href="/adminLinkPrefix/admin">Link Prefixes</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Add/update prefixes of links supported by GigaDB" href="/adminLinkPrefix/admin">Link Prefixes</a>
 
-                            <a class="btn-green left2" title="Add/update funder" href="/funder/admin">Funder</a>
-                            <div class="clear"></div>
+                                <div class="clear"></div>
 
-                            <a class="btn-green left2" title="Add/update attribute" href="/attribute/admin">Attribute</a>
+                                <a class="btn-green left2" title="Add/update funder" href="/funder/admin">Funder</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Add/update attribute" href="/attribute/admin">Attribute</a>
 
-                            <a class="btn-green left2" title="Add/update list of logs" href="/report/index">Google Analytics</a>
-                        </div>
+                                <div class="clear"></div>
 
-                    </td>
-                    <td style="vertical-align: top;">
+                                <a class="btn-green left2" title="Add/update list of logs" href="/report/index">Google Analytics</a>
+                            </div>
 
+                        </td>
+                        <td style="vertical-align: top;">
 
-                        <div class="form well height1">
 
-                            <a class="btn-green left2" title="Add/update types of datasets supported by GigaDB" href="/adminDatasetType/admin">Dataset Types</a>
+                            <div class="form well height1">
 
+                                <a class="btn-green left2" title="Add/update types of datasets supported by GigaDB" href="/adminDatasetType/admin">Dataset Types</a>
 
-                            <div class="clear"></div>
 
+                                <div class="clear"></div>
 
-                            <a class="btn-green left2" title="Add/update types of files supported by GigaDB" href="/adminFileType/admin">Data Types</a>
 
+                                <a class="btn-green left2" title="Add/update types of files supported by GigaDB" href="/adminFileType/admin">Data Types</a>
 
-                            <div class="clear"></div>
 
+                                <div class="clear"></div>
 
 
 
-                            <a class="btn-green left2" title="Add/update formats of files supported by GigaDB" href="/adminFileFormat/admin">File Formats</a>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Add/update formats of files supported by GigaDB" href="/adminFileFormat/admin">File Formats</a>
 
+                                <div class="clear"></div>
 
 
-                            <a class="btn-green left2" title="Manage GigaDB user accounts" href="/user/admin">Users</a>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Manage GigaDB user accounts" href="/user/admin">Users</a>
 
-                            <a class="btn-green left2" title="Newsletter Subscribers" href="/user/newsletter">Newsletter Subscribers</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Newsletter Subscribers" href="/user/newsletter">Newsletter Subscribers</a>
 
+                                <div class="clear"></div>
 
-                            <a class="btn-green left2" title="Manage GigaDB news items to show on home page" href="/news/admin" >News Items</a>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Manage GigaDB news items to show on home page" href="/news/admin" >News Items</a>
 
+                                <div class="clear"></div>
 
 
 
-                            <a class="btn-green left2" title="manage RSS feed items" href="/rssMessage/admin">RSS Messages</a>
 
-                            <div class="clear"></div>
-                            <a class="btn-green left2" title="Add/update list of publishers" href="/adminPublisher/admin">Publishers</a>
+                                <a class="btn-green left2" title="manage RSS feed items" href="/rssMessage/admin">RSS Messages</a>
 
-                            <div class="clear"></div>
-                            <a class="btn-green left2" title="Add/update list of logs" href="/datasetLog/admin">Update Logs</a>
+                                <div class="clear"></div>
+                                <a class="btn-green left2" title="Add/update list of publishers" href="/adminPublisher/admin">Publishers</a>
 
-                        </div>
-                    </td>
-                </tr>
-            </table>
+                                <div class="clear"></div>
+                                <a class="btn-green left2" title="Add/update list of logs" href="/datasetLog/admin">Update Logs</a>
 
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+
+            </div>
         </div>
     </div>
+
 </div>


### PR DESCRIPTION
# Pull request for issue: #1482

This is a pull request for the following functionalities:

* Create DatasetAuthor page (http://gigadb.gigasciencejournal.com:9170/adminDatasetAuthor/create) updated to more modern look

Before:

![image](https://github.com/gigascience/gigadb-website/assets/143437854/84b557ed-68e4-4efa-81c3-753e512c0570)

After:

![image](https://github.com/gigascience/gigadb-website/assets/143437854/e457580b-b655-4e75-93b0-e70d9ecb5ca4)

Focus style:

![image](https://github.com/gigascience/gigadb-website/assets/143437854/5f1709f7-01f5-4c3d-b25a-87f21ed4c2f4)

Alt focus state:

![image](https://github.com/gigascience/gigadb-website/assets/143437854/aaf27e5b-58cf-4adf-838e-2afd030881f7)


## How to test?

* Navigate to http://gigadb.gigasciencejournal.com:9170/adminDatasetAuthor/create and review page appearance and form appearance
* Confirm that php input components follow good practices / suggest any changes that might help adhere to best practices common to php / yii projects
* Optional: provide feedback on styles

## How have functionalities been implemented?

* Replaced old layout by modern layout
* Created reusable input components that have accessibility features built in
* Updated form-group styles and incorporated them in the reusable inputs
* wrapped form in row + col to make it narrower

## Any issues with implementation?

None

## Any changes to automated tests?

None

## Any changes to documentation?

None

## Any technical debt repayment?

None

## Any improvements to CI/CD pipeline?

None