### PR TITLE
Sample attributes list lost and not saved correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
+
 # GigaDB Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-
+- Fix #1102: On sample admin form, save all valid sample attributes while showing errors for non-existent attributes
 - Feat #1434: Setup playwright local environment for automated accessibility testing
 - Feat #1443: Make ansible playbooks can execute plays separately by adding tags
 - Fix #1428: Increase resilience of provisioning by extracting saving EC2 IP addresses as standalone bootstrap plays

--- a/protected/controllers/AdminSampleController.php
+++ b/protected/controllers/AdminSampleController.php
@@ -333,9 +333,9 @@ class AdminSampleController extends Controller
 
         if (!empty($model->attributesList) && trim($model->attributesList)) {
             // From a model we will clone
-            $sampleAttribute = new SampleAttribute();
-            $sampleAttribute->sample_id = $model->id;
             foreach (explode('",', $model->attributesList) as $attributes) {
+                $sampleAttribute = new SampleAttribute();
+                $sampleAttribute->sample_id = $model->id;
                 $attributes = str_replace('"', '', $attributes);
                 $attributeData = explode('=', $attributes);
                 if (count($attributeData) == 2) {
@@ -345,10 +345,9 @@ class AdminSampleController extends Controller
                         $model->addError('error', 'Attribute name for the input ' . $attributeData[0] . "=" . $attributeData[1] . ' is not valid - please select a valid attribute name!');
                     } else {
                         // Let's save the new sample attribute
-                        $sampleAttribute = clone $sampleAttribute;
                         $sampleAttribute->value = trim($attributeData[1]);
                         $sampleAttribute->attribute_id = $attribute->id;
-                        if (!$sampleAttribute->save()) {
+                        if (!$sampleAttribute->save(true)) {
                             foreach ($sampleAttribute->getErrors() as $errors) {
                                 foreach ($errors as $errorMessage) {
                                     $model->addError('error', $errorMessage);

--- a/protected/views/adminSample/_form.php
+++ b/protected/views/adminSample/_form.php
@@ -51,7 +51,7 @@
         <div class="control-group">
             <?php echo $form->labelEx($model,'attributesList',array('class'=>'control-label')); ?>
             <div class="controls">
-                <textarea name="Sample[attributesList]"><?= $model->getAttributesList(true) ?></textarea>
+                <textarea name="Sample[attributesList]"><?php echo $model->attributesList ? $model->attributesList :  $model->getAttributesList(true) ?></textarea>
                 <?php echo $form->error($model,'attributesList'); ?>
             </div>
         </div>

--- a/tests/acceptance/AdminSample.feature
+++ b/tests/acceptance/AdminSample.feature
@@ -16,13 +16,16 @@ Feature: admin page for samples
 
   @ok
   Scenario: display 1 input error message when update
-    Given I am on "/adminSample/update/id/432"
+    Given I am on "/adminSample/update/id/154"
     And I should see "lat_lon"
-    When I fill in the field of "name" "Sample[attributesList]" with "animal=\"tiger\""
+    When I fill in the field of "name" "Sample[attributesList]" with "source_mat_id=\"David Lambert & BGI\",est_genome_size=\"1.32\",alternative_names=\"PYGAD\",animal=\"tiger\""
     And I press the button "Save"
     And I wait "1" seconds
     Then I should see "Please fix the following input errors:"
     And I should see "Attribute name for the input animal=\tiger\ is not valid - please select a valid attribute name!"
+    And I should see "David Lambert"
+    And I should see "1.32"
+    And I should see "PYGAD"
 
 
   @ok

--- a/tests/acceptance/AdminSample.feature
+++ b/tests/acceptance/AdminSample.feature
@@ -27,6 +27,16 @@ Feature: admin page for samples
     And I should see "1.32"
     And I should see "PYGAD"
 
+  @ok
+  Scenario: show the original attribute when update
+    Given I am on "/adminSample/update/id/154"
+    And I should see "lat_lon"
+    And I press the button "Save"
+    And I wait "1" seconds
+    And I should see "David Lambert"
+    And I should see "1.32"
+    And I should see "PYGAD"
+
 
   @ok
   Scenario: display error message for empty taxon id when update

--- a/tests/acceptance/AdminSample.feature
+++ b/tests/acceptance/AdminSample.feature
@@ -127,8 +127,9 @@ Feature: admin page for samples
     Given I am on "/adminSample/create"
     And I should see "Create"
     When I fill in the field of "name" "Sample[species_id]" with "87676:Eucalyptus pauciflora"
-    And I fill in the field of "name" "Sample[attributesList]" with "sex=\"male\""
+    And I fill in the field of "name" "Sample[attributesList]" with "sex=\"male\",alternative_names=\"Alternative name here\""
     And I press the button "Create"
     And I wait "1" seconds
     Then I should see "View Sample #433"
     And I should see "male"
+    And I should see "Alternative name here"


### PR DESCRIPTION
# Pull request for issue: #1102

This is a pull request for fixing the following problematic situation:

1) After an invalid entry the form shows in the field what's from the database instead of what was inputed by the user
2) When the form is submitted, whether or not there are errors in the attribute list, only the last valid attribute is saved in the database
3) Because all sample attributes in the databases are deleted first after form is submitted,  if there is an error in the list of attributes, due to 1) and 2), we lose existing attributes from the database with no way to recover them

The fix will ensure that:
*  the data entered by user in the from stays in the form after updating with error
* all valid sample attributes will be saved in the database upon form submission

## How to test?

I updated the scenarios in `tests/acceptance/AdminSample.feature` to cover the situation describe above.
All the tests should pass.

### manually

* Navigate to http://gigadb.gigasciencejournal.com:9170/adminSample/update/id/154
* to the existing list of attributes in the "Attributes List" field, add `animal="tiger"` and submit the form
* You should see:
  * `- Attribute name for the input animal=tiger is not valid - please select a valid attribute name!`
  * the content of the  "Attributes List" field should stay the same as when the form was submitted (including the invalid attribute)
  
Then two parallel tracks to test:
1) Click "Cancel" and return to http://gigadb.gigasciencejournal.com:9170/adminSample/update/id/154, all the valid attributes from the database should be  listed in the "Sample Attributes" column and navigating to the form will show them all in the "Attributes List" field
2) Replace the `animal="tiger"` with `age="5"` then submit again, you should be on http://gigadb.gigasciencejournal.com:9170/adminSample/view/id/154 and the original attributes and the new one should be listed in the view


## How have functionalities been implemented?

The most critical issue was in `protected/controllers/AdminSampleController.php`'s `updateSampleAttributes` function where new sample attribute CActiveRecord models are not created correctly.

The line 
```
$sampleAttribute = clone $sampleAttribute;
```
Will not work properly as it reference the same variable name on both side of the equal sign
Furthermore that variable is declared outside of the loop with:
```
$sampleAttribute = new SampleAttribute();
```

So the cloning will create a new object but assign it to the same original variable, at every iteration,
So that when calling `->save()` inside the loop, it keeps saving the same model, and of course the last save win, which is why the latest attribute appears to be the only saved. 
There were all actually saved but into the same sample attribute model so previous save were overwritten.

So the fix is to ensure that the clone is assigned to a variable declared inside the loop, so that at every iteration, a new variable is used.


The other issue is related to what is displayed in the "Attributes list" field after errors are reported.
Previously, it load what's in the database, but that's incorrect. It should show the data that was entered by the user, so that they can correct it by themselves.


## Any issues with implementation?

n/a

## Any changes to automated tests?

Augmented the acceptance tests scenario in `tests/acceptance/AdminSample.feature` to reproduce the two issues.

## Any changes to documentation?

n/a

## Any technical debt repayment?

n/a

## Any improvements to CI/CD pipeline?

n/a
