### PR TITLE
Admin styles - Manage Dataset Samples page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1485: Admin styles - Update styles of Manage Dataset Samples page
 - Feat #1374: Improve accessibility and use of semantic html of search results card
-
 - Fix #1449: Fix issue preventing deployment to live production environment bastion server
 - Fix #1102: Display error message when creating a sample object or updating an existing sample object with attribute not found in attribute table, and do not create/save it. Refactored container scanning jobs in gitlab pipeline.
 - Feat #1376: Fix heading hierarchy in Contact Page, wrap address in `<address>` element

--- a/less/current/modules/pagination.less
+++ b/less/current/modules/pagination.less
@@ -45,3 +45,26 @@
   box-shadow: none;
   border-color: @color-medium-gray;
 }
+
+// Yii pagination restyled to look similar to custom pagination
+.pagination {
+  & > li {
+    height: 34px;
+    display: inline-block;
+    &.page.selected > a {
+      background-color: @color-lighter-gray;
+      color: @color-warm-black;
+      border-color: @color-light-gray;
+      cursor: default;
+    }
+  }
+}
+// Workaround for round border on first visible item
+.pagination > li > a.first-visible {
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+.pagination > li > a.last-visible {
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+}

--- a/protected/components/Controller.php
+++ b/protected/components/Controller.php
@@ -33,6 +33,8 @@ class Controller extends CController
             'redirect' => false,
         );
 
+    public $loadBaBbqPolyfills = false;
+
     /*
      * An Admin has role == 'admin', that stored in the user obj
      *

--- a/protected/components/CustomGridView.php
+++ b/protected/components/CustomGridView.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * CustomGridView Class
+ *
+ * Extends CGridView to add custom pagination styles by using bootstrap classes.
+ *
+ * Example usage:
+ * ```php
+ * $this->widget('CustomGridView', array(
+ *   'dataProvider' => $dataProvider,
+ *   // other options here...
+ * ));
+ * ```
+ *
+ * Note: This class assumes jQuery is loaded. It uses AJAX to refresh the pagination state.
+ */
+
+
+Yii::import('zii.widgets.grid.CGridView');
+
+class CustomGridView extends CGridView {
+
+    public function init() {
+        $this->pager = array_merge(
+            $this->pager,
+            array(
+                'header' => '',
+                'htmlOptions' => array('class' => 'pagination'),
+            )
+        );
+
+        $this->pagerCssClass = 'pagination-container';
+
+        parent::init();
+
+        Yii::app()->clientScript->registerScript('pagination-adjustment', '
+          if (typeof jQuery !== "undefined") {
+            function adjustPagination() {
+              $(".pagination > li > a").removeClass("first-visible");
+              $(".pagination > li > a").removeClass("last-visible");
+              $(".pagination > li:not(.hidden)").first().children("a").addClass("first-visible");
+              $(".pagination > li:not(.hidden)").last().children("a").addClass("last-visible");
+            }
+
+            adjustPagination();
+
+            // run every time pagination triggers
+            $(document).ajaxComplete(function() {
+              adjustPagination();
+            });
+          }
+        ', CClientScript::POS_END);
+    }
+}

--- a/protected/components/TitleBreadcrumb.php
+++ b/protected/components/TitleBreadcrumb.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * TitleBreadcrumb Widget
+ *
+ * This component is used to render a breadcrumb and a page title.
+ *
+ * Usage Example:
+ *
+ * ```php
+ * $this->widget('application.components.TitleBreadcrumb', [
+ *     'pageTitle' => 'Your Page Title',
+ *     'breadcrumbItems' => [
+ *         ['isActive' => true, 'label' => 'Admin'],
+ *         ['label' => 'Dashboard', 'href' => '/dashboard']
+ *         // Add more items as needed
+ *     ]
+ * ]);
+ * ```
+ *
+ * `pageTitle`: string
+ * The main title displayed on the page. Required.
+ *
+ * `breadcrumbItems`: array
+ * An array of breadcrumb items. Each item is an associative array with keys:
+ * - `isActive`: bool, optional. Whether the breadcrumb item is active. Will NOT render a link if true.
+ * - `label`: string, required. The display text of the breadcrumb item.
+ * - `href`: string, optional. The URL / pathname for the breadcrumb item.
+ */
+
+
+/**
+ * Class TitleBreadcrumb
+ * Renders a breadcrumb and a page title.
+ */
+class TitleBreadcrumb extends CWidget
+{
+  public $pageTitle;
+  public $breadcrumbItems = [];
+  const ACTIVE_CLASS = 'active';
+
+  private function generateBreadcrumbItems(): string
+  {
+    return implode("\n", array_map(function ($item) {
+      $isActive = $item['isActive'] ?? false;
+      $label = $item['label'];
+      $href = $item['href'] ?? '#';
+
+      if ($isActive) {
+        return CHtml::tag('li', ['class' => self::ACTIVE_CLASS], $label);
+      }
+
+      return CHtml::tag('li', [], CHtml::link($label, $href));
+    }, $this->breadcrumbItems));
+  }
+
+  public function run()
+  {
+    if (empty($this->pageTitle)) {
+      throw new CException('pageTitle must be set.');
+    }
+
+    $breadcrumbHtml = $this->generateBreadcrumbItems();
+
+    Yii::app()->controller->renderPartial('//shared/_titleBreadcrumb', [
+      'pageTitle' => $this->pageTitle,
+      'breadcrumbHtml' => $breadcrumbHtml
+    ]);
+  }
+}

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -143,7 +143,7 @@ class AdminDatasetController extends Controller
     public function actionAdmin()
     {
 
-        $criteria=new CDbCriteria(array(                    
+        $criteria=new CDbCriteria(array(
             'order'=>'identifier asc',
         ));
 
@@ -189,8 +189,8 @@ class AdminDatasetController extends Controller
             "dryRunMode"=>false,
             ]);
         $datasetUpload = new DatasetUpload(
-            $fileUploadSrv->dataset, 
-            $fileUploadSrv, 
+            $fileUploadSrv->dataset,
+            $fileUploadSrv,
             Yii::$app->params['dataset_upload']
         );
 
@@ -218,7 +218,7 @@ class AdminDatasetController extends Controller
                         );
                         break;
                     default:
-                        $statusIsSet = true;                    
+                        $statusIsSet = true;
                 }
                 if ($statusIsSet) {
                     CurationLog::createlog($_POST['Dataset']['upload_status'], $id);

--- a/protected/controllers/AdminDatasetSampleController.php
+++ b/protected/controllers/AdminDatasetSampleController.php
@@ -348,6 +348,7 @@ class AdminDatasetSampleController extends Controller
 		if(isset($_GET['DatasetSample']))
 			$model->setAttributes($_GET['DatasetSample']);
 
+        $this->loadBaBbqPolyfills = true;
         $this->layout = '//layouts/new_column2';
 		$this->render('admin',array(
 			'model'=>$model,

--- a/protected/controllers/AdminDatasetSampleController.php
+++ b/protected/controllers/AdminDatasetSampleController.php
@@ -46,7 +46,7 @@ class AdminDatasetSampleController extends Controller
 	public function actionView($id)
 	{
             $model=$this->loadModel($id);
-            
+
             $this->render('view',array(
 			'model'=>$model,
 		));
@@ -124,7 +124,7 @@ class AdminDatasetSampleController extends Controller
             }
             //-1 means it doesn't exit in our database
             if ($model->tax_id != -1) {
-                
+
                 $species = Species::model()->findByAttributes(array('tax_id' => $tax_id));
                  $species_id = $species->id;
             } else {
@@ -138,14 +138,14 @@ class AdminDatasetSampleController extends Controller
                     else {
                         //insert a new species record
                         $model->addError('comment', 'The species you input is not in our database, please
-                            input 0:new organism and contact 
+                            input 0:new organism and contact
                         <a href=&quot;mailto:database@gigasciencejournal.com&quot;>database@gigasciencejournal.com</a>.');
                        //ac $model = new DatasetSample;
                         return false;
                     }
                 }
             }
-            //2) insert sample 
+            //2) insert sample
             $sample = new Sample;
             $sample->species_id = $species_id;
             $sample->code = $model->code;
@@ -156,13 +156,13 @@ class AdminDatasetSampleController extends Controller
                 return false;
             }
             $sample_id = $sample->id;
-           
 
-            //3) insert dataset_sample 
+
+            //3) insert dataset_sample
 
             $model->sample_id = $sample_id;
             $model->dataset_id = $dataset_id;
-            
+
             if (!$model->save()) {
                 $model->addError('keyword', 'Dataset_Sample is not stored!');
                 return false;
@@ -185,7 +185,7 @@ class AdminDatasetSampleController extends Controller
         $model = new DatasetSample;
         $model->dataset_id = 1;
         //$model->
-        //update 
+        //update
         if (!isset($_SESSION['samples']))
             $_SESSION['samples'] = array();
 
@@ -217,7 +217,7 @@ class AdminDatasetSampleController extends Controller
           //  var_dump( $model->code, $model->attribute);
 
             $id = 0;
-            
+
             if(strpos($name,'SAMPLE') == 0)
             {
                 $attribute_temp=null;
@@ -227,8 +227,8 @@ class AdminDatasetSampleController extends Controller
                 if($temp[0]=='SAMPLE')
                 {
                     $xmlpath=  'http://www.ebi.ac.uk/ena/data/view/'."$temp[1]".'&display=xml';
-                    $allfile= simplexml_load_file($xmlpath);                 
-                    
+                    $allfile= simplexml_load_file($xmlpath);
+
                    foreach ($allfile->SAMPLE->SAMPLE_ATTRIBUTES->SAMPLE_ATTRIBUTE as $child)
                 {
                     if($child->TAG=='Sample type'||$child->TAG=='Time of sample collection'||$child->TAG=='Habitat'||$child->TAG=='Sample extracted from')
@@ -246,19 +246,19 @@ class AdminDatasetSampleController extends Controller
                             $species1.=$child->VALUE.",";
                         if($child->TAG=='COMMON_NAME')
                             $species1.=$child->VALUE;
-                           
+
                     }
-                   
-                      
+
+
                 }
                      $attrs=$attribute_temp;
                     // $species=$species1;
                      $model->attribute = $attrs;
                     // $model->tax_id=$tax_id1;
-                     
-               
+
+
             }
-         
+
 
             if ($this->storeSample($model, $id)) {
 
@@ -348,6 +348,7 @@ class AdminDatasetSampleController extends Controller
 		if(isset($_GET['DatasetSample']))
 			$model->setAttributes($_GET['DatasetSample']);
 
+        $this->layout = '//layouts/new_column2';
 		$this->render('admin',array(
 			'model'=>$model,
 		));
@@ -457,7 +458,7 @@ class AdminDatasetSampleController extends Controller
         }
 
         public function actionAddSampleAttr() {
-            if(isset($_POST['sample_id']) && isset($_POST['attr_id']) 
+            if(isset($_POST['sample_id']) && isset($_POST['attr_id'])
                 && isset($_POST['attr_value']) && isset($_POST['attr_unit'])) {
 
                 if(strlen($_POST['attr_id']) < 3) {
@@ -530,7 +531,7 @@ class AdminDatasetSampleController extends Controller
                 $criteria = new CDbCriteria;
                 $criteria->addSearchCondition('attribute_name', $_GET['term']);
                 $attrs = Attribute::model()->findAll($criteria);
-                
+
                 foreach($attrs as $attr) {
                     $result[$attr->attribute_name] = $attr->attribute_name;
                 }

--- a/protected/controllers/SiteController.php
+++ b/protected/controllers/SiteController.php
@@ -67,6 +67,7 @@ class SiteController extends Controller {
 	**/
 
 	public function actionAdmin() {
+        $this->layout='new_main';
 		$this->render('admin');
 	}
 

--- a/protected/views/adminDatasetSample/admin.php
+++ b/protected/views/adminDatasetSample/admin.php
@@ -1,34 +1,37 @@
-<h1>Manage Dataset - Samples</h1>
+<div class="container">
+	<h1>Manage Dataset - Samples</h1>
 
-<a href="/adminDatasetSample/create" class="btn">Add a Sample to a Dataset</a>
+	<a href="/adminDatasetSample/create" class="btn">Add a Sample to a Dataset</a>
 
-<?php $this->widget('zii.widgets.grid.CGridView', array(
-	'id'=>'dataset-sample-grid',
-	'ajaxUpdate' => false,
-	'dataProvider'=>$model->search(),
-	'itemsCssClass'=>'table table-bordered',
-	'filter'=>$model,
-	'columns'=>array(
-		array('name'=> 'doi_search', 'value'=>'$data->dataset->identifier'),
-		'sample_id',
-		array('name'=> 'sample_name', 'value'=>'$data->sample->name'),
-		array('header'=> 'Sample Attributes','type'=>'raw' ,'value'=>'FormattedDatasetSamples::getDisplayAttr($data->sample->id,$data->sample->getSampleAttributeArrayMap())'),
-		array(
-			'class'=>'CButtonColumn',
+	<?php $this->widget('zii.widgets.grid.CGridView', array(
+		'id'=>'dataset-sample-grid',
+		'ajaxUpdate' => false,
+		'dataProvider'=>$model->search(),
+		'itemsCssClass'=>'table table-bordered',
+		'filter'=>$model,
+		'columns'=>array(
+			array('name'=> 'doi_search', 'value'=>'$data->dataset->identifier'),
+			'sample_id',
+			array('name'=> 'sample_name', 'value'=>'$data->sample->name'),
+			array('header'=> 'Sample Attributes','type'=>'raw' ,'value'=>'FormattedDatasetSamples::getDisplayAttr($data->sample->id,$data->sample->getSampleAttributeArrayMap())'),
+			array(
+				'class'=>'CButtonColumn',
+			),
 		),
-	),
-)); ?>
+	)); ?>
 
-<?php
-$clientScript = Yii::app()->clientScript;
-$register_script = <<<EO_SCRIPT
-    jQuery(".js-desc").click(function(e) {
-        e.preventDefault();
-        id = $(this).attr('data');
-        jQuery(this).hide();
-        jQuery('.js-short-'+id).toggle();
-        jQuery('.js-long-'+id).toggle();
-    })
-EO_SCRIPT;
-$clientScript->registerScript('register_script', $register_script, CClientScript::POS_READY);
-?>
+	<?php
+	$clientScript = Yii::app()->clientScript;
+	$register_script = <<<EO_SCRIPT
+			jQuery(".js-desc").click(function(e) {
+					e.preventDefault();
+					id = $(this).attr('data');
+					jQuery(this).hide();
+					jQuery('.js-short-'+id).toggle();
+					jQuery('.js-long-'+id).toggle();
+			})
+	EO_SCRIPT;
+	$clientScript->registerScript('register_script', $register_script, CClientScript::POS_READY);
+	?>
+
+</div>

--- a/protected/views/adminDatasetSample/admin.php
+++ b/protected/views/adminDatasetSample/admin.php
@@ -11,7 +11,7 @@
 
 	<a href="/adminDatasetSample/create" class="btn">Add a Sample to a Dataset</a>
 
-	<?php $this->widget('zii.widgets.grid.CGridView', array(
+	<?php $this->widget('CustomGridView', array(
 		'id' => 'dataset-sample-grid',
 		'ajaxUpdate' => false,
 		'dataProvider' => $model->search(),

--- a/protected/views/adminDatasetSample/admin.php
+++ b/protected/views/adminDatasetSample/admin.php
@@ -1,21 +1,29 @@
 <div class="container">
-	<h1>Manage Dataset - Samples</h1>
+	<?php
+	$this->widget('application.components.TitleBreadcrumb', [
+		'pageTitle' => 'Manage Dataset - Samples',
+		'breadcrumbItems' => [
+			['label' => 'Admin', 'href' => '/site/admin'],
+			['isActive' => true, 'label' => 'Dataset Samples'],
+		]
+	]);
+	?>
 
 	<a href="/adminDatasetSample/create" class="btn">Add a Sample to a Dataset</a>
 
 	<?php $this->widget('zii.widgets.grid.CGridView', array(
-		'id'=>'dataset-sample-grid',
+		'id' => 'dataset-sample-grid',
 		'ajaxUpdate' => false,
-		'dataProvider'=>$model->search(),
-		'itemsCssClass'=>'table table-bordered',
-		'filter'=>$model,
-		'columns'=>array(
-			array('name'=> 'doi_search', 'value'=>'$data->dataset->identifier'),
+		'dataProvider' => $model->search(),
+		'itemsCssClass' => 'table table-bordered',
+		'filter' => $model,
+		'columns' => array(
+			array('name' => 'doi_search', 'value' => '$data->dataset->identifier'),
 			'sample_id',
-			array('name'=> 'sample_name', 'value'=>'$data->sample->name'),
-			array('header'=> 'Sample Attributes','type'=>'raw' ,'value'=>'FormattedDatasetSamples::getDisplayAttr($data->sample->id,$data->sample->getSampleAttributeArrayMap())'),
+			array('name' => 'sample_name', 'value' => '$data->sample->name'),
+			array('header' => 'Sample Attributes', 'type' => 'raw', 'value' => 'FormattedDatasetSamples::getDisplayAttr($data->sample->id,$data->sample->getSampleAttributeArrayMap())'),
 			array(
-				'class'=>'CButtonColumn',
+				'class' => 'CButtonColumn',
 			),
 		),
 	)); ?>

--- a/protected/views/adminDatasetSample/admin.php
+++ b/protected/views/adminDatasetSample/admin.php
@@ -1,6 +1,6 @@
 <div class="container">
 	<?php
-	$this->widget('application.components.TitleBreadcrumb', [
+	$this->widget('TitleBreadcrumb', [
 		'pageTitle' => 'Manage Dataset - Samples',
 		'breadcrumbItems' => [
 			['label' => 'Admin', 'href' => '/site/admin'],
@@ -9,7 +9,11 @@
 	]);
 	?>
 
-	<a href="/adminDatasetSample/create" class="btn">Add a Sample to a Dataset</a>
+	<a href="/adminDatasetSample/create" class="btn background-btn">Add a Sample to a Dataset</a>
+
+	<div class="sr-only">
+		Column headers with links are sortable. Cells with a text input are used for filtering.
+	</div>
 
 	<?php $this->widget('CustomGridView', array(
 		'id' => 'dataset-sample-grid',
@@ -23,7 +27,9 @@
 			array('name' => 'sample_name', 'value' => '$data->sample->name'),
 			array('header' => 'Sample Attributes', 'type' => 'raw', 'value' => 'FormattedDatasetSamples::getDisplayAttr($data->sample->id,$data->sample->getSampleAttributeArrayMap())'),
 			array(
-				'class' => 'CButtonColumn',
+				'header'=>'Actions',
+				'class'=>'CButtonColumn',
+				'htmlOptions'=>array('width'=>'75')
 			),
 		),
 	)); ?>

--- a/protected/views/layouts/new_datasetpage.php
+++ b/protected/views/layouts/new_datasetpage.php
@@ -35,6 +35,77 @@
                 <link rel="stylesheet" type="text/css" href="/css/current.css" />
                 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
                 <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" defer></script>
+                <?php if (isset($this->loadBaBbqPolyfills) && $this->loadBaBbqPolyfills) { ?>
+                    <!-- Polyfills needed for 3.6.0/jquery.min.js and jquery.ba-bbq.min.js compatibility -->
+                    <script src="https://code.jquery.com/jquery-migrate-3.3.2.min.js"></script>
+                    <script>
+
+// Limit scope pollution from any deprecated API
+(function() {
+
+var matched, browser;
+
+// Use of jQuery.browser is frowned upon.
+// More details: http://api.jquery.com/jQuery.browser
+// jQuery.uaMatch maintained for back-compat
+jQuery.uaMatch = function( ua ) {
+    ua = ua.toLowerCase();
+
+    var match = /(chrome)[ \/]([\w.]+)/.exec( ua ) ||
+        /(webkit)[ \/]([\w.]+)/.exec( ua ) ||
+        /(opera)(?:.*version|)[ \/]([\w.]+)/.exec( ua ) ||
+        /(msie) ([\w.]+)/.exec( ua ) ||
+        ua.indexOf("compatible") < 0 && /(mozilla)(?:.*? rv:([\w.]+)|)/.exec( ua ) ||
+        [];
+
+    return {
+        browser: match[ 1 ] || "",
+        version: match[ 2 ] || "0"
+    };
+};
+
+matched = jQuery.uaMatch( navigator.userAgent );
+browser = {};
+
+if ( matched.browser ) {
+    browser[ matched.browser ] = true;
+    browser.version = matched.version;
+}
+
+// Chrome is Webkit, but Webkit is also Safari.
+if ( browser.chrome ) {
+    browser.webkit = true;
+} else if ( browser.webkit ) {
+    browser.safari = true;
+}
+
+jQuery.browser = browser;
+
+jQuery.sub = function() {
+    function jQuerySub( selector, context ) {
+        return new jQuerySub.fn.init( selector, context );
+    }
+    jQuery.extend( true, jQuerySub, this );
+    jQuerySub.superclass = this;
+    jQuerySub.fn = jQuerySub.prototype = this();
+    jQuerySub.fn.constructor = jQuerySub;
+    jQuerySub.sub = this.sub;
+    jQuerySub.fn.init = function init( selector, context ) {
+        if ( context && context instanceof jQuery && !(context instanceof jQuerySub) ) {
+            context = jQuerySub( context );
+        }
+
+        return jQuery.fn.init.call( this, selector, context, rootjQuerySub );
+    };
+    jQuerySub.fn.init.prototype = jQuerySub.fn;
+    var rootjQuerySub = jQuerySub(document);
+    return jQuerySub;
+};
+
+})();
+                    </script>
+                    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.ba-bbq/1.2.1/jquery.ba-bbq.min.js" defer></script>
+                <?php } ?>
                 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" defer></script>
                 <script type="text/javascript" src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js" defer></script>
                 <script type="text/javascript" src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap.min.js" defer></script>

--- a/protected/views/layouts/new_main.php
+++ b/protected/views/layouts/new_main.php
@@ -27,6 +27,77 @@
                 <link rel="stylesheet" type="text/css" href="/css/current.css" />
                 <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.js" defer></script>
                 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+                <?php if (isset($this->loadBaBbqPolyfills) && $this->loadBaBbqPolyfills) { ?>
+                    <!-- Polyfills needed for 3.6.0/jquery.min.js and jquery.ba-bbq.min.js compatibility -->
+                    <script src="https://code.jquery.com/jquery-migrate-3.3.2.min.js"></script>
+                    <script>
+
+// Limit scope pollution from any deprecated API
+(function() {
+
+var matched, browser;
+
+// Use of jQuery.browser is frowned upon.
+// More details: http://api.jquery.com/jQuery.browser
+// jQuery.uaMatch maintained for back-compat
+jQuery.uaMatch = function( ua ) {
+    ua = ua.toLowerCase();
+
+    var match = /(chrome)[ \/]([\w.]+)/.exec( ua ) ||
+        /(webkit)[ \/]([\w.]+)/.exec( ua ) ||
+        /(opera)(?:.*version|)[ \/]([\w.]+)/.exec( ua ) ||
+        /(msie) ([\w.]+)/.exec( ua ) ||
+        ua.indexOf("compatible") < 0 && /(mozilla)(?:.*? rv:([\w.]+)|)/.exec( ua ) ||
+        [];
+
+    return {
+        browser: match[ 1 ] || "",
+        version: match[ 2 ] || "0"
+    };
+};
+
+matched = jQuery.uaMatch( navigator.userAgent );
+browser = {};
+
+if ( matched.browser ) {
+    browser[ matched.browser ] = true;
+    browser.version = matched.version;
+}
+
+// Chrome is Webkit, but Webkit is also Safari.
+if ( browser.chrome ) {
+    browser.webkit = true;
+} else if ( browser.webkit ) {
+    browser.safari = true;
+}
+
+jQuery.browser = browser;
+
+jQuery.sub = function() {
+    function jQuerySub( selector, context ) {
+        return new jQuerySub.fn.init( selector, context );
+    }
+    jQuery.extend( true, jQuerySub, this );
+    jQuerySub.superclass = this;
+    jQuerySub.fn = jQuerySub.prototype = this();
+    jQuerySub.fn.constructor = jQuerySub;
+    jQuerySub.sub = this.sub;
+    jQuerySub.fn.init = function init( selector, context ) {
+        if ( context && context instanceof jQuery && !(context instanceof jQuerySub) ) {
+            context = jQuerySub( context );
+        }
+
+        return jQuery.fn.init.call( this, selector, context, rootjQuerySub );
+    };
+    jQuerySub.fn.init.prototype = jQuerySub.fn;
+    var rootjQuerySub = jQuerySub(document);
+    return jQuerySub;
+};
+
+})();
+                    </script>
+                    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.ba-bbq/1.2.1/jquery.ba-bbq.min.js" defer></script>
+                <?php } ?>
                 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" defer></script>
                 <? } ?>
                     <title>

--- a/protected/views/shared/_titleBreadcrumb.php
+++ b/protected/views/shared/_titleBreadcrumb.php
@@ -1,0 +1,8 @@
+<section class="page-title-section">
+    <div class="page-title">
+        <ol class="breadcrumb pull-right">
+            <?= $breadcrumbHtml ?>
+        </ol>
+        <h1 class="h4"><?= $pageTitle ?></h1>
+    </div>
+</section>

--- a/protected/views/site/admin.php
+++ b/protected/views/site/admin.php
@@ -1,162 +1,172 @@
-<h2>Administration Page</h2>
 <div class="clear"></div>
-<div class="row">
-    <div class="span8 offset2">
-        <div class="form well">
-            <table class="admin">
-                <tr>
-                    <td style="vertical-align: top;">
+<div class="container">
+    <?php
+        $this->widget('application.components.TitleBreadcrumb', [
+            'pageTitle' => 'Administration Page',
+            'breadcrumbItems' => [
+                ['isActive' => true, 'label' => 'Admin'],
+            ]
+        ]);
+    ?>
+    <div class="row">
+        <div class="span8 offset2">
+            <div class="form well">
+                <table class="admin">
+                    <tr>
+                        <td style="vertical-align: top;">
 
-                        <div class="form well height1">
+                            <div class="form well height1">
 
-                            <a class="btn-green left2" title="Access all DOIs to update/release" href="/adminDataset/admin">Datasets</a>
+                                <a class="btn-green left2" title="Access all DOIs to update/release" href="/adminDataset/admin">Datasets</a>
 
-                            <div class="clear"></div>
-                            
-                            <a class="btn-green left2" title="Manage authors of datasets" href="/adminDatasetAuthor/admin">Dataset:Authors</a>
+                                <div class="clear"></div>
 
+                                <a class="btn-green left2" title="Manage authors of datasets" href="/adminDatasetAuthor/admin">Dataset:Authors</a>
 
-                            <div class="clear"></div>
 
-                            <a class="btn-green left2" title="Manage sample:DOI associations" href="/adminDatasetSample/admin">Dataset:Samples</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Manage sample:DOI associations" href="/adminDatasetSample/admin">Dataset:Samples</a>
 
-                            <a class="btn-green left2" title="Add/update all Files and manage their attributes" tilte="Add/update all Files and manage their attributes" href="/adminFile/admin">Dataset:Files</a>
+                                <div class="clear"></div>
 
+                                <a class="btn-green left2" title="Add/update all Files and manage their attributes" tilte="Add/update all Files and manage their attributes" href="/adminFile/admin">Dataset:Files</a>
 
-                            <div class="clear"></div>
 
-                            <a class="btn-green left2" title="Manage links from datasets to external project pages" href="/adminDatasetProject/admin">Dataset:Project links</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Manage links from datasets to external project pages" href="/adminDatasetProject/admin">Dataset:Project links</a>
 
+                                <div class="clear"></div>
 
-                            <a class="btn-green left2" title="List of external accessions for all DOIs" href="/adminLink/admin">Dataset:Links</a>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="List of external accessions for all DOIs" href="/adminLink/admin">Dataset:Links</a>
 
-                            <a class="btn-green left2" title="Manage DOI:DOI relationships" href="/adminRelation/admin">Dataset:Relations</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Manage DOI:DOI relationships" href="/adminRelation/admin">Dataset:Relations</a>
 
-                            <a class="btn-green left2" title="Manage DOI:Funder" href="/datasetFunder/admin">Dataset:Funder</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Manage DOI:Funder" href="/datasetFunder/admin">Dataset:Funder</a>
 
-                            <a class="btn-green left2" href="/adminManuscript/admin"  title="Add/update links to manuscriptions citing our DOIs" tilte="Add/update links to manuscriptions citing our DOIs" >Dataset:Manuscript</a>
+                                <div class="clear"></div>
 
-                            <!--
-                            <div class="clear"></div>
+                                <a class="btn-green left2" href="/adminManuscript/admin"  title="Add/update links to manuscriptions citing our DOIs" tilte="Add/update links to manuscriptions citing our DOIs" >Dataset:Manuscript</a>
 
-                            <a class="btn-green left2" title="Fairly use policy" href="/policy/create">Fairly Use Policy</a> -->
+                                <!--
+                                <div class="clear"></div>
 
+                                <a class="btn-green left2" title="Fairly use policy" href="/policy/create">Fairly Use Policy</a> -->
 
-                            <div class="clear"></div>
 
+                                <div class="clear"></div>
 
 
-<!--                            <a class="btn-green left2" title="Manualy create a new dataset via web-form" href="/adminDataset/create">Create Dataset</a>
 
--->
+    <!--                            <a class="btn-green left2" title="Manualy create a new dataset via web-form" href="/adminDataset/create">Create Dataset</a>
 
+    -->
 
 
-                        </div>
 
-                    </td>
-                    <td style="vertical-align: top;">
-                        <div class="form well height1">
+                            </div>
 
-                            <a class="btn-green left2" title=" List all authors cited in GigaDB, update ORCID for authors" href="/adminAuthor/admin">Authors</a>
+                        </td>
+                        <td style="vertical-align: top;">
+                            <div class="form well height1">
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title=" List all authors cited in GigaDB, update ORCID for authors" href="/adminAuthor/admin">Authors</a>
 
-                            <a class="btn-green left2" title="Access all Samples list and update sample details" href="/adminSample/admin">Samples</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Access all Samples list and update sample details" href="/adminSample/admin">Samples</a>
 
-                            <a class="btn-green left2" title="Add/update all Species and manage their attributes" href="/adminSpecies/admin">Species</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Add/update all Species and manage their attributes" href="/adminSpecies/admin">Species</a>
 
-                            <a class="btn-green left2" title="Add/update list of external projects linked to from datasets" href="/adminProject/admin">Projects</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Add/update list of external projects linked to from datasets" href="/adminProject/admin">Projects</a>
 
-                            <a class="btn-green left2" title="Add/update links to genome browsers and related links" href="/adminExternalLink/admin">External Links</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Add/update links to genome browsers and related links" href="/adminExternalLink/admin">External Links</a>
 
-                            <a class="btn-green left2" title="Add/update prefixes of links supported by GigaDB" href="/adminLinkPrefix/admin">Link Prefixes</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Add/update prefixes of links supported by GigaDB" href="/adminLinkPrefix/admin">Link Prefixes</a>
 
-                            <a class="btn-green left2" title="Add/update funder" href="/funder/admin">Funder</a>
-                            <div class="clear"></div>
+                                <div class="clear"></div>
 
-                            <a class="btn-green left2" title="Add/update attribute" href="/attribute/admin">Attribute</a>
+                                <a class="btn-green left2" title="Add/update funder" href="/funder/admin">Funder</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Add/update attribute" href="/attribute/admin">Attribute</a>
 
-                            <a class="btn-green left2" title="Add/update list of logs" href="/report/index">Google Analytics</a>
-                        </div>
+                                <div class="clear"></div>
 
-                    </td>
-                    <td style="vertical-align: top;">
+                                <a class="btn-green left2" title="Add/update list of logs" href="/report/index">Google Analytics</a>
+                            </div>
 
+                        </td>
+                        <td style="vertical-align: top;">
 
-                        <div class="form well height1">
 
-                            <a class="btn-green left2" title="Add/update types of datasets supported by GigaDB" href="/adminDatasetType/admin">Dataset Types</a>
+                            <div class="form well height1">
 
+                                <a class="btn-green left2" title="Add/update types of datasets supported by GigaDB" href="/adminDatasetType/admin">Dataset Types</a>
 
-                            <div class="clear"></div>
 
+                                <div class="clear"></div>
 
-                            <a class="btn-green left2" title="Add/update types of files supported by GigaDB" href="/adminFileType/admin">Data Types</a>
 
+                                <a class="btn-green left2" title="Add/update types of files supported by GigaDB" href="/adminFileType/admin">Data Types</a>
 
-                            <div class="clear"></div>
 
+                                <div class="clear"></div>
 
 
 
-                            <a class="btn-green left2" title="Add/update formats of files supported by GigaDB" href="/adminFileFormat/admin">File Formats</a>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Add/update formats of files supported by GigaDB" href="/adminFileFormat/admin">File Formats</a>
 
+                                <div class="clear"></div>
 
 
-                            <a class="btn-green left2" title="Manage GigaDB user accounts" href="/user/admin">Users</a>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Manage GigaDB user accounts" href="/user/admin">Users</a>
 
-                            <a class="btn-green left2" title="Newsletter Subscribers" href="/user/newsletter">Newsletter Subscribers</a>
+                                <div class="clear"></div>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Newsletter Subscribers" href="/user/newsletter">Newsletter Subscribers</a>
 
+                                <div class="clear"></div>
 
-                            <a class="btn-green left2" title="Manage GigaDB news items to show on home page" href="/news/admin" >News Items</a>
 
-                            <div class="clear"></div>
+                                <a class="btn-green left2" title="Manage GigaDB news items to show on home page" href="/news/admin" >News Items</a>
 
+                                <div class="clear"></div>
 
 
 
-                            <a class="btn-green left2" title="manage RSS feed items" href="/rssMessage/admin">RSS Messages</a>
 
-                            <div class="clear"></div>
-                            <a class="btn-green left2" title="Add/update list of publishers" href="/adminPublisher/admin">Publishers</a>
+                                <a class="btn-green left2" title="manage RSS feed items" href="/rssMessage/admin">RSS Messages</a>
 
-                            <div class="clear"></div>
-                            <a class="btn-green left2" title="Add/update list of logs" href="/datasetLog/admin">Update Logs</a>
+                                <div class="clear"></div>
+                                <a class="btn-green left2" title="Add/update list of publishers" href="/adminPublisher/admin">Publishers</a>
 
-                        </div>
-                    </td>
-                </tr>
-            </table>
+                                <div class="clear"></div>
+                                <a class="btn-green left2" title="Add/update list of logs" href="/datasetLog/admin">Update Logs</a>
 
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+
+            </div>
         </div>
     </div>
+
 </div>


### PR DESCRIPTION
# Pull request for issue: #1485

This is a pull request for the following functionalities:

* Manage Dataset Samples page (http://gigadb.gigasciencejournal.com:9170/adminDatasetSample/admin) updated to more modern look

Before

![image](https://github.com/gigascience/gigadb-website/assets/143437854/e085dfc2-a029-46a5-a92a-6b65ebf54f68)

After

![image](https://github.com/gigascience/gigadb-website/assets/143437854/5c43a244-c6f5-4f98-a04c-baa8d9e88b69)


## How to test?

* Navigate to http://gigadb.gigasciencejournal.com:9170/adminDatasetSample/admin and review page appearance

## How have functionalities been implemented?

* Replaced old layout by modern layout
* Updated acceptance test to pass
* Minimal accessibility improvements
* Cherry picked reusable title + breadcrumb solution from another branch
* Cherry picked polyfill implementation from another branch to enable table interactivity
* Cherry picked table widget that extends Yii grid widget with styled pagination

## Any issues with implementation?

None

## Any changes to automated tests?

None

## Any changes to documentation?

None

## Any technical debt repayment?

None

## Any improvements to CI/CD pipeline?

None
