### PR TITLE
Update Readme tool's README.md file after regenerating readme files on staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Docs #1448: Update documentation to use files metadata console tool to update
+  File location URLs
 - Fix #1428: Increase resilience of provisioning by extracting saving EC2 IP addresses as standalone bootstrap plays
 - Feat #1368: Improve accessibility of About Page
 - Fix #1483: Fix URL creation for ftp_site field in dataset table when using files metadata console tool

--- a/gigadb/app/tools/files-metadata-console/README.md
+++ b/gigadb/app/tools/files-metadata-console/README.md
@@ -26,8 +26,9 @@ To make changes to the database, use the `--apply` flag:
 $ docker-compose run --rm files-metadata-console ./yii update/urls --separator=/pub/ --exclude='100020' --next=3 --apply
 ```
 
-You can also specify a stop DOI so when the current DOI to be processed is greater
-than or equal to the stop DOI then File URL transformation is terminated:
+You can also specify a stop DOI so when the current DOI to be processed is
+greater than or equal to the stop DOI then File URL transformation is
+terminated:
 ```
 $ docker-compose run --rm files-metadata-console ./yii update/urls --separator=/pub/ --exclude='100020' --next=3 --stop='200000' --apply
 ```
@@ -51,9 +52,10 @@ $ docker-compose run --rm files-metadata-console ./yii update/urls --separator=/
 
 #### Dataset 100396
 
-Dataset 100396 contains nearly 200,000 files which all need to have their location column updating with correct Wasabi 
-URL. The tool is not able to work with so many files and so need to update manually. Firstly, update ftp_site column in
-dataset table for Dataset 100396:
+Dataset 100396 contains nearly 200,000 files which all need to have their 
+location column updating with correct Wasabi URL. The tool is not able to work 
+with so many files and so need to update manually. Firstly, update ftp_site
+column in dataset table for Dataset 100396:
 ```
 # Connect to dev database
 $ PGPASSWORD=vagrant psql -h localhost -p 54321 -U gigadb postgres
@@ -121,7 +123,7 @@ $ docker run --rm "registry.gitlab.com/$GITLAB_PROJECT/production-files-metadata
 ```
 
 > The dataset file update process should take up to 1 hour and a half to 
-> transform production GigaDB data from start to finish.
+> transform production GigaDB data from start to finish on a bastion server.
 
 Re-create database triggers:
 ```
@@ -134,15 +136,60 @@ The information on dataset page displayed to users may not reflect the changes
 to dataset FTP site and file location URLs now in the database because of how
 the current GigaDB website caching functionality works. For this reason, the
 web application should be restarted to reset the cache on the Gitlab pipeline
-web console. This can be using the Pipelines page on the Gitlab web console by
+web console. This can be done on the Pipelines page on the Gitlab web console by
 manually executing `*_stop_app` and `*_start_app` jobs. You should now be able
 to go to any GigaDB website page for a dataset that is not in the excluded list
 and see file links that point to Wasabi.
 
-Manually update file location URLs for those datasets containing too many files
-which will result in a memory error, e.g. dataset 100396
+Some datasets have been excluded from having their File location URLs updated
+because they contain too many files for the files metadata console tool to 
+process. You can identify these datasets using the big datasets spreadsheet as 
+they will need to be manually updated. You can confirm these datasets have not 
+been updated by cross-referencing them with the DOIs listed by this SQL command:
 ```
-$ docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c 'Update file set location = REPLACE(location, 'https://ftp.cngb.org/pub/gigadb/pub/', 'https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/live/pub/') where dataset_id = 629;'
+# Identify datasets whose ftp_site URLs contain 'cngb'
+$ docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c "SELECT id, identifier, ftp_site FROM dataset WHERE ftp_site ~ 'cngb' ORDER BY identifier ASC;"
+  id  | identifier |                             ftp_site                              
+------+------------+-------------------------------------------------------------------
+   xx | 100050     | https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100050/
+  xxx | 100115     | https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100115
+  xxx | 100157     | https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100157/
+  xxx | 100310     | https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100310/
+```
+
+Manually update `ftp_site` field in dataset table for those datasets:
+```
+$ docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c "Update dataset set ftp_site = REPLACE(ftp_site, 'https://ftp.cngb.org/pub/gigadb/pub/', 'https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/live/pub/') where identifier = '100310';"
+UPDATE 1
+```
+
+Check result of above command:
+```
+$ docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c "select id, identifier, ftp_site from dataset where identifier = '100310';"
+ id  | identifier |                                            ftp_site                                            
+-----+------------+------------------------------------------------------------------------------------------------
+ xxx | 100310     | https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/live/pub/10.5524/100001_101000/100310/
+(1 row)
+```
+
+Finally, manually update file location URLs for those datasets containing too 
+many files which will result in a memory error, e.g. dataset 100310.
+```
+$ docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c "Update file set location = REPLACE(location, 'https://ftp.cngb.org/pub/gigadb/pub/', 'https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/live/pub/') where dataset_id = 385;"
+UPDATE 19981
+```
+
+Check result of above command:
+```
+$ docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c "select location from file where dataset_id = '385' limit 5;"
+                                                                                             location                                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/live/pub/10.5524/100001_101000/100310/mapDamage/14Oral_mapDamage_results/mapDamage_Oral_006/Stats_out_MCMC_iter_summ_stat.csv
+ https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/live/pub/10.5524/100001_101000/100310/mapDamage/Human_Actinobacteria_mapDamage_results/mapDamage_Actino_oral_156/Stats_out_MCMC_iter.csv
+ https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/live/pub/10.5524/100001_101000/100310/mapDamage/14Oral_mapDamage_results/mapDamage_Oral_041/Stats_out_MCMC_iter_summ_stat.csv
+ https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/live/pub/10.5524/100001_101000/100310/mapDamage/14Oral_mapDamage_results/mapDamage_Oral_043/dnacomp_genome.csv
+ https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/live/pub/10.5524/100001_101000/100310/mapDamage/14Oral_mapDamage_results/mapDamage_Oral_042/Stats_out_MCMC_iter_summ_stat.csv
+(5 rows)
 ```
 
 ## Running unit and functional tests in files metadata console tool

--- a/gigadb/app/tools/files-metadata-console/README.md
+++ b/gigadb/app/tools/files-metadata-console/README.md
@@ -143,7 +143,14 @@ and see file links that point to Wasabi.
 
 Some datasets have been excluded from having their File location URLs updated
 because they contain too many files for the files metadata console tool to 
-process. You can identify these datasets using the big datasets spreadsheet as 
+process. These datasets need to be manually updated using SQL commands. We begin
+by starting a database transaction so that each manual dataset update is 
+contained within a unit of work:
+```
+$ docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c "BEGIN TRANSACTION;"
+```
+
+You can identify these datasets using the big datasets spreadsheet as 
 they will need to be manually updated. You can confirm these datasets have not 
 been updated by cross-referencing them with the DOIs listed by this SQL command:
 ```
@@ -190,6 +197,11 @@ $ docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/produ
  https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/live/pub/10.5524/100001_101000/100310/mapDamage/14Oral_mapDamage_results/mapDamage_Oral_043/dnacomp_genome.csv
  https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/live/pub/10.5524/100001_101000/100310/mapDamage/14Oral_mapDamage_results/mapDamage_Oral_042/Stats_out_MCMC_iter_summ_stat.csv
 (5 rows)
+```
+
+Finally, we commit the dataset changes and end the database transaction:
+```
+$ docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c "COMMIT TRANSACTION;"
 ```
 
 ## Running unit and functional tests in files metadata console tool

--- a/gigadb/app/tools/files-metadata-console/README.md
+++ b/gigadb/app/tools/files-metadata-console/README.md
@@ -1,240 +1,8 @@
-<p align="center">
-    <a href="https://github.com/yiisoft" target="_blank">
-        <img src="https://avatars0.githubusercontent.com/u/993323" height="100px">
-    </a>
-    <h1 align="center">Yii 2 Basic Project Template</h1>
-    <br>
-</p>
+# Files Metadata Console
 
-Yii 2 Basic Project Template is a skeleton [Yii 2](http://www.yiiframework.com/) application best for
-rapidly creating small projects.
+## Updating dataset file URLs with Wasabi prefix
 
-The template contains the basic features including user login/logout and a contact page.
-It includes all commonly used configurations that would allow you to focus on adding new
-features to your application.
-
-[![Latest Stable Version](https://img.shields.io/packagist/v/yiisoft/yii2-app-basic.svg)](https://packagist.org/packages/yiisoft/yii2-app-basic)
-[![Total Downloads](https://img.shields.io/packagist/dt/yiisoft/yii2-app-basic.svg)](https://packagist.org/packages/yiisoft/yii2-app-basic)
-[![build](https://github.com/yiisoft/yii2-app-basic/workflows/build/badge.svg)](https://github.com/yiisoft/yii2-app-basic/actions?query=workflow%3Abuild)
-
-DIRECTORY STRUCTURE
--------------------
-
-      assets/             contains assets definition
-      commands/           contains console commands (controllers)
-      config/             contains application configurations
-      controllers/        contains Web controller classes
-      mail/               contains view files for e-mails
-      models/             contains model classes
-      runtime/            contains files generated during runtime
-      tests/              contains various tests for the basic application
-      vendor/             contains dependent 3rd-party packages
-      views/              contains view files for the Web application
-      web/                contains the entry script and Web resources
-
-
-
-REQUIREMENTS
-------------
-
-The minimum requirement by this project template that your Web server supports PHP 5.6.0.
-
-
-INSTALLATION
-------------
-
-### Install via Composer
-
-If you do not have [Composer](http://getcomposer.org/), you may install it by following the instructions
-at [getcomposer.org](http://getcomposer.org/doc/00-intro.md#installation-nix).
-
-You can then install this project template using the following command:
-
-~~~
-composer create-project --prefer-dist yiisoft/yii2-app-basic basic
-~~~
-
-Now you should be able to access the application through the following URL, assuming `basic` is the directory
-directly under the Web root.
-
-~~~
-http://localhost/basic/web/
-~~~
-
-### Install from an Archive File
-
-Extract the archive file downloaded from [yiiframework.com](http://www.yiiframework.com/download/) to
-a directory named `basic` that is directly under the Web root.
-
-Set cookie validation key in `config/web.php` file to some random secret string:
-
-```php
-'request' => [
-    // !!! insert a secret key in the following (if it is empty) - this is required by cookie validation
-    'cookieValidationKey' => '<secret random string goes here>',
-],
-```
-
-You can then access the application through the following URL:
-
-~~~
-http://localhost/basic/web/
-~~~
-
-
-### Install with Docker
-
-Update your vendor packages
-
-    docker-compose run --rm php composer update --prefer-dist
-    
-Run the installation triggers (creating cookie validation code)
-
-    docker-compose run --rm php composer install    
-    
-Start the container
-
-    docker-compose up -d
-    
-You can then access the application through the following URL:
-
-    http://127.0.0.1:8000
-
-**NOTES:** 
-- Minimum required Docker engine version `17.04` for development (see [Performance tuning for volume mounts](https://docs.docker.com/docker-for-mac/osxfs-caching/))
-- The default configuration uses a host-volume in your home directory `.docker-composer` for composer caches
-
-
-CONFIGURATION
--------------
-
-### Database
-
-Edit the file `config/db.php` with real data, for example:
-
-```php
-return [
-    'class' => 'yii\db\Connection',
-    'dsn' => 'mysql:host=localhost;dbname=yii2basic',
-    'username' => 'root',
-    'password' => '1234',
-    'charset' => 'utf8',
-];
-```
-
-**NOTES:**
-- Yii won't create the database for you, this has to be done manually before you can access it.
-- Check and edit the other files in the `config/` directory to customize your application as required.
-- Refer to the README in the `tests` directory for information specific to basic application tests.
-
-
-TESTING
--------
-
-Tests are located in `tests` directory. They are developed with [Codeception PHP Testing Framework](http://codeception.com/).
-By default, there are 3 test suites:
-
-- `unit`
-- `functional`
-- `acceptance`
-
-Tests can be executed by running
-
-```
-vendor/bin/codecept run
-```
-
-The command above will execute unit and functional tests. Unit tests are testing the system components, while functional
-tests are for testing user interaction. Acceptance tests are disabled by default as they require additional setup since
-they perform testing in real browser. 
-
-
-### Running  acceptance tests
-
-To execute acceptance tests do the following:  
-
-1. Rename `tests/acceptance.suite.yml.example` to `tests/acceptance.suite.yml` to enable suite configuration
-
-2. Replace `codeception/base` package in `composer.json` with `codeception/codeception` to install full-featured
-   version of Codeception
-
-3. Update dependencies with Composer 
-
-    ```
-    composer update  
-    ```
-
-4. Download [Selenium Server](http://www.seleniumhq.org/download/) and launch it:
-
-    ```
-    java -jar ~/selenium-server-standalone-x.xx.x.jar
-    ```
-
-    In case of using Selenium Server 3.0 with Firefox browser since v48 or Google Chrome since v53 you must download [GeckoDriver](https://github.com/mozilla/geckodriver/releases) or [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/downloads) and launch Selenium with it:
-
-    ```
-    # for Firefox
-    java -jar -Dwebdriver.gecko.driver=~/geckodriver ~/selenium-server-standalone-3.xx.x.jar
-    
-    # for Google Chrome
-    java -jar -Dwebdriver.chrome.driver=~/chromedriver ~/selenium-server-standalone-3.xx.x.jar
-    ``` 
-    
-    As an alternative way you can use already configured Docker container with older versions of Selenium and Firefox:
-    
-    ```
-    docker run --net=host selenium/standalone-firefox:2.53.0
-    ```
-
-5. (Optional) Create `yii2basic_test` database and update it by applying migrations if you have them.
-
-   ```
-   tests/bin/yii migrate
-   ```
-
-   The database configuration can be found at `config/test_db.php`.
-
-
-6. Start web server:
-
-    ```
-    tests/bin/yii serve
-    ```
-
-7. Now you can run all available tests
-
-   ```
-   # run all available tests
-   vendor/bin/codecept run
-
-   # run acceptance tests
-   vendor/bin/codecept run acceptance
-
-   # run only unit and functional tests
-   vendor/bin/codecept run unit,functional
-   ```
-
-### Code coverage support
-
-By default, code coverage is disabled in `codeception.yml` configuration file, you should uncomment needed rows to be able
-to collect code coverage. You can run your tests and collect coverage with the following command:
-
-```
-#collect coverage for all tests
-vendor/bin/codecept run --coverage --coverage-html --coverage-xml
-
-#collect coverage only for unit tests
-vendor/bin/codecept run unit --coverage --coverage-html --coverage-xml
-
-#collect coverage for unit and functional tests
-vendor/bin/codecept run functional,unit --coverage --coverage-html --coverage-xml
-```
-
-You can see code coverage output under the `tests/_output` directory.
-
-### Updating dataset file URLs with Wasabi prefix
-
-#### Preparation
+### Preparation
 
 Go to `gigadb/app/tools/files-metadata-console` and create a .env file: 
 ```
@@ -245,7 +13,7 @@ Update the .env file with values for REPO_NAME and GITLAB_PRIVATE_TOKEN. Re-run
 `docker-compose run --rm configure` to create a .secrets file and other 
 configuration files in config directory.
 
-#### Dev environment
+### Dev environment
 
 To begin update of file URLs in batches of 3 datasets, execute in dry run mode:
 ```
@@ -264,7 +32,7 @@ than or equal to the stop DOI then File URL transformation is terminated:
 $ docker-compose run --rm files-metadata-console ./yii update/urls --separator=/pub/ --exclude='100020' --next=3 --stop='200000' --apply
 ```
 
-##### Test with production data
+### Test with production data
 
 ```
 # Connect to dev database
@@ -281,7 +49,7 @@ $ docker-compose run --rm test pg_restore -h database -p 5432 -U gigadb -d gigad
 $ docker-compose run --rm files-metadata-console ./yii update/urls --separator=/pub/ --exclude='100396,100446,100584,100747,100957,102311' --stop=200002 --next=3 --apply 
 ```
 
-##### Dataset 100396
+#### Dataset 100396
 
 Dataset 100396 contains nearly 200,000 files which all need to have their location column updating with correct Wasabi 
 URL. The tool is not able to work with so many files and so need to update manually. Firstly, update ftp_site column in
@@ -320,7 +88,7 @@ gigadb=# select * from file where dataset_id = 629 and id = 287662;
  287662 |        629 | 50930810.pdb | https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/live/pub/10.5524/100001_101000/100396/eModelBDB/810/50930810.pdb | pdb       | 370380 | reactant set ID 50930810 | 2018-07-04 |         6 |     254 | FILE_CODE |             |              0 | 
 ```
 
-#### Staging and live environments
+### Staging and live environments
 
 To complete a thorough transformation of all dataset file location URLs, the 
 values of specific command-line parameters should be determined.
@@ -377,7 +145,7 @@ which will result in a memory error, e.g. dataset 100396
 $ docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c 'Update file set location = REPLACE(location, 'https://ftp.cngb.org/pub/gigadb/pub/', 'https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/live/pub/') where dataset_id = 629;'
 ```
 
-### Running unit and functional tests in files metadata console tool
+## Running unit and functional tests in files metadata console tool
 
 Execute all unit tests:
 ```

--- a/gigadb/app/tools/readme-generator/README.md
+++ b/gigadb/app/tools/readme-generator/README.md
@@ -346,16 +346,6 @@ $ ./createReadme.sh --doi 100142 --outdir /app/readmeFiles --wasabi --apply
 You can confirm that the presence of the new readme file in the 100142 directory
 using the Wasabi web console by checking the gigadb-datasets/staging bucket.
 
-There is a batch mode for the script which can be used by providing the 
-`--batch` flag followed by a number to denote the number of datasets to be
-processed. For example, to process DOIs 100141, 100142, 100143:
-```
-$ ./createReadme.sh --doi 100141 --outdir /app/readmeFiles --wasabi --batch 3
-```
-
-You will be able to see in the latest log file in the logs directory that 3
-readme files have been created and copied into Wasabi in dry-run mode.
-
 To copy the readme file to the live data directory, use the `--use-live-data`
 and `--apply` flags:
 ```
@@ -365,3 +355,27 @@ $ ./createReadme.sh --doi 100142 --outdir /app/readmeFiles --wasabi --use-live-d
 Now check the directory for dataset 100142 in relevant location in
 gigadb-datasets/live bucket in Wasabi.
 
+There is a batch mode for the script which can be used by providing the
+`--batch` flag followed by a number to denote the number of datasets to be
+processed. For example, to process DOIs 100141, 100142, 100143:
+```
+$ ./createReadme.sh --doi 100141 --outdir /app/readmeFiles --wasabi --batch 3 --apply
+```
+
+You will be able to see in the latest log file in the logs directory that 3
+readme files have been created and copied into Wasabi in dry-run mode. To
+continue batch-generation of readme files, you need to make a note of the DOI of
+the last dataset whose readme file was created then use the following DOI in the
+next batch command, for example:
+```
+# Because the previous batch command created readme files for 100141, 100142, 100143
+$ ./createReadme.sh --doi 100144 --outdir /app/readmeFiles --wasabi --batch 3 --apply
+```
+
+N.B. Regenerating the readme files for all datasets which numbered ~2320 in
+October 2023 will take approximately 20 hours.
+
+## Troubleshooting
+
+If batch creation of readme files starts to slow down, you might be able to
+improve this problem by running `docker system prune`.


### PR DESCRIPTION
# Pull request for issue #1424: Regenerate readme files for the datasets on staging

This is a pull request to update the Readme tool's README.md file:

* There is a small note at the end of the README.md file describing how to generate readme files for datasets one batch after another and a statement saying that it will take 20 hours to regenerate the readme files for over 2300 datasets. 
