### PR TITLE
fix: allow wrap of author list

### DIFF
--- a/less/current/modules/search-result-card.less
+++ b/less/current/modules/search-result-card.less
@@ -12,6 +12,7 @@
   }
   .search-result-author-list {
     display: flex;
+    flex-wrap: wrap;
   }
   .search-result-row {
     display: flex;


### PR DESCRIPTION
# Pull request for issue: ---

This PR fixes this issue:

![image](https://github.com/gigascience/gigadb-website/assets/143437854/68a0cfe3-890b-458f-93e5-f528b39ab051)


## How to test?

In local no dataset as so many authors, but you might:

* Go to protected/views/search/_new_result.php
* Update the following line:

```
$unorderedList = '<ul class="search-result-list search-result-author-list">' . $listItems . '</ul>';
```

To:

```
$unorderedList = '<ul class="search-result-list search-result-author-list">' . $listItems . $listItems  . $listItems  . $listItems  . '</ul>';
```

* Navigate to http://gigadb.gigasciencejournal.com:9170/search/new?keyword=Genomic&type%5B%5D=dataset&dataset_type%5B%5D=Genomic and confirm that list of auithors look ok

## How have functionalities been implemented?

* Add style to wrap flex children

## Any issues with implementation?

None

## Any changes to automated tests?

None

## Any changes to documentation?

None

## Any technical debt repayment?

None

## Any improvements to CI/CD pipeline?

None