### PR TITLE
Save bastion user public key as gitlab variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1420: Save bastion user's public key to gitlab variable page
 - Feat #1423: Create bash script to update dataset and file links to Wasabi URLs
 
 ## v4.0.2 - 2023-11-27 - cba0ca7a

--- a/docs/sop/PRODUCTION_TROUBLESHOOT.md
+++ b/docs/sop/PRODUCTION_TROUBLESHOOT.md
@@ -311,7 +311,7 @@ then execute the `user_playbook` for the user:
 ```
 which will generate a new pair of ssh keys, the new private key will then be sent to the user, while the public key will be pushed to the the gitlab variable page and also the bastion server.
 
-### What if a user still cannot connect to the bastion server even they have a valid private key file in their computer and the corresponding public key in the baston server
+### What if a user still cannot connect to the bastion server even they have a valid private key file in their computer and the corresponding public key in the bastion server
 
 This may be because the sshd service in the bastion server has not been started properly, tech team will:
 ```

--- a/docs/sop/PRODUCTION_TROUBLESHOOT.md
+++ b/docs/sop/PRODUCTION_TROUBLESHOOT.md
@@ -321,9 +321,38 @@ This may be because the sshd service in the bastion server has not been started 
 systemctl restart sshd.service
 ```
 
+### How to convert ssh private key format from pem to ppk for a Window user
+
+Mostly, Windows users will use PuTTY to connect with the remote server, and the connection requires a ssh private key in ppk format.
+The format conversion can be done as below:
+```
+# install putty to make puttygen tool available on MacOS, if not
+% brew install putty
+# make sure puttygen is available
+% puttygen --version
+puttygen: Release 0.79
+Build platform: 64-bit Unix
+Compiler: clang 14.0.3 (clang-1403.0.22.14.1)
+Source commit: b10059fc922aeb9343a55a409ea01740061d2440
+# go to the location for storing the private key, for example
+% cd gigadb-website/ops/infrastructure/envs/live
+# make sure the private key is available
+% ls -l output/privkeys-$bastion-ip/
+total 8
+-r-x------@ 1 kencho  staff  3357 Nov 29 13:58 $user
+# convert the format from pem to ppk
+% puttygen $user -o $user.ppk
+ % ls -l output/privkeys-$bastion-ip/
+total 16
+-r-x------@ 1 kencho  staff  3357 Nov 29 13:58 $user
+-rw-------@ 1 kencho  staff  2659 Nov 30 13:06 $user.ppk
+```
+
+Then the $user.ppk can be sent to the user for the server connection. 
+
 ### How to connect to the bastion server for a Windows user
 
-Assuming PuTTY is installed, details can be found at [here](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html), and the user has received the private key from the tech team.
+Assuming PuTTY is installed by the user, details can be found at [here](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html), and the user has received the private key from the tech team.
 
 Then user can connect to the bastion server with the given private key as below:
 ```
@@ -331,6 +360,6 @@ Then user can connect to the bastion server with the given private key as below:
 2. Enter the remote server Host Name or IP address under "Session".
 3. Navigate to "Connection" > "SSH" > "Auth".
 4. Click "Browse..." under "Authentication parameters" / "Private key file for authentication".
-5. Locate the $user private key and click "Open".
+5. Locate the $user.ppk private key and click "Open".
 6. Finally, click "Open" again to log into the remote server with key pair authentication.
 ```

--- a/ops/infrastructure/roles/bastion-users/tasks/main.yml
+++ b/ops/infrastructure/roles/bastion-users/tasks/main.yml
@@ -36,8 +36,7 @@
       - 404
   register: public_key_in_gitlab
 
-- name:
-  debug:
+- debug:
     msg: "{{ public_key_in_gitlab.status }}"
 
 - name: check if public key exists in bastion server
@@ -45,8 +44,7 @@
     path: "/home/{{ newuser }}/.ssh/authorized_keys"
   register: public_key_in_bastion
 
-- name:
-  debug:
+- debug:
     msg: "{{ public_key_in_bastion.stat.exists }}"
 
 - name: generate private/public key pair
@@ -54,11 +52,17 @@
     path: "/home/centos/{{ newuser }}.keys/id_ssh_rsa"
     owner: centos
   register: pk
-  when: public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 404
+  when: (public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 404)
 
-- name:
-  debug:
+- debug:
     msg: "{{ pk }}"
+
+- name: downloading the private key
+  ansible.builtin.fetch:
+    src: "/home/centos/{{ newuser }}.keys/id_ssh_rsa"
+    dest: "output/privkeys-{{ inventory_hostname }}/{{ newuser }}"
+    flat: yes
+  when: pk.changed == true
 
 - name: Add curator to sudoers
   ansible.builtin.lineinfile:
@@ -87,13 +91,13 @@
     body_format: json
     body:
       key: "{{ newuser }}_bastion_public_key"
-      value: "{{ pk.public_key }} "
+      value: "{{ pk.public_key }}"
       environment_scope: "{{ gigadb_environment }}"
     status_code:
       - 201
       - 400
   register: save_pk_to_gitlab
-  when: public_key_in_gitlab.status == 404
+  when: (pk.changed == true and public_key_in_gitlab.status == 404)
 
 - name: download pubic key from GitLab CI environment variable
   ansible.builtin.uri:
@@ -115,14 +119,7 @@
     owner: "{{ newuser }}"
     group: "{{ newuser }}"
     mode: g-rw,o-rw
-  when: public_key_from_gl.status == 200
-
-- name: downloading the private key
-  ansible.builtin.fetch:
-    src: "/home/centos/{{ newuser }}.keys/id_ssh_rsa"
-    dest: "output/privkeys-{{ inventory_hostname }}/{{ newuser }}"
-    flat: yes
-  when: pk.changed == true
+  when: (public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 200)
 
 - name: Restart systemd sshd service
   command: systemctl restart sshd.service

--- a/ops/infrastructure/roles/bastion-users/tasks/main.yml
+++ b/ops/infrastructure/roles/bastion-users/tasks/main.yml
@@ -95,38 +95,27 @@
   register: save_pk_to_gitlab
   when: public_key_in_gitlab.status == 404
 
-#- name:
-#  debug:
-#    msg: "{{ save_pk_to_gitlab.status }}"
-
-#- name: get public key from GitLab CI environment variable to authorized keys
-#  ansible.builtin.uri:
-#    url: "{{ gitlab_url }}/variables/{{ newuser }}_bastion_public_key?filter%5benvironment_scope%5d={{ gigadb_environment }}"
-#    method: GET
-#    dest: "/home/{{ newuser }}/.ssh/authorized_keys"
-#    owner: "{{ newuser }}"
-#    group: "{{ newuser }}"
-#    mode: g-rw,o-rw
-#    headers:
-#      PRIVATE-TOKEN: "{{ gitlab_private_token }}"
-#    status_code:
-#      - 200
-#      - 400
-#  register: get_pk_from_gitlab
-#  when: (public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 200)
-#
-#- name:
-#  debug:
-#    msg: "{{ get_pk_from_gitlab.status }}"
-- name: get public key from GitLab CI environment variable to authorized keys
-  shell: 'curl -s --header PRIVATE-TOKEN: "{{ gitlab_private_token }}" "{{ gitlab_url }}/variables/{{ newuser }}_bastion_public_key?filter%5benvironment_scope%5d={{ gigadb_environment }}" | jq -r .value'
-  register: gitlab_pk_value
+- name: download pubic key from GitLab CI environment variable
+  ansible.builtin.uri:
+    url: "{{ gitlab_url }}/variables/{{ newuser }}_bastion_public_key?filter%5benvironment_scope%5d={{ gigadb_environment }}"
+    method: GET
+    headers:
+      PRIVATE-TOKEN: "{{ gitlab_private_token }}"
+    body_format: json
+    status_code:
+      - 200
+      - 400
+  register: public_key_from_gl
   when: (public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 200)
 
-- name:
-  debug:
-    msg: "{{ gitlab_pk_value }}"
-
+- name: copy public key from gitlab to authorized file
+  ansible.builtin.copy:
+    content: "{{ public_key_from_gl.json.value  }}"
+    dest: "/home/{{ newuser }}/.ssh/authorized_keys"
+    owner: "{{ newuser }}"
+    group: "{{ newuser }}"
+    mode: g-rw,o-rw
+  when: public_key_from_gl.status == 200
 
 - name: downloading the private key
   ansible.builtin.fetch:

--- a/ops/infrastructure/roles/bastion-users/tasks/main.yml
+++ b/ops/infrastructure/roles/bastion-users/tasks/main.yml
@@ -82,7 +82,7 @@
     mode: g-rw,o-rw
   when: (public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 404)
 
-- name: save ssh public key to GitLab CI environment variable (first time)
+- name: save ssh public key to GitLab CI environment variable (for newly created user)
   ansible.builtin.uri:
     url: "{{ gitlab_url }}/variables"
     method: POST
@@ -98,6 +98,29 @@
       - 400
   register: save_pk_to_gitlab
   when: (pk.changed == true and public_key_in_gitlab.status == 404)
+
+- name: copy ssh public key (for existing user)
+  slurp:
+    src: "/home/{{ newuser }}/.ssh/authorized_keys"
+  register: existing_public_key
+  when: public_key_in_bastion.stat.exists == true
+
+- name: save ssh public key to GitLab CI environment variable (for existing user)
+  ansible.builtin.uri:
+    url: "{{ gitlab_url }}/variables"
+    method: POST
+    headers:
+      PRIVATE-TOKEN: "{{ gitlab_private_token }}"
+    body_format: json
+    body:
+      key: "{{ newuser }}_bastion_public_key"
+      value: "{{ existing_public_key['content'] | b64decode}}"
+      environment_scope: "{{ gigadb_environment }}"
+    status_code:
+      - 201
+      - 400
+  register: save_pk_to_gitlab
+  when: (public_key_in_bastion.stat.exists == true and public_key_in_gitlab.status == 404)
 
 - name: download pubic key from GitLab CI environment variable
   ansible.builtin.uri:

--- a/ops/infrastructure/roles/bastion-users/tasks/main.yml
+++ b/ops/infrastructure/roles/bastion-users/tasks/main.yml
@@ -25,6 +25,15 @@
     owner: centos
     group: centos
 
+- name: Add curator to sudoers
+  ansible.builtin.lineinfile:
+    path: "/etc/sudoers.d/91-add-{{ newuser }}"
+    line: "{{ newuser }} ALL=(ALL)       NOPASSWD: /home/centos/datasetUpload.sh, /home/centos/postUpload.sh\n"
+    owner: root
+    group: root
+    mode: 440
+    create: yes
+
 - name: check if public key exists in GitLab CI environment variable
   ansible.builtin.uri:
     url: "{{ gitlab_url }}/variables/{{ newuser }}_bastion_public_key?filter%5benvironment_scope%5d={{ gigadb_environment }}"
@@ -47,39 +56,28 @@
 - debug:
     msg: "{{ public_key_in_bastion.stat.exists }}"
 
-- name: generate private/public key pair
-  community.crypto.openssh_keypair:
-    path: "/home/centos/{{ newuser }}.keys/id_ssh_rsa"
-    owner: centos
-  register: pk
-  when: (public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 404)
+- name: generate private/public key pair and download public key
+  block:
+    - name: generate key pair
+      community.crypto.openssh_keypair:
+        path: "/home/centos/{{ newuser }}.keys/id_ssh_rsa"
+        owner: centos
+      register: pk
 
-- debug:
-    msg: "{{ pk }}"
+    - name: download public key
+      ansible.builtin.fetch:
+        src: "/home/centos/{{ newuser }}.keys/id_ssh_rsa"
+        dest: "output/privkeys-{{ inventory_hostname }}/{{ newuser }}"
+        flat: yes
+      when: pk.changed == true
 
-- name: downloading the private key
-  ansible.builtin.fetch:
-    src: "/home/centos/{{ newuser }}.keys/id_ssh_rsa"
-    dest: "output/privkeys-{{ inventory_hostname }}/{{ newuser }}"
-    flat: yes
-  when: pk.changed == true
-
-- name: Add curator to sudoers
-  ansible.builtin.lineinfile:
-    path: "/etc/sudoers.d/91-add-{{ newuser }}"
-    line: "{{ newuser }} ALL=(ALL)       NOPASSWD: /home/centos/datasetUpload.sh, /home/centos/postUpload.sh\n"
-    owner: root
-    group: root
-    mode: 440
-    create: yes
-
-- name: Add public key to authorized keys
-  ansible.builtin.copy:
-    content: "{{ pk.public_key }}"
-    dest: "/home/{{ newuser }}/.ssh/authorized_keys"
-    owner: "{{ newuser }}"
-    group: "{{ newuser }}"
-    mode: g-rw,o-rw
+    - name: Add public key to authorized keys
+      ansible.builtin.copy:
+        content: "{{ pk.public_key }}"
+        dest: "/home/{{ newuser }}/.ssh/authorized_keys"
+        owner: "{{ newuser }}"
+        group: "{{ newuser }}"
+        mode: g-rw,o-rw
   when: (public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 404)
 
 - name: save ssh public key to GitLab CI environment variable (for newly created user)
@@ -122,26 +120,27 @@
   register: save_pk_to_gitlab
   when: (public_key_in_bastion.stat.exists == true and public_key_in_gitlab.status == 404)
 
-- name: download pubic key from GitLab CI environment variable
-  ansible.builtin.uri:
-    url: "{{ gitlab_url }}/variables/{{ newuser }}_bastion_public_key?filter%5benvironment_scope%5d={{ gigadb_environment }}"
-    method: GET
-    headers:
-      PRIVATE-TOKEN: "{{ gitlab_private_token }}"
-    body_format: json
-    status_code:
-      - 200
-      - 400
-  register: public_key_from_gl
-  when: (public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 200)
+- name: download pubic key from GitLab CI environment variable and copy it to authorized file
+  block:
+    - name: get public key
+      ansible.builtin.uri:
+        url: "{{ gitlab_url }}/variables/{{ newuser }}_bastion_public_key?filter%5benvironment_scope%5d={{ gigadb_environment }}"
+        method: GET
+        headers:
+          PRIVATE-TOKEN: "{{ gitlab_private_token }}"
+        body_format: json
+        status_code:
+          - 200
+          - 400
+      register: public_key_from_gl
 
-- name: copy public key from gitlab to authorized file
-  ansible.builtin.copy:
-    content: "{{ public_key_from_gl.json.value  }}"
-    dest: "/home/{{ newuser }}/.ssh/authorized_keys"
-    owner: "{{ newuser }}"
-    group: "{{ newuser }}"
-    mode: g-rw,o-rw
+    - name: copy public key
+      ansible.builtin.copy:
+        content: "{{ public_key_from_gl.json.value  }}"
+        dest: "/home/{{ newuser }}/.ssh/authorized_keys"
+        owner: "{{ newuser }}"
+        group: "{{ newuser }}"
+        mode: g-rw,o-rw
   when: (public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 200)
 
 - name: Restart systemd sshd service

--- a/ops/infrastructure/roles/bastion-users/tasks/main.yml
+++ b/ops/infrastructure/roles/bastion-users/tasks/main.yml
@@ -64,12 +64,12 @@
         owner: centos
       register: pk
 
-    - name: download public key
+    - name: download private key
       ansible.builtin.fetch:
         src: "/home/centos/{{ newuser }}.keys/id_ssh_rsa"
         dest: "output/privkeys-{{ inventory_hostname }}/{{ newuser }}"
         flat: yes
-      when: pk.changed == true
+      when: pk.failed == false
 
     - name: Add public key to authorized keys
       ansible.builtin.copy:
@@ -95,7 +95,7 @@
       - 201
       - 400
   register: save_pk_to_gitlab
-  when: (pk.changed == true and public_key_in_gitlab.status == 404)
+  when: public_key_in_gitlab.status == 404
 
 - name: copy ssh public key and save it to GitLab CI environment variable (for existing user)
   block:

--- a/ops/infrastructure/roles/bastion-users/tasks/main.yml
+++ b/ops/infrastructure/roles/bastion-users/tasks/main.yml
@@ -42,7 +42,7 @@
 
 - name: check if public key exists in bastion server
   ansible.builtin.stat:
-    path: "/home/centos/{{ newuser }}.keys/id_ssh_rsa.pub"
+    path: "/home/{{ newuser }}/.ssh/authorized_keys"
   register: public_key_in_bastion
 
 - name:
@@ -54,6 +54,7 @@
     path: "/home/centos/{{ newuser }}.keys/id_ssh_rsa"
     owner: centos
   register: pk
+  when: public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 404
 
 - name:
   debug:
@@ -75,6 +76,7 @@
     owner: "{{ newuser }}"
     group: "{{ newuser }}"
     mode: g-rw,o-rw
+  when: (public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 404)
 
 - name: save ssh public key to GitLab CI environment variable (first time)
   ansible.builtin.uri:
@@ -91,16 +93,47 @@
       - 201
       - 400
   register: save_pk_to_gitlab
+  when: public_key_in_gitlab.status == 404
+
+#- name:
+#  debug:
+#    msg: "{{ save_pk_to_gitlab.status }}"
+
+#- name: get public key from GitLab CI environment variable to authorized keys
+#  ansible.builtin.uri:
+#    url: "{{ gitlab_url }}/variables/{{ newuser }}_bastion_public_key?filter%5benvironment_scope%5d={{ gigadb_environment }}"
+#    method: GET
+#    dest: "/home/{{ newuser }}/.ssh/authorized_keys"
+#    owner: "{{ newuser }}"
+#    group: "{{ newuser }}"
+#    mode: g-rw,o-rw
+#    headers:
+#      PRIVATE-TOKEN: "{{ gitlab_private_token }}"
+#    status_code:
+#      - 200
+#      - 400
+#  register: get_pk_from_gitlab
+#  when: (public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 200)
+#
+#- name:
+#  debug:
+#    msg: "{{ get_pk_from_gitlab.status }}"
+- name: get public key from GitLab CI environment variable to authorized keys
+  shell: 'curl -s --header PRIVATE-TOKEN: "{{ gitlab_private_token }}" "{{ gitlab_url }}/variables/{{ newuser }}_bastion_public_key?filter%5benvironment_scope%5d={{ gigadb_environment }}" | jq -r .value'
+  register: gitlab_pk_value
+  when: (public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 200)
 
 - name:
   debug:
-    msg: "{{ save_pk_to_gitlab.status }}"
+    msg: "{{ gitlab_pk_value }}"
+
 
 - name: downloading the private key
   ansible.builtin.fetch:
     src: "/home/centos/{{ newuser }}.keys/id_ssh_rsa"
     dest: "output/privkeys-{{ inventory_hostname }}/{{ newuser }}"
     flat: yes
+  when: pk.changed == true
 
 - name: Restart systemd sshd service
   command: systemctl restart sshd.service

--- a/ops/infrastructure/roles/bastion-users/tasks/main.yml
+++ b/ops/infrastructure/roles/bastion-users/tasks/main.yml
@@ -25,6 +25,29 @@
     owner: centos
     group: centos
 
+- name: check if public key exists in GitLab CI environment variable
+  ansible.builtin.uri:
+    url: "{{ gitlab_url }}/variables/{{ newuser }}_bastion_public_key?filter%5benvironment_scope%5d={{ gigadb_environment }}"
+    headers:
+      PRIVATE-TOKEN: "{{ gitlab_private_token }}"
+    body_format: json
+    status_code:
+      - 200
+      - 404
+  register: public_key_in_gitlab
+
+- name:
+  debug:
+    msg: "{{ public_key_in_gitlab.status }}"
+
+- name: check if public key exists in bastion server
+  ansible.builtin.stat:
+    path: "/home/centos/{{ newuser }}.keys/id_ssh_rsa.pub"
+  register: public_key_in_bastion
+
+- name:
+  debug:
+    msg: "{{ public_key_in_bastion.stat.exists }}"
 
 - name: generate private/public key pair
   community.crypto.openssh_keypair:
@@ -32,6 +55,9 @@
     owner: centos
   register: pk
 
+- name:
+  debug:
+    msg: "{{ pk }}"
 
 - name: Add curator to sudoers
   ansible.builtin.lineinfile:
@@ -49,6 +75,26 @@
     owner: "{{ newuser }}"
     group: "{{ newuser }}"
     mode: g-rw,o-rw
+
+- name: save ssh public key to GitLab CI environment variable (first time)
+  ansible.builtin.uri:
+    url: "{{ gitlab_url }}/variables"
+    method: POST
+    headers:
+      PRIVATE-TOKEN: "{{ gitlab_private_token }}"
+    body_format: json
+    body:
+      key: "{{ newuser }}_bastion_public_key"
+      value: "{{ pk.public_key }} "
+      environment_scope: "{{ gigadb_environment }}"
+    status_code:
+      - 201
+      - 400
+  register: save_pk_to_gitlab
+
+- name:
+  debug:
+    msg: "{{ save_pk_to_gitlab.status }}"
 
 - name: downloading the private key
   ansible.builtin.fetch:

--- a/ops/infrastructure/roles/bastion-users/tasks/main.yml
+++ b/ops/infrastructure/roles/bastion-users/tasks/main.yml
@@ -56,13 +56,16 @@
 - debug:
     msg: "{{ public_key_in_bastion.stat.exists }}"
 
-- name: generate private/public key pair and download public key
+- name: generate private/public key pair and download private key
   block:
     - name: generate key pair
       community.crypto.openssh_keypair:
         path: "/home/centos/{{ newuser }}.keys/id_ssh_rsa"
         owner: centos
       register: pk
+
+    - debug:
+        msg: "{{ pk }}"
 
     - name: download private key
       ansible.builtin.fetch:
@@ -78,24 +81,26 @@
         owner: "{{ newuser }}"
         group: "{{ newuser }}"
         mode: g-rw,o-rw
-  when: (public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 404)
 
-- name: save ssh public key to GitLab CI environment variable (for newly created user)
-  ansible.builtin.uri:
-    url: "{{ gitlab_url }}/variables"
-    method: POST
-    headers:
-      PRIVATE-TOKEN: "{{ gitlab_private_token }}"
-    body_format: json
-    body:
-      key: "{{ newuser }}_bastion_public_key"
-      value: "{{ pk.public_key }}"
-      environment_scope: "{{ gigadb_environment }}"
-    status_code:
-      - 201
-      - 400
-  register: save_pk_to_gitlab
-  when: public_key_in_gitlab.status == 404
+    - name: save ssh public key to GitLab CI environment variable (for newly created user)
+      ansible.builtin.uri:
+        url: "{{ gitlab_url }}/variables"
+        method: POST
+        headers:
+          PRIVATE-TOKEN: "{{ gitlab_private_token }}"
+        body_format: json
+        body:
+          key: "{{ newuser }}_bastion_public_key"
+          value: "{{ pk.public_key }}"
+          environment_scope: "{{ gigadb_environment }}"
+        status_code:
+          - 201
+          - 400
+      register: save_pk_to_gitlab
+
+    - debug:
+        msg: "{{ save_pk_to_gitlab.status }}"
+  when: (public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 404)
 
 - name: copy ssh public key and save it to GitLab CI environment variable (for existing user)
   block:
@@ -119,6 +124,9 @@
           - 201
           - 400
       register: save_pk_to_gitlab
+
+    - debug:
+        msg: "{{ save_pk_to_gitlab.status }}"
   when: (public_key_in_bastion.stat.exists == true and public_key_in_gitlab.status == 404)
 
 - name: download pubic key from GitLab CI environment variable and copy it to authorized file

--- a/ops/infrastructure/roles/bastion-users/tasks/main.yml
+++ b/ops/infrastructure/roles/bastion-users/tasks/main.yml
@@ -97,27 +97,28 @@
   register: save_pk_to_gitlab
   when: (pk.changed == true and public_key_in_gitlab.status == 404)
 
-- name: copy ssh public key (for existing user)
-  slurp:
-    src: "/home/{{ newuser }}/.ssh/authorized_keys"
-  register: existing_public_key
-  when: public_key_in_bastion.stat.exists == true
+- name: copy ssh public key and save it to GitLab CI environment variable (for existing user)
+  block:
+    - name: copy ssh public key
+      slurp:
+        src: "/home/{{ newuser }}/.ssh/authorized_keys"
+      register: existing_public_key
 
-- name: save ssh public key to GitLab CI environment variable (for existing user)
-  ansible.builtin.uri:
-    url: "{{ gitlab_url }}/variables"
-    method: POST
-    headers:
-      PRIVATE-TOKEN: "{{ gitlab_private_token }}"
-    body_format: json
-    body:
-      key: "{{ newuser }}_bastion_public_key"
-      value: "{{ existing_public_key['content'] | b64decode}}"
-      environment_scope: "{{ gigadb_environment }}"
-    status_code:
-      - 201
-      - 400
-  register: save_pk_to_gitlab
+    - name: save ssh public key to GitLab CI environment variable
+      ansible.builtin.uri:
+        url: "{{ gitlab_url }}/variables"
+        method: POST
+        headers:
+          PRIVATE-TOKEN: "{{ gitlab_private_token }}"
+        body_format: json
+        body:
+          key: "{{ newuser }}_bastion_public_key"
+          value: "{{ existing_public_key['content'] | b64decode}}"
+          environment_scope: "{{ gigadb_environment }}"
+        status_code:
+          - 201
+          - 400
+      register: save_pk_to_gitlab
   when: (public_key_in_bastion.stat.exists == true and public_key_in_gitlab.status == 404)
 
 - name: download pubic key from GitLab CI environment variable and copy it to authorized file

--- a/ops/infrastructure/roles/bastion-users/tasks/main.yml
+++ b/ops/infrastructure/roles/bastion-users/tasks/main.yml
@@ -129,7 +129,7 @@
         msg: "{{ save_pk_to_gitlab.status }}"
   when: (public_key_in_bastion.stat.exists == true and public_key_in_gitlab.status == 404)
 
-- name: download pubic key from GitLab CI environment variable and copy it to authorized file
+- name: download public key from GitLab CI environment variable and copy it to authorized file
   block:
     - name: get public key
       ansible.builtin.uri:

--- a/ops/infrastructure/roles/bastion-users/tasks/main.yml
+++ b/ops/infrastructure/roles/bastion-users/tasks/main.yml
@@ -95,7 +95,6 @@
           environment_scope: "{{ gigadb_environment }}"
         status_code:
           - 201
-          - 400
       register: save_pk_to_gitlab
 
     - debug:
@@ -122,7 +121,6 @@
           environment_scope: "{{ gigadb_environment }}"
         status_code:
           - 201
-          - 400
       register: save_pk_to_gitlab
 
     - debug:
@@ -140,7 +138,6 @@
         body_format: json
         status_code:
           - 200
-          - 400
       register: public_key_from_gl
 
     - name: copy public key

--- a/ops/infrastructure/roles/bastion-users/tasks/main.yml
+++ b/ops/infrastructure/roles/bastion-users/tasks/main.yml
@@ -36,7 +36,7 @@
 
 - name: check if public key exists in GitLab CI environment variable
   ansible.builtin.uri:
-    url: "{{ gitlab_url }}/variables/{{ newuser }}_bastion_public_key?filter%5benvironment_scope%5d={{ gigadb_environment }}"
+    url: "{{ gitlab_url }}/variables/bastion_authorized_keys_{{ newuser }}?filter%5benvironment_scope%5d={{ gigadb_environment }}"
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
     body_format: json
@@ -90,7 +90,7 @@
           PRIVATE-TOKEN: "{{ gitlab_private_token }}"
         body_format: json
         body:
-          key: "{{ newuser }}_bastion_public_key"
+          key: "bastion_authorized_keys_{{ newuser }}"
           value: "{{ pk.public_key }}"
           environment_scope: "{{ gigadb_environment }}"
         status_code:
@@ -117,7 +117,7 @@
           PRIVATE-TOKEN: "{{ gitlab_private_token }}"
         body_format: json
         body:
-          key: "{{ newuser }}_bastion_public_key"
+          key: "bastion_authorized_keys_{{ newuser }}"
           value: "{{ existing_public_key['content'] | b64decode}}"
           environment_scope: "{{ gigadb_environment }}"
         status_code:
@@ -133,7 +133,7 @@
   block:
     - name: get public key
       ansible.builtin.uri:
-        url: "{{ gitlab_url }}/variables/{{ newuser }}_bastion_public_key?filter%5benvironment_scope%5d={{ gigadb_environment }}"
+        url: "{{ gitlab_url }}/variables/bastion_authorized_keys_{{ newuser }}?filter%5benvironment_scope%5d={{ gigadb_environment }}"
         method: GET
         headers:
           PRIVATE-TOKEN: "{{ gitlab_private_token }}"

--- a/ops/infrastructure/users_playbook.yml
+++ b/ops/infrastructure/users_playbook.yml
@@ -2,6 +2,6 @@
 # Create users on bastion server
 
 - name: Create an additional user on bastion for curators team
-  hosts: name_bastion_server_staging*:name_bastion_server_live*
+  hosts: name_bastion_server_{{gigadb_env}}*
   roles:
     - role: ../../roles/bastion-users


### PR DESCRIPTION
# Pull request for issue: #1420 

This is a pull request for the following functionalities:

The user_playbook will make sure the same ssh public key co-exists in the bastion server and gitlab variable page.


## How to test?

Describe how the new functionalities can be tested by PR reviewers

```
# Create a new user `lily` for the first time in staging
% cd /gigadb-website/ops/infrastructure/envs/staging
% ../../../scripts/tf_init.sh --project gigascience/forks/kencho-gigadb-website --env staging
% terraform apply
% terraform refresh
% ../../../scripts/ansible_init.sh --env staging
% ansible-playbook -i ../../inventories users_playbook.yml -e "newuser=lily" --extra-vars="gigadb_env=staging"
% chmod 500 output/privkeys-$bastion-ip/lily
% ssh -i output/privkeys-$bastion-ip/lily lily@$bastion-ip
# check if lily_bastion_public_key (staging) exists in the gitlab variables page

# destroy the ec2 instances, re-create, and login as lily 
% cd /gigadb-website/ops/infrastructure/envs/staging
% terraform destroy
% terraform apply
% terraform refresh
% ../../../scripts/ansible_init.sh --env staging
% ansible-playbook -i ../../inventories users_playbook.yml -e "newuser=lily" --extra-vars="gigadb_env=staging"
# download public key from gitlab, and save it as lily's authorized keys
% ssh -i output/privkeys-$bastion-ip/lily lily@$bastion-ip

# delete gitlab variable lily_bastion_public_key manually, upload existing public key from bastion server to gitlab variable agin
% cd /gigadb-website/ops/infrastructure/envs/staging
% ansible-playbook -i ../../inventories users_playbook.yml -e "newuser=lily" --extra-vars="gigadb_env=staging"
# check if lily_bastion_public_key (staging) exists in the gitlab variables page
```

```
# Create a new user `lily` for the first time in live
% cd /gigadb-website/ops/infrastructure/envs/live
% ../../../scripts/tf_init.sh --project gigascience/forks/kencho-gigadb-website --env live
% terraform apply
% terraform refresh
% ../../../scripts/ansible_init.sh --env live
% ansible-playbook -i ../../inventories users_playbook.yml -e "newuser=lily" --extra-vars="gigadb_env=live"
% chmod 500 output/privkeys-$bastion-ip/lily
% ssh -i output/privkeys-$bastion-ip/lily lily@$bastion-ip
# check if lily_bastion_public_key (live) exists in the gitlab variables page

# destroy the ec2 instances, re-create, and login as lily 
% cd /gigadb-website/ops/infrastructure/envs/live
% terraform destroy
% terraform apply
% terraform refresh
% ../../../scripts/ansible_init.sh --env live
% ansible-playbook -i ../../inventories users_playbook.yml -e "newuser=lily" --extra-vars="gigadb_env=live"
# download public key from gitlab, and save it as lily's authorized keys
% ssh -i output/privkeys-$bastion-ip/lily lily@$bastion-ip

# delete gitlab variable lily_bastion_public_key (live) manually, upload existing public key from bastion server to gitlab variable agin
% cd /gigadb-website/ops/infrastructure/envs/live
% ansible-playbook -i ../../inventories users_playbook.yml -e "newuser=lily" --extra-vars="gigadb_env=live"
# check if lily_bastion_public_key (live) exists in the gitlab variables page
```


## How have functionalities been implemented?

The user_playbook will first check the existence of the ssh public key in bastion server and also in gitlab variable page, then store the checking results in these two variables `public_key_in_bastion` and `public_key_in_gitlab`.

The status of the `public_key_in_bastion` and `public_key_in_gitlab` will trigger the blocks as below: 

```
If public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 404, the playbook will generate a new ssh key-pair, then push the public key to bastion server and gitlab variable page.

If public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 200, the playbook will copy the public key from gitlab variable page to the bastion server.

If public_key_in_bastion.stat.exists == true and public_key_in_gitlab.status == 404, , the playbook will copy the public key from the bastion server to to gitlab variable page.
```

But if public_key_in_bastion.stat.exists == true and public_key_in_gitlab.status == 200, which means the ssh key-pair has been generated already,  the playbook will only try to create a user account.


## Any issues with implementation?

Describe any problems with your implementation

## Any changes to automated tests?

Describe any automated tests that have been developed for the new 
functionalities

## Any changes to documentation?

Describe changes to the documentation

## Any technical debt repayment?

Describe changes to code that repays any technical debt

## Any improvements to CI/CD pipeline?

Describe any improvements to the Gitlab pipeline
