### PR TITLE
No caching on mockup page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1528: Do not use caching on mockup pages
+
 ## v4.0.1 - 2023-11-20 - 57129850
 
 - Fix #1562: Make live tideways jobs only available in the tagged GitLab pipeline

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eaae7a5ccc82a28be2793220dc5d1301",
+    "content-hash": "af661719c4f233551f32f407c8964beb",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -513,63 +513,6 @@
             "time": "2021-12-25T01:21:49+00:00"
         },
         {
-            "name": "firebase/php-jwt",
-            "version": "v5.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "d2113d9b2e0e349796e72d2a63cf9319100382d2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d2113d9b2e0e349796e72d2a63cf9319100382d2",
-                "reference": "d2113d9b2e0e349796e72d2a63cf9319100382d2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": ">=4.8 <=9"
-            },
-            "suggest": {
-                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Firebase\\JWT\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Neuman Vong",
-                    "email": "neuman+pear@twilio.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Anant Narayanan",
-                    "email": "anant@php.net",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
-            "homepage": "https://github.com/firebase/php-jwt",
-            "keywords": [
-                "jwt",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v5.4.0"
-            },
-            "time": "2021-06-23T19:00:23+00:00"
-        },
-        {
             "name": "gabrielelana/byte-units",
             "version": "0.5.0",
             "source": {
@@ -624,170 +567,6 @@
                 "source": "https://github.com/gabrielelana/byte-units/tree/master"
             },
             "time": "2018-01-11T10:40:03+00:00"
-        },
-        {
-            "name": "google/apiclient",
-            "version": "v2.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/googleapis/google-api-php-client.git",
-                "reference": "4e0fd83510e579043e10e565528b323b7c2b3c81"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/4e0fd83510e579043e10e565528b323b7c2b3c81",
-                "reference": "4e0fd83510e579043e10e565528b323b7c2b3c81",
-                "shasum": ""
-            },
-            "require": {
-                "firebase/php-jwt": "~2.0|~3.0|~4.0|~5.0",
-                "google/apiclient-services": "~0.13",
-                "google/auth": "^1.0",
-                "guzzlehttp/guzzle": "~5.3.1|~6.0",
-                "guzzlehttp/psr7": "^1.2",
-                "monolog/monolog": "^1.17",
-                "php": ">=5.4",
-                "phpseclib/phpseclib": "~0.3.10|~2.0"
-            },
-            "require-dev": {
-                "cache/filesystem-adapter": "^0.3.2",
-                "phpunit/phpunit": "~4.8.36",
-                "squizlabs/php_codesniffer": "~2.3",
-                "symfony/css-selector": "~2.1",
-                "symfony/dom-crawler": "~2.1"
-            },
-            "suggest": {
-                "cache/filesystem-adapter": "For caching certs and tokens (using Google_Client::setCache)"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Google_": "src/"
-                },
-                "classmap": [
-                    "src/Google/Service/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "description": "Client library for Google APIs",
-            "homepage": "http://developers.google.com/api-client-library/php",
-            "keywords": [
-                "google"
-            ],
-            "support": {
-                "issues": "https://github.com/googleapis/google-api-php-client/issues",
-                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.2.2"
-            },
-            "time": "2018-06-20T15:52:20+00:00"
-        },
-        {
-            "name": "google/apiclient-services",
-            "version": "v0.203.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "e397f35251a49e0f4284d5f7d934164ca1274066"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/e397f35251a49e0f4284d5f7d934164ca1274066",
-                "reference": "e397f35251a49e0f4284d5f7d934164ca1274066",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7||^8.5.13"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Google\\Service\\": "src"
-                },
-                "files": [
-                    "autoload.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "description": "Client library for Google APIs",
-            "homepage": "http://developers.google.com/api-client-library/php",
-            "keywords": [
-                "google"
-            ],
-            "support": {
-                "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
-                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.203.0"
-            },
-            "time": "2021-07-10T11:20:23+00:00"
-        },
-        {
-            "name": "google/auth",
-            "version": "v1.16.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/googleapis/google-auth-library-php.git",
-                "reference": "c747738d2dd450f541f09f26510198fbedd1c8a0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/c747738d2dd450f541f09f26510198fbedd1c8a0",
-                "reference": "c747738d2dd450f541f09f26510198fbedd1c8a0",
-                "shasum": ""
-            },
-            "require": {
-                "firebase/php-jwt": "~2.0|~3.0|~4.0|~5.0",
-                "guzzlehttp/guzzle": "^5.3.1|^6.2.1|^7.0",
-                "guzzlehttp/psr7": "^1.2",
-                "php": ">=5.4",
-                "psr/cache": "^1.0|^2.0",
-                "psr/http-message": "^1.0"
-            },
-            "require-dev": {
-                "guzzlehttp/promises": "0.1.1|^1.3",
-                "kelvinmo/simplejwt": "^0.2.5|^0.5.1",
-                "phpseclib/phpseclib": "^2.0.31",
-                "phpunit/phpunit": "^4.8.36|^5.7",
-                "sebastian/comparator": ">=1.2.3",
-                "squizlabs/php_codesniffer": "^3.5"
-            },
-            "suggest": {
-                "phpseclib/phpseclib": "May be used in place of OpenSSL for signing strings or for token management. Please require version ^2."
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Google\\Auth\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "description": "Google Auth Library for PHP",
-            "homepage": "http://github.com/google/google-auth-library-php",
-            "keywords": [
-                "Authentication",
-                "google",
-                "oauth2"
-            ],
-            "support": {
-                "docs": "https://googleapis.github.io/google-auth-library-php/master/",
-                "issues": "https://github.com/googleapis/google-auth-library-php/issues",
-                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.16.0"
-            },
-            "time": "2021-06-22T18:06:03+00:00"
         },
         {
             "name": "gregwar/captcha",
@@ -1592,92 +1371,6 @@
             "time": "2021-01-26T14:36:01+00:00"
         },
         {
-            "name": "monolog/monolog",
-            "version": "1.26.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "c6b00f05152ae2c9b04a448f99c7590beb6042f5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c6b00f05152ae2c9b04a448f99c7590beb6042f5",
-                "reference": "c6b00f05152ae2c9b04a448f99c7590beb6042f5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0",
-                "psr/log": "~1.0"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0.0"
-            },
-            "require-dev": {
-                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
-                "doctrine/couchdb": "~1.0@dev",
-                "graylog2/gelf-php": "~1.0",
-                "php-amqplib/php-amqplib": "~2.4",
-                "php-console/php-console": "^3.1.3",
-                "phpstan/phpstan": "^0.12.59",
-                "phpunit/phpunit": "~4.5",
-                "ruflin/elastica": ">=0.90 <3.0",
-                "sentry/sentry": "^0.13",
-                "swiftmailer/swiftmailer": "^5.3|^6.0"
-            },
-            "suggest": {
-                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
-                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                "ext-mongo": "Allow sending log messages to a MongoDB server",
-                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
-                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
-                "php-console/php-console": "Allow sending log messages to Google Chrome",
-                "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                "sentry/sentry": "Allow sending log messages to a Sentry server"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Monolog\\": "src/Monolog"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-            "homepage": "http://github.com/Seldaek/monolog",
-            "keywords": [
-                "log",
-                "logging",
-                "psr-3"
-            ],
-            "support": {
-                "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/1.26.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/Seldaek",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-05-28T08:32:12+00:00"
-        },
-        {
             "name": "mtdowling/jmespath.php",
             "version": "2.6.1",
             "source": {
@@ -2263,164 +1956,6 @@
             "time": "2020-04-27T08:12:48+00:00"
         },
         {
-            "name": "phpseclib/phpseclib",
-            "version": "2.0.32",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "f5c4c19880d45d0be3e7d24ae8ac434844a898cd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/f5c4c19880d45d0be3e7d24ae8ac434844a898cd",
-                "reference": "f5c4c19880d45d0be3e7d24ae8ac434844a898cd",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phing/phing": "~2.7",
-                "phpunit/phpunit": "^4.8.35|^5.7|^6.0|^9.4",
-                "squizlabs/php_codesniffer": "~2.0"
-            },
-            "suggest": {
-                "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
-                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
-                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
-                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "phpseclib/bootstrap.php"
-                ],
-                "psr-4": {
-                    "phpseclib\\": "phpseclib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jim Wigginton",
-                    "email": "terrafrost@php.net",
-                    "role": "Lead Developer"
-                },
-                {
-                    "name": "Patrick Monnerat",
-                    "email": "pm@datasphere.ch",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Andreas Fischer",
-                    "email": "bantu@phpbb.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Hans-Jürgen Petrich",
-                    "email": "petrich@tronic-media.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Graham Campbell",
-                    "email": "graham@alt-three.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
-            "homepage": "http://phpseclib.sourceforge.net",
-            "keywords": [
-                "BigInteger",
-                "aes",
-                "asn.1",
-                "asn1",
-                "blowfish",
-                "crypto",
-                "cryptography",
-                "encryption",
-                "rsa",
-                "security",
-                "sftp",
-                "signature",
-                "signing",
-                "ssh",
-                "twofish",
-                "x.509",
-                "x509"
-            ],
-            "support": {
-                "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/2.0.32"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/terrafrost",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/phpseclib",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpseclib/phpseclib",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-06-12T12:12:59+00:00"
-        },
-        {
-            "name": "psr/cache",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for caching libraries",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr-6"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/cache/tree/master"
-            },
-            "time": "2016-08-06T20:24:11+00:00"
-        },
-        {
             "name": "psr/http-message",
             "version": "1.0.1",
             "source": {
@@ -2472,56 +2007,6 @@
                 "source": "https://github.com/php-fig/http-message/tree/master"
             },
             "time": "2016-08-06T14:39:51+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "1.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
-            },
-            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -6128,6 +5613,92 @@
             "time": "2017-05-15T08:35:42+00:00"
         },
         {
+            "name": "monolog/monolog",
+            "version": "1.26.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "c6b00f05152ae2c9b04a448f99c7590beb6042f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c6b00f05152ae2c9b04a448f99c7590beb6042f5",
+                "reference": "c6b00f05152ae2c9b04a448f99c7590beb6042f5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/log": "~1.0"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "graylog2/gelf-php": "~1.0",
+                "php-amqplib/php-amqplib": "~2.4",
+                "php-console/php-console": "^3.1.3",
+                "phpstan/phpstan": "^0.12.59",
+                "phpunit/phpunit": "~4.5",
+                "ruflin/elastica": ">=0.90 <3.0",
+                "sentry/sentry": "^0.13",
+                "swiftmailer/swiftmailer": "^5.3|^6.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-mongo": "Allow sending log messages to a MongoDB server",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "php-console/php-console": "Allow sending log messages to Google Chrome",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                "sentry/sentry": "Allow sending log messages to a Sentry server"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "http://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/1.26.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-28T08:32:12+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.10.2",
             "source": {
@@ -7856,6 +7427,55 @@
             "time": "2013-11-22T08:30:29+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/master"
+            },
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "1.0.0",
             "source": {
@@ -7907,6 +7527,56 @@
                 "source": "https://github.com/php-fig/container/tree/master"
             },
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
+            },
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/ops/configuration/php-conf/composer.json.dist
+++ b/ops/configuration/php-conf/composer.json.dist
@@ -12,7 +12,6 @@
         "yiisoft/yii2-swiftmailer": "~2.1.0",
         "phpmailer/phpmailer": "^6.0",
         "gabrielelana/byte-units": "^0.5",
-        "google/apiclient": "~v2.2.2",
         "suin/php-rss-writer": "^1.6",
          "leafo/lessphp": "^v0.5.0",
          "opauth/opauth": "^0.4.5",

--- a/ops/configuration/yii-conf/index.dev.php.dist
+++ b/ops/configuration/yii-conf/index.dev.php.dist
@@ -4,7 +4,7 @@
 # To be effective, ensure the two lines below are placed before we load Yii.php
 define('YII_DEBUG',$YII_DEBUG);
 define('YII_TRACE_LEVEL',$YII_TRACE_LEVEL);
-define('DISABLE_CACHE',$DISABLE_CACHE);
+define('DISABLE_CACHE',false);
 
 # Load the modified root class for Yii1.1/Yii2.0
 $yii=dirname(__FILE__).'/protected/components/Yii.php';

--- a/ops/packaging/Production-Dockerfile
+++ b/ops/packaging/Production-Dockerfile
@@ -207,7 +207,6 @@ COPY ./sql /var/www/sql/
 COPY ./index.php /var/www/index.php
 COPY fuw/app/common/models/Upload.php /app/common/models/
 COPY fuw/app/backend/models/FiledropAccount.php /app/backend/models/
-COPY ./VERSION /var/www/
 
 ARG TARGET_PHP_VERSION=7.0
 COPY ops/configuration/php-conf/php-production.ini /usr/local/etc/php/php.ini

--- a/ops/packaging/Production-Dockerfile
+++ b/ops/packaging/Production-Dockerfile
@@ -207,6 +207,7 @@ COPY ./sql /var/www/sql/
 COPY ./index.php /var/www/index.php
 COPY fuw/app/common/models/Upload.php /app/common/models/
 COPY fuw/app/backend/models/FiledropAccount.php /app/backend/models/
+COPY ./VERSION /var/www/
 
 ARG TARGET_PHP_VERSION=7.0
 COPY ops/configuration/php-conf/php-production.ini /usr/local/etc/php/php.ini

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -164,7 +164,6 @@ b_gigadb:
     - time docker-compose run --rm config
     - time docker-compose run --rm application composer install -a --no-dev
     - docker-compose run --rm less
-    - git describe --always > VERSION
 #    - docker-compose run --rm fuw-config
 #    - docker-compose run --rm console bash -c "cd /app && composer install -a --no-dev"
 #    - docker-compose run --rm console bash -c 'cd /gigadb-apps/worker/file-worker/ && composer install -a --no-dev'

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -164,6 +164,7 @@ b_gigadb:
     - time docker-compose run --rm config
     - time docker-compose run --rm application composer install -a --no-dev
     - docker-compose run --rm less
+    - git describe --always > VERSION
 #    - docker-compose run --rm fuw-config
 #    - docker-compose run --rm console bash -c "cd /app && composer install -a --no-dev"
 #    - docker-compose run --rm console bash -c 'cd /gigadb-apps/worker/file-worker/ && composer install -a --no-dev'

--- a/protected/components/DatasetPageAssembly.php
+++ b/protected/components/DatasetPageAssembly.php
@@ -55,7 +55,7 @@ class DatasetPageAssembly extends yii\base\Component
      * @param Dataset $d Dataset instance to pass to the instanciated Page assembly
      * @param CApplication $app Yii web application from which to access cache and database
      * @param FileUploadService $srv GigaDB client to File Upload Wizard API
-     * @param ?array $config Additional options to configure teh assembly (only 'skip_cache' for now)
+     * @param ?array $config Additional options to configure the assembly (only 'skip_cache' for now)
      * @return DatasetPageAssembly  a new instance of DatasetAssembly
      */
     public static function assemble(Dataset $d, CApplication $app, FileUploadService $srv, array $config = null): DatasetPageAssembly

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -349,7 +349,7 @@ class AdminDatasetController extends Controller
 
                 // retrieve existing redirect
                 $criteria = new CDbCriteria(array('order'=>'id ASC'));
-                $urlToRedirectAttr = Attribute::model()->findByAttributes(array('attribute_name'=>'urltoredirect'));
+                $urlToRedirectAttr = Attributes::model()->findByAttributes(array('attribute_name'=>'urltoredirect'));
                 $urlToRedirectDatasetAttribute = datasetAttributes::model()->findByAttributes(array('dataset_id'=>$id,'attribute_id'=>$urlToRedirectAttr->id), $criteria);
 
                 // saving url to redirect as a dataset attribute

--- a/protected/controllers/AdminDatasetSampleController.php
+++ b/protected/controllers/AdminDatasetSampleController.php
@@ -472,10 +472,10 @@ class AdminDatasetSampleController extends Controller
                 }
 
                 // try to find attribute, if not found, create a new one
-               $attr = Attribute::model()->findByAttributes(array('attribute_name'=>$_POST['attr_id']));
+               $attr = Attributes::model()->findByAttributes(array('attribute_name'=>$_POST['attr_id']));
                if(!$attr) {
                     #create new attribute
-                    $attr = new Attribute;
+                    $attr = new Attributes;
                     $attr->attribute_name = $_POST['attr_id'];
                     $attr->save(false);
                }
@@ -529,7 +529,7 @@ class AdminDatasetSampleController extends Controller
             if (isset($_GET['term'])) {
                 $criteria = new CDbCriteria;
                 $criteria->addSearchCondition('attribute_name', $_GET['term']);
-                $attrs = Attribute::model()->findAll($criteria);
+                $attrs = Attributes::model()->findAll($criteria);
                 
                 foreach($attrs as $attr) {
                     $result[$attr->attribute_name] = $attr->attribute_name;

--- a/protected/controllers/AdminFileController.php
+++ b/protected/controllers/AdminFileController.php
@@ -885,7 +885,7 @@ EO_MAIL;
             $criteria->addCondition('file_id = ' . $file->id);
             $fileAttributes = FileAttributes::model()->findAll($criteria);
             foreach ($fileAttributes as $fileAttribute) {
-                if (strpos(Attribute::AUTO_ATTRIBUTE, $fileAttribute->attribute->structured_comment_name)) {
+                if (strpos(Attributes::AUTO_ATTRIBUTE, $fileAttribute->attribute->structured_comment_name)) {
                     $fileAttribute->delete();
                 }
             }
@@ -910,14 +910,14 @@ EO_MAIL;
                 
                 // Number of Amino Acids
                 $numberAminoAcids = clone $fileAttribute;
-                $attribute = Attribute::model()->findByAttributes(array('structured_comment_name' => 'num_amino_acids'));
+                $attribute = Attributes::model()->findByAttributes(array('structured_comment_name' => 'num_amino_acids'));
                 $numberAminoAcids->attribute_id = $attribute->id;
                 $numberAminoAcids->value = $aminoAcids;
                 $numberAminoAcids->save();
 
                 // Number of nucleotides
                 $numberNucleotides = clone $fileAttribute;
-                $attribute = Attribute::model()->findByAttributes(array('structured_comment_name' => 'num_nucleotides'));
+                $attribute = Attributes::model()->findByAttributes(array('structured_comment_name' => 'num_nucleotides'));
                 $numberNucleotides->value = $nucleotides;
                 $numberNucleotides->attribute_id = $attribute->id;
                 $numberNucleotides->save();
@@ -958,14 +958,14 @@ EO_MAIL;
 
                 // Number of words
                 $numberWords = clone $fileAttribute;
-                $attribute = Attribute::model()->findByAttributes(array('structured_comment_name' => 'num_words'));
+                $attribute = Attributes::model()->findByAttributes(array('structured_comment_name' => 'num_words'));
                 $numberWords->attribute_id = $attribute->id;
                 $numberWords->value = $numberOfWords;
                 $numberWords->save();
 
                 // Number of lines
                 $numberLines = clone $fileAttribute;
-                $attribute = Attribute::model()->findByAttributes(array('structured_comment_name' => 'num_lines'));
+                $attribute = Attributes::model()->findByAttributes(array('structured_comment_name' => 'num_lines'));
                 $numberLines->attribute_id = $attribute->id;
                 $numberLines->value = $numberOfLines;
                 $numberLines->save();
@@ -999,14 +999,14 @@ EO_MAIL;
                 }
                 // Number of rows
                 $numberRows = clone $fileAttribute;
-                $attribute = Attribute::model()->findByAttributes(array('structured_comment_name' => 'num_rows'));
+                $attribute = Attributes::model()->findByAttributes(array('structured_comment_name' => 'num_rows'));
                 $numberRows->attribute_id = $attribute->id;
                 $numberRows->value = $rows;
                 $numberRows->save();
 
                 // Number of columns
                 $numberColumns = clone $fileAttribute;
-                $attribute = Attribute::model()->findByAttributes(array('structured_comment_name' => 'num_columns'));
+                $attribute = Attributes::model()->findByAttributes(array('structured_comment_name' => 'num_columns'));
                 $numberColumns->value = $columns;
                 $numberColumns->attribute_id = $attribute->id;
                 $numberColumns->save();

--- a/protected/controllers/AdminSampleController.php
+++ b/protected/controllers/AdminSampleController.php
@@ -340,7 +340,7 @@ class AdminSampleController extends Controller
                 $attributeData = explode('=', $attributes);
                 if (count($attributeData) == 2) {
                     // Get attribute model
-                    $attribute = Attribute::model()->findByAttributes(array('structured_comment_name' => trim($attributeData[0])));
+                    $attribute = Attributes::model()->findByAttributes(array('structured_comment_name' => trim($attributeData[0])));
                     if (!$attribute) {
                         $model->addError('error', 'Attribute name for the input ' . $attributeData[0] . "=" . $attributeData[1] . ' is not valid - please select a valid attribute name!');
                     } else {

--- a/protected/controllers/AttributeController.php
+++ b/protected/controllers/AttributeController.php
@@ -58,14 +58,14 @@ class AttributeController extends Controller
 	 */
 	public function actionCreate()
 	{
-		$model=new Attribute;
+		$model=new Attributes;
 
 		// Uncomment the following line if AJAX validation is needed
 		// $this->performAjaxValidation($model);
 
-		if(isset($_POST['Attribute']))
+		if(isset($_POST['Attributes']))
 		{
-			$model->attributes=$_POST['Attribute'];
+			$model->attributes=$_POST['Attributes'];
 			if($model->save())
 				$this->redirect(array('view','id'=>$model->id));
 		}
@@ -86,9 +86,9 @@ class AttributeController extends Controller
 		// Uncomment the following line if AJAX validation is needed
 		// $this->performAjaxValidation($model);
 
-		if(isset($_POST['Attribute']))
+		if(isset($_POST['Attributes']))
 		{
-			$model->attributes=$_POST['Attribute'];
+			$model->attributes=$_POST['Attributes'];
 			if($model->save())
 				$this->redirect(array('view','id'=>$model->id));
 		}
@@ -122,7 +122,7 @@ class AttributeController extends Controller
 	 */
 	public function actionIndex()
 	{
-		$dataProvider=new CActiveDataProvider('Attribute');
+		$dataProvider=new CActiveDataProvider('Attributes');
 		$this->render('index',array(
 			'dataProvider'=>$dataProvider,
 		));
@@ -133,10 +133,10 @@ class AttributeController extends Controller
 	 */
 	public function actionAdmin()
 	{
-		$model=new Attribute('search');
+		$model=new Attributes('search');
 		$model->unsetAttributes();  // clear any default values
-		if(isset($_GET['Attribute']))
-			$model->setAttributes($_GET['Attribute']);
+		if(isset($_GET['Attributes']))
+			$model->setAttributes($_GET['Attributes']);
 
 		$this->render('admin',array(
 			'model'=>$model,
@@ -152,7 +152,7 @@ class AttributeController extends Controller
 		if($this->_model===null)
 		{
 			if(isset($_GET['id']))
-				$this->_model=Attribute::model()->findbyPk($_GET['id']);
+				$this->_model=Attributes::model()->findbyPk($_GET['id']);
 			if($this->_model===null)
 				throw new CHttpException(404,'The requested page does not exist.');
 		}

--- a/protected/controllers/DatasetController.php
+++ b/protected/controllers/DatasetController.php
@@ -88,8 +88,12 @@ class DatasetController extends Controller
         }
 
         // Assembling page components and page settings
+        $assemblyConfig = [];
         if ("invalid" !== $datasetPageSettings->getPageType()) {
-            $assembly = DatasetPageAssembly::assemble($model, Yii::app(), $srv);
+            if (preg_match("/dataset\/$id\/token/",$_SERVER['REQUEST_URI'])) {
+                $assemblyConfig = ['skip_cache' => true] ;
+            }
+            $assembly = DatasetPageAssembly::assemble($model, Yii::app(), $srv, $assemblyConfig);
             $assembly->setDatasetSubmitter()
                 ->setDatasetAccessions()
                 ->setDatasetMainSection()

--- a/protected/controllers/DatasetSubmissionController.php
+++ b/protected/controllers/DatasetSubmissionController.php
@@ -791,13 +791,13 @@ EO_MAIL;
             }
 
             # load attributes
-            $keywordsAttr = Attribute::model()->findByAttributes(array('attribute_name'=>'PX_keywords'));
-            $sppAttr = Attribute::model()->findByAttributes(array('attribute_name'=>'PX_sample_processing_protocol'));
-            $dppAttr = Attribute::model()->findByAttributes(array('attribute_name'=>'PX_data_processing_protocol'));
-            $expTypeAttr = Attribute::model()->findByAttributes(array('attribute_name'=>'PX_experiment_type'));
-            $instrumentAttr = Attribute::model()->findByAttributes(array('attribute_name'=>'PX_instrument'));
-            $quantificationAttr = Attribute::model()->findByAttributes(array('attribute_name'=>'PX_quantification'));
-            $modificationAttr = Attribute::model()->findByAttributes(array('attribute_name'=>'PX_modification'));
+            $keywordsAttr = Attributes::model()->findByAttributes(array('attribute_name'=>'PX_keywords'));
+            $sppAttr = Attributes::model()->findByAttributes(array('attribute_name'=>'PX_sample_processing_protocol'));
+            $dppAttr = Attributes::model()->findByAttributes(array('attribute_name'=>'PX_data_processing_protocol'));
+            $expTypeAttr = Attributes::model()->findByAttributes(array('attribute_name'=>'PX_experiment_type'));
+            $instrumentAttr = Attributes::model()->findByAttributes(array('attribute_name'=>'PX_instrument'));
+            $quantificationAttr = Attributes::model()->findByAttributes(array('attribute_name'=>'PX_quantification'));
+            $modificationAttr = Attributes::model()->findByAttributes(array('attribute_name'=>'PX_modification'));
 
             if (!$keywordsAttr or !$sppAttr or !$dppAttr or !$expTypeAttr or !$instrumentAttr or !$quantificationAttr or !$modificationAttr) {
                 Yii::app()->user->setFlash('keyword', "Attr cannot be found.");

--- a/protected/controllers/PolicyController.php
+++ b/protected/controllers/PolicyController.php
@@ -34,10 +34,10 @@ class PolicyController extends CController {
 
 	public function actionCreate() {
 		$model = new DatasetAttributes;
-		$att = Attribute::model()->findByAttributes(array('attribute_name'=> Attribute::FUP));
+		$att = Attributes::model()->findByAttributes(array('attribute_name'=> Attributes::FUP));
 		if(!$att) {
-			$att = new Attribute;
-			$att->attribute_name = Attribute::FUP;
+			$att = new Attributes;
+			$att->attribute_name = Attributes::FUP;
 			$att->definition = '';
 			$att->save();
 		}

--- a/protected/models/Attributes.php
+++ b/protected/models/Attributes.php
@@ -15,13 +15,13 @@
  * @property string $ontology_link
  * @property string $note
  */
-class Attribute extends CActiveRecord
+class Attributes extends CActiveRecord
 {
     const FUP = 'Fairly Use Policy';
         const AUTO_ATTRIBUTE = "'file_size', 'num_amino_acids', 'num_nucleotides', 'num_words', 'num_lines', 'num_rows', 'num_columns'";
     /**
      * Returns the static model of the specified AR class.
-     * @return Attribute the static model class
+     * @return Attributes the static model class
      */
     public static function model($className = __CLASS__)
     {
@@ -121,7 +121,7 @@ class Attribute extends CActiveRecord
 
         $criteria->compare('note', $this->note, true);
 
-        return new CActiveDataProvider('Attribute', array(
+        return new CActiveDataProvider('Attributes', array(
             'criteria' => $criteria,
         ));
     }

--- a/protected/models/Dataset.php
+++ b/protected/models/Dataset.php
@@ -137,12 +137,12 @@ class Dataset extends CActiveRecord
             'funders' =>array(self::HAS_MANY, 'Funder', 'dataset_funder(dataset_id, funder_id)'),
             'datasetLogs'=>array(self::HAS_MANY, 'DatasetLog', 'dataset_id'),
             'datasetAttributes' => array(self::HAS_MANY, 'DatasetAttributes', 'dataset_id'),
-            'attributes' => array(self::MANY_MANY, 'Attribute', 'dataset_attributes(dataset_id, attribute_id)'),
+            'attributes' => array(self::MANY_MANY, 'Attributes', 'dataset_attributes(dataset_id, attribute_id)'),
         );
     }
 
     public function getPolicy() {
-        $att = Attribute::model()->findByAttributes(array('attribute_name'=>Attribute::FUP));
+        $att = Attributes::model()->findByAttributes(array('attribute_name'=>Attributes::FUP));
         if(!$att)
             return null;
         return DatasetAttributes::model()->findByAttributes(array('dataset_id'=>$this->id, 'attribute_id'=>$att->id));
@@ -429,7 +429,7 @@ class Dataset extends CActiveRecord
     }
 
     public function getSemanticKeywords() {
-        $sKeywordAttr = Attribute::model()->findByAttributes(array('attribute_name'=>'keyword'));
+        $sKeywordAttr = Attributes::model()->findByAttributes(array('attribute_name'=>'keyword'));
 
         $sk = DatasetAttributes::model()->findAllByAttributes(array('dataset_id'=>$this->id,'attribute_id'=>$sKeywordAttr->id));
 
@@ -445,7 +445,7 @@ class Dataset extends CActiveRecord
 
         $criteria = new CDbCriteria(array('order'=>'id ASC'));
 
-        $urlToRedirectAttr = Attribute::model()->findByAttributes(array('attribute_name'=>'urltoredirect'));
+        $urlToRedirectAttr = Attributes::model()->findByAttributes(array('attribute_name'=>'urltoredirect'));
 
         $urlToRedirectDatasetAttribute = DatasetAttributes::model()->findByAttributes(array('dataset_id'=>$this->id,'attribute_id'=>$urlToRedirectAttr->id), $criteria);
 

--- a/protected/models/DatasetAttributes.php
+++ b/protected/models/DatasetAttributes.php
@@ -11,7 +11,7 @@
  * @property string $units_id
  *
  * The followings are the available model relations:
- * @property Attribute $attribute
+ * @property Attributes $attribute
  * @property Dataset $dataset
  * @property Unit $units
  * @property integer $image_id
@@ -65,7 +65,7 @@ class DatasetAttributes extends CActiveRecord
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
         return array(
-            'attribute' => array(self::BELONGS_TO, 'Attribute', 'attribute_id'),
+            'attribute' => array(self::BELONGS_TO, 'Attributes', 'attribute_id'),
             'dataset' => array(self::BELONGS_TO, 'Dataset', 'dataset_id'),
             'units' => array(self::BELONGS_TO, 'Unit', 'units_id'),
             'image' => array(self::BELONGS_TO, 'Images', 'image_id'),
@@ -80,7 +80,7 @@ class DatasetAttributes extends CActiveRecord
         return array(
             'id' => 'ID',
             'dataset_id' => 'Dataset',
-            'attribute_id' => 'Attribute',
+            'attribute_id' => 'Attributes',
             'value' => 'Value',
             'units_id' => 'Units',
             'image_id' => 'Image',

--- a/protected/models/DatasetDAO.php
+++ b/protected/models/DatasetDAO.php
@@ -6,7 +6,7 @@
  *
  * @uses DatasetAttributesFactory.php
  * @uses DatasetAttributes.php
- * @uses Attribute.php
+ * @uses Attributes.php
  *
  * @author Rija Menage <rija+git@cinecinetique.com>
  * @license GPL-3.0
@@ -62,7 +62,7 @@ class DatasetDAO extends yii\base\BaseObject
 	 */
 	public function removeKeywordsFromDatabaseForDatasetId($dataset_id)
 	{
-		$keyword_attribute = Attribute::model()->findByAttributes(array('attribute_name'=>'keyword'));
+		$keyword_attribute = Attributes::model()->findByAttributes(array('attribute_name'=>'keyword'));
 
 		$datasetAttributes = DatasetAttributes::model()->findAllByAttributes(
 								array('dataset_id'=>$dataset_id,'attribute_id'=>$keyword_attribute->id)
@@ -82,7 +82,7 @@ class DatasetDAO extends yii\base\BaseObject
 	 */
 	public function addKeywordsToDatabaseForDatasetIdAndString($dataset_id, $post_keywords_string)
 	{
-		$keyword_attribute = Attribute::model()->findByAttributes(array('attribute_name'=>'keyword'));
+		$keyword_attribute = Attributes::model()->findByAttributes(array('attribute_name'=>'keyword'));
 		$keywords_array = array_filter(explode(',', $post_keywords_string));
 
 		foreach ($keywords_array as $keyword) {

--- a/protected/models/ExpAttributes.php
+++ b/protected/models/ExpAttributes.php
@@ -11,7 +11,7 @@
  * @property string $units_id
  *
  * The followings are the available model relations:
- * @property Attribute $attribute
+ * @property Attributes $attribute
  * @property Experiment $exp
  * @property Unit $units
  */
@@ -60,7 +60,7 @@ class ExpAttributes extends CActiveRecord
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
         return array(
-            'attribute' => array(self::BELONGS_TO, 'Attribute', 'attribute_id'),
+            'attribute' => array(self::BELONGS_TO, 'Attributes', 'attribute_id'),
             'exp' => array(self::BELONGS_TO, 'Experiment', 'exp_id'),
             'units' => array(self::BELONGS_TO, 'Unit', 'units_id'),
         );
@@ -74,7 +74,7 @@ class ExpAttributes extends CActiveRecord
         return array(
             'id' => 'ID',
             'exp_id' => 'Exp',
-            'attribute_id' => 'Attribute',
+            'attribute_id' => 'Attributes',
             'value' => 'Value',
             'units_id' => 'Units',
         );

--- a/protected/models/FileAttributes.php
+++ b/protected/models/FileAttributes.php
@@ -11,7 +11,7 @@
  * @property string $unit_id
  *
  * The followings are the available model relations:
- * @property Attribute $attribute
+ * @property Attributes $attribute
  * @property File $file
  * @property Unit $unit
  */
@@ -62,7 +62,7 @@ class FileAttributes extends CActiveRecord
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
         return array(
-            'attribute' => array(self::BELONGS_TO, 'Attribute', 'attribute_id'),
+            'attribute' => array(self::BELONGS_TO, 'Attributes', 'attribute_id'),
             'file' => array(self::BELONGS_TO, 'File', 'file_id'),
             'unit' => array(self::BELONGS_TO, 'Unit', 'unit_id'),
         );
@@ -76,7 +76,7 @@ class FileAttributes extends CActiveRecord
         return array(
             'id' => 'ID',
             'file_id' => 'File',
-            'attribute_id' => 'Attribute',
+            'attribute_id' => 'Attributes',
             'value' => 'Value',
             'unit_id' => 'Unit',
         );

--- a/protected/models/Sample.php
+++ b/protected/models/Sample.php
@@ -88,7 +88,7 @@ class Sample extends CActiveRecord
             'datasetSamples' => array(self::HAS_MANY, 'DatasetSample', 'sample_id'),
             'datasets' => array(self::MANY_MANY, 'Dataset', 'dataset_sample(dataset_id,sample_id)'),
             'sampleAttributes' => array(self::HAS_MANY, 'SampleAttribute', 'sample_id', 'order' => 'id asc'),
-            'attributes' => array(self::HAS_MANY, 'Attribute', array('id' => 'attribute_id'), 'through' => 'sampleAttributes'),
+            'attributes' => array(self::HAS_MANY, 'Attributes', array('id' => 'attribute_id'), 'through' => 'sampleAttributes'),
             'alternativeIdentifiers' => array(self::HAS_MANY, 'AlternativeIdentifiers', 'sample_id'),
         );
     }

--- a/protected/models/SampleAttribute.php
+++ b/protected/models/SampleAttribute.php
@@ -59,7 +59,7 @@ class SampleAttribute extends CActiveRecord
      */
     public function validateAttributeId($attribute, $param)
     {
-        $attributeModel = Attribute::model()->findByPk($this->attribute_id);
+        $attributeModel = Attributes::model()->findByPk($this->attribute_id);
         if ($attributeModel === null) {
             $this->addError('attribute_id', 'The specified attribute id does not exist in the Attribute table.');
         }
@@ -88,7 +88,7 @@ class SampleAttribute extends CActiveRecord
 		// NOTE: you may need to adjust the relation name and the related
 		// class name for the relations automatically generated below.
 		return array(
-			'attribute' => array(self::BELONGS_TO, 'Attribute', 'attribute_id'),
+			'attribute' => array(self::BELONGS_TO, 'Attributes', 'attribute_id'),
 			'sample' => array(self::BELONGS_TO, 'Sample', 'sample_id'),
 			'unit' => array(self::BELONGS_TO, 'Unit', 'unit_id'),
 		);
@@ -102,7 +102,7 @@ class SampleAttribute extends CActiveRecord
 		return array(
 			'id' => 'Id',
 			'sample_id' => 'Sample',
-			'attribute_id' => 'Attribute',
+			'attribute_id' => 'Attributes',
 			'value' => 'Value',
 			'unit_id' => 'Unit',
 		);

--- a/protected/views/adminFile/_attr.php
+++ b/protected/views/adminFile/_attr.php
@@ -1,7 +1,7 @@
 <!--TODO: Adding 'style'=>'width: 100%;' to each div is just a temp styling fix, need further investigation on how to implement CSS styling properly.-->
 <td>
 	<?php echo CHtml::activeHiddenField($attribute, 'id') ?>
-	<?php echo CHtml::activeDropDownList($attribute, 'attribute_id',CHtml::listData(Attribute::model()->findAll(),'id','attribute_name'), array('class'=>'attr-form', 'style'=>'width: 100%;', 'empty'=>'Select name')); ?>
+	<?php echo CHtml::activeDropDownList($attribute, 'attribute_id',CHtml::listData(Attributes::model()->findAll(),'id','attribute_name'), array('class'=>'attr-form', 'style'=>'width: 100%;', 'empty'=>'Select name')); ?>
 </td>
 <td>
 	<?php echo CHtml::activeTextField($attribute, 'value',array('class'=>'attr-form', 'style'=>'width: 100%;'));?>

--- a/protected/views/adminFile/_form.php
+++ b/protected/views/adminFile/_form.php
@@ -85,7 +85,7 @@
             <a href="#" role="button" class="btn btn-attr">New Attribute</a>
             <br/>
             <div class="js-new-attr" style="display:none;margin-top: 10px">
-                <?php echo CHtml::activeDropDownList($attribute, 'attribute_id',CHtml::listData(Attribute::model()->findAll(),'id','attribute_name'), array('class'=>'attr-form', 'empty'=>'Select name')); ?>
+                <?php echo CHtml::activeDropDownList($attribute, 'attribute_id',CHtml::listData(Attributes::model()->findAll(),'id','attribute_name'), array('class'=>'attr-form', 'empty'=>'Select name')); ?>
                 <?php echo $form->textField($attribute, 'value',array('class'=>'attr-form'));?>
                 <?php echo CHtml::activeDropDownList($attribute, 'unit_id',CHtml::listData(Unit::model()->findAll(),'id','name'), array('class'=>'attr-form', 'empty'=>'Select unit')); ?>
                 <input type="submit" class="btn" name="submit_attr" value="Add" />

--- a/protected/views/api/dump.php
+++ b/protected/views/api/dump.php
@@ -154,7 +154,7 @@ foreach($dataset_attributes as $dataset_attribute)
 {
     if(isset($dataset_attribute->value) && $dataset_attribute->value!=""){
     $xml.="<attribute>";
-    $datasetattribute=Attribute::model()->findByAttributes(array('id'=>$dataset_attribute->attribute_id));
+    $datasetattribute=Attributes::model()->findByAttributes(array('id'=>$dataset_attribute->attribute_id));
     if(isset($datasetattribute)){
     $xml.="<key>$datasetattribute->attribute_name</key>";
     }else{
@@ -208,7 +208,7 @@ foreach($samples as $sample){
     $xml.="<sample_attributes>";
     $sa_attributes=  SampleAttribute::model()->findAllByAttributes(array('sample_id'=>$sample->id));
     foreach($sa_attributes as $sa_attribute){
-        $saattribute=  Attribute::model()->findByAttributes(array('id'=>$sa_attribute->attribute_id));
+        $saattribute=  Attributes::model()->findByAttributes(array('id'=>$sa_attribute->attribute_id));
         $xml.="<attribute>";
         $xml.="<key>$saattribute->attribute_name</key>";
         $xml.="<value>$sa_attribute->value</value>";
@@ -261,7 +261,7 @@ $xml.="<file_attributes>";
 $fileattributes=$file->fileAttributes;
 foreach($fileattributes as $fileattribute){
     $xml.="<attribute>";
-    $file_att=  Attribute::model()->findByAttributes(array('id'=>$fileattribute->attribute_id));
+    $file_att=  Attributes::model()->findByAttributes(array('id'=>$fileattribute->attribute_id));
     $xml.="<key>$file_att->name</key>";
     $xml.="<value>$fileattribute->value</value>";
     $file_unit=  Unit::model()->findByAttributes(array('id'=>$fileattribute->unit_id));

--- a/protected/views/api/keyword.php
+++ b/protected/views/api/keyword.php
@@ -168,7 +168,7 @@ foreach($dataset_attributes as $dataset_attribute)
 {
     if(isset($dataset_attribute->value) && $dataset_attribute->value!=""){
     $xml.="<attribute>";
-    $datasetattribute=Attribute::model()->findByAttributes(array('id'=>$dataset_attribute->attribute_id));
+    $datasetattribute=Attributes::model()->findByAttributes(array('id'=>$dataset_attribute->attribute_id));
     if(isset($datasetattribute)){
     $xml.="<key>$datasetattribute->attribute_name</key>";
     }else{
@@ -231,7 +231,7 @@ if($datasetid1 == $datasetid)
     $xml.="<sample_attributes>";
     $sa_attributes=  SampleAttribute::model()->findAllByAttributes(array('sample_id'=>$sample->id));
     foreach($sa_attributes as $sa_attribute){
-        $saattribute=  Attribute::model()->findByAttributes(array('id'=>$sa_attribute->attribute_id));
+        $saattribute=  Attributes::model()->findByAttributes(array('id'=>$sa_attribute->attribute_id));
         $xml.="<attribute>";
         $xml.="<key>$saattribute->attribute_name</key>";
         $xml.="<value>$sa_attribute->value</value>";
@@ -283,7 +283,7 @@ $xml.="<file_attributes>";
 $fileattributes=$file->fileAttributes;
 foreach($fileattributes as $fileattribute){
     $xml.="<attribute id=\"$fileattribute->id\">";
-    $file_att=  Attribute::model()->findByAttributes(array('id'=>$fileattribute->attribute_id));
+    $file_att=  Attributes::model()->findByAttributes(array('id'=>$fileattribute->attribute_id));
     $xml.="<key>$file_att->attribute_name</key>";
     $xml.="<value>$fileattribute->value</value>";
     $file_unit=  Unit::model()->findByAttributes(array('id'=>$fileattribute->unit_id));
@@ -352,7 +352,7 @@ foreach($sample->datasets as $dataset)
     $xml.="<sample_attributes>";
     $sa_attributes=  SampleAttribute::model()->findAllByAttributes(array('sample_id'=>$sample->id));
     foreach($sa_attributes as $sa_attribute){
-        $saattribute=  Attribute::model()->findByAttributes(array('id'=>$sa_attribute->attribute_id));
+        $saattribute=  Attributes::model()->findByAttributes(array('id'=>$sa_attribute->attribute_id));
         $xml.="<attribute>";
         $xml.="<key>$saattribute->attribute_name</key>";
         $xml.="<value>$sa_attribute->value</value>";
@@ -402,7 +402,7 @@ $xml.="<file_attributes>";
 $fileattributes=$file->fileAttributes;
 foreach($fileattributes as $fileattribute){
     $xml.="<attribute id=\"$fileattribute->id\">";
-    $file_att=  Attribute::model()->findByAttributes(array('id'=>$fileattribute->attribute_id));
+    $file_att=  Attributes::model()->findByAttributes(array('id'=>$fileattribute->attribute_id));
     $xml.="<key id=\"$file_att->id\">$file_att->name</key>";
     $xml.="<value>$fileattribute->value</value>";
     $file_unit=  Unit::model()->findByAttributes(array('id'=>$fileattribute->unit_id));

--- a/protected/views/api/keywordalldataset.php
+++ b/protected/views/api/keywordalldataset.php
@@ -166,7 +166,7 @@ foreach($dataset_attributes as $dataset_attribute)
 {
     if(isset($dataset_attribute->value) && $dataset_attribute->value!=""){
     $xml.="<attribute>";
-    $datasetattribute=Attribute::model()->findByAttributes(array('id'=>$dataset_attribute->attribute_id));
+    $datasetattribute=Attributes::model()->findByAttributes(array('id'=>$dataset_attribute->attribute_id));
     if(isset($datasetattribute)){
     $xml.="<key>$datasetattribute->attribute_name</key>";
     }else{

--- a/protected/views/api/keywordallfile.php
+++ b/protected/views/api/keywordallfile.php
@@ -35,7 +35,7 @@ $xml.="<file_attributes>";
 $fileattributes=$file->fileAttributes;
 foreach($fileattributes as $fileattribute){
     $xml.="<attribute id=\"$fileattribute->id\">";
-    $file_att=  Attribute::model()->findByAttributes(array('id'=>$fileattribute->attribute_id));
+    $file_att=  Attributes::model()->findByAttributes(array('id'=>$fileattribute->attribute_id));
     $xml.="<key>$file_att->attribute_name</key>";
     $xml.="<value>$fileattribute->value</value>";
     $file_unit=  Unit::model()->findByAttributes(array('id'=>$fileattribute->unit_id));

--- a/protected/views/api/keywordallsample.php
+++ b/protected/views/api/keywordallsample.php
@@ -42,7 +42,7 @@ foreach($sample->datasets as $dataset)
     $xml.="<sample_attributes>";
     $sa_attributes=  SampleAttribute::model()->findAllByAttributes(array('sample_id'=>$sample->id));
     foreach($sa_attributes as $sa_attribute){
-        $saattribute=  Attribute::model()->findByAttributes(array('id'=>$sa_attribute->attribute_id));
+        $saattribute=  Attributes::model()->findByAttributes(array('id'=>$sa_attribute->attribute_id));
         $xml.="<attribute>";
         $xml.="<key>$saattribute->attribute_name</key>";
         $xml.="<value>$sa_attribute->value</value>";

--- a/protected/views/api/keyworddataset.php
+++ b/protected/views/api/keyworddataset.php
@@ -166,7 +166,7 @@ foreach($dataset_attributes as $dataset_attribute)
 {
     if(isset($dataset_attribute->value) && $dataset_attribute->value!=""){
     $xml.="<attribute>";
-    $datasetattribute=Attribute::model()->findByAttributes(array('id'=>$dataset_attribute->attribute_id));
+    $datasetattribute=Attributes::model()->findByAttributes(array('id'=>$dataset_attribute->attribute_id));
     if(isset($datasetattribute)){
     $xml.="<key>$datasetattribute->attribute_name</key>";
     }else{

--- a/protected/views/api/keywordfile.php
+++ b/protected/views/api/keywordfile.php
@@ -37,7 +37,7 @@ $xml.="<file_attributes>";
 $fileattributes=$file->fileAttributes;
 foreach($fileattributes as $fileattribute){
     $xml.="<attribute id=\"$fileattribute->id\">";
-    $file_att=  Attribute::model()->findByAttributes(array('id'=>$fileattribute->attribute_id));
+    $file_att=  Attributes::model()->findByAttributes(array('id'=>$fileattribute->attribute_id));
     $xml.="<key id=\"$file_att->id\">$file_att->attribute_name</key>";
     $xml.="<value>$fileattribute->value</value>";
     $file_unit=  Unit::model()->findByAttributes(array('id'=>$fileattribute->unit_id));

--- a/protected/views/api/keywordsample.php
+++ b/protected/views/api/keywordsample.php
@@ -38,7 +38,7 @@ foreach($samples as $sample){
     $xml.="<sample_attributes>";
     $sa_attributes=  SampleAttribute::model()->findAllByAttributes(array('sample_id'=>$sample->id));
     foreach($sa_attributes as $sa_attribute){
-        $saattribute=  Attribute::model()->findByAttributes(array('id'=>$sa_attribute->attribute_id));
+        $saattribute=  Attributes::model()->findByAttributes(array('id'=>$sa_attribute->attribute_id));
         $xml.="<attribute>";
         $xml.="<key>$saattribute->attribute_name</key>";
         $xml.="<value>$sa_attribute->value</value>";

--- a/protected/views/api/singledataset.php
+++ b/protected/views/api/singledataset.php
@@ -162,7 +162,7 @@ foreach($dataset_attributes as $dataset_attribute)
 {
     if(isset($dataset_attribute->value) && $dataset_attribute->value!=""){
     $xml.="   <attribute>\n";
-    $datasetattribute=Attribute::model()->findByAttributes(array('id'=>$dataset_attribute->attribute_id));
+    $datasetattribute=Attributes::model()->findByAttributes(array('id'=>$dataset_attribute->attribute_id));
     if(isset($datasetattribute)){
     $xml.="    <key>$datasetattribute->attribute_name</key>\n";
     }else{
@@ -216,7 +216,7 @@ foreach($samples as $sample){
     $xml.="   <sample_attributes>\n";
     $sa_attributes=  SampleAttribute::model()->findAllByAttributes(array('sample_id'=>$sample->id));
     foreach($sa_attributes as $sa_attribute){
-        $saattribute=  Attribute::model()->findByAttributes(array('id'=>$sa_attribute->attribute_id));
+        $saattribute=  Attributes::model()->findByAttributes(array('id'=>$sa_attribute->attribute_id));
         $xml.="    <attribute>\n";
         $xml.="     <key>$saattribute->attribute_name</key>\n";
         $xml.="     <value>$sa_attribute->value</value>\n";
@@ -270,7 +270,7 @@ $xml.="   <file_attributes>\n";
 $fileattributes=$file->fileAttributes;
 foreach($fileattributes as $fileattribute){
     $xml.="   <attribute>\n";
-    $file_att=  Attribute::model()->findByAttributes(array('id'=>$fileattribute->attribute_id));
+    $file_att=  Attributes::model()->findByAttributes(array('id'=>$fileattribute->attribute_id));
     $xml.="    <key>$file_att->attribute_name</key>\n";
     $xml.="    <value>$fileattribute->value</value>\n";
     $file_unit=  Unit::model()->findByAttributes(array('id'=>$fileattribute->unit_id));

--- a/protected/views/api/singledatasetonly.php
+++ b/protected/views/api/singledatasetonly.php
@@ -162,7 +162,7 @@ foreach($dataset_attributes as $dataset_attribute)
 {
     if(isset($dataset_attribute->value) && $dataset_attribute->value!=""){
     $xml.="<attribute>";
-    $datasetattribute=Attribute::model()->findByAttributes(array('id'=>$dataset_attribute->attribute_id));
+    $datasetattribute=Attributes::model()->findByAttributes(array('id'=>$dataset_attribute->attribute_id));
     if(isset($datasetattribute)){
     $xml.="<key>$datasetattribute->attribute_name</key>";
     }else{

--- a/protected/views/api/singlefile.php
+++ b/protected/views/api/singlefile.php
@@ -32,7 +32,7 @@ $xml.="<file_attributes>";
 $fileattributes=$file->fileAttributes;
 foreach($fileattributes as $fileattribute){
     $xml.="<attribute>";
-    $file_att=  Attribute::model()->findByAttributes(array('id'=>$fileattribute->attribute_id));
+    $file_att=  Attributes::model()->findByAttributes(array('id'=>$fileattribute->attribute_id));
     $xml.="<key>$file_att->attribute_name</key>";
     $xml.="<value>$fileattribute->value</value>";
     $file_unit=  Unit::model()->findByAttributes(array('id'=>$fileattribute->unit_id));

--- a/protected/views/api/singlesample.php
+++ b/protected/views/api/singlesample.php
@@ -36,7 +36,7 @@ foreach($samples as $sample){
     $xml.="<sample_attributes>";
     $sa_attributes=  SampleAttribute::model()->findAllByAttributes(array('sample_id'=>$sample->id));
     foreach($sa_attributes as $sa_attribute){
-        $saattribute=  Attribute::model()->findByAttributes(array('id'=>$sa_attribute->attribute_id));
+        $saattribute=  Attributes::model()->findByAttributes(array('id'=>$sa_attribute->attribute_id));
         $xml.="<attribute>";
         $xml.="<key>$saattribute->attribute_name</key>";
         $xml.="<value>$sa_attribute->value</value>";

--- a/tests/_support/Steps/CuratorSteps.php
+++ b/tests/_support/Steps/CuratorSteps.php
@@ -180,9 +180,21 @@ class CuratorSteps extends \Codeception\Actor
             case "dataset metadata":
                 $this->I->updateInDatabase('dataset', ['description' => "lorem ipsum from automated tests"], ['id' => $dataset_id]);
                 break;
+            case "sample metadata":
+                $this->I->updateInDatabase('sample_attribute', ['value' => 'value from automated tests'],['sample_id' => 154,'attribute_id' => 376 ]);
+                break;
             default:
                 throw new \PHPUnit\Framework\IncompleteTestError("Step `I make an update to the non-public dataset :arg1's :arg2 in the admin pages` is not defined");
         }
+    }
+
+    /**
+     * @Given sample :sample_id is associated with dataset :doi
+     */
+    public function sampleIsAssociatedWithDataset($sample_id, $doi)
+    {
+        $dataset_id = $this->I->grabFromDatabase('dataset', 'id', array('identifier' => '200070'));
+        $this->I->haveInDatabase('dataset_sample', ['dataset_id' => $dataset_id,'sample_id' => $sample_id ]);
     }
 
     /**
@@ -193,6 +205,10 @@ class CuratorSteps extends \Codeception\Actor
         switch ($changeType) {
             case "dataset metadata":
                 $this->I->canSee("lorem ipsum from automated tests");
+                break;
+            case "sample metadata":
+                $this->I->cantSee("1.32");
+                $this->I->canSee("value from automated tests");
                 break;
             default:
                 throw new \PHPUnit\Framework\IncompleteTestError("Step `I can see the changes to the :arg1 displayed` is not defined");

--- a/tests/_support/Steps/CuratorSteps.php
+++ b/tests/_support/Steps/CuratorSteps.php
@@ -170,4 +170,20 @@ class CuratorSteps extends \Codeception\Actor
         $this->I->assertRegExp($semVerPattern,$versionText);
      }
 
+    /**
+     * @Given I make an update to the non-public dataset :arg1's :arg2 in the admin pages
+     */
+    public function iMakeAnUpdateToTheNonpublicDatasetsInTheAdminPages($arg1, $arg2)
+    {
+        throw new \PHPUnit\Framework\IncompleteTestError("Step `I make an update to the non-public dataset :arg1's :arg2 in the admin pages` is not defined");
+    }
+
+    /**
+     * @Then I can see the changes to the :arg1 displayed
+     */
+    public function iCanSeeTheChangesToTheDisplayed($arg1)
+    {
+        throw new \PHPUnit\Framework\IncompleteTestError("Step `I can see the changes to the :arg1 displayed` is not defined");
+    }
+
 }

--- a/tests/_support/Steps/CuratorSteps.php
+++ b/tests/_support/Steps/CuratorSteps.php
@@ -186,6 +186,9 @@ class CuratorSteps extends \Codeception\Actor
             case "file metadata":
                 $this->I->updateInDatabase('file', ['description' => 'description from automated tests'],['id' => 95366]);
                 break;
+            case "author metadata":
+                $this->I->haveInDatabase('dataset_author', ['dataset_id' => $dataset_id,'author_id' => 3325, 'rank' => 1]);
+                break;
             default:
                 throw new \PHPUnit\Framework\IncompleteTestError("Step `I make an update to the non-public dataset :arg1's :arg2 in the admin pages` is not defined");
         }
@@ -223,6 +226,9 @@ class CuratorSteps extends \Codeception\Actor
                 break;
             case "file metadata":
                 $this->I->canSee("description from automated tests");
+                break;
+            case "author metadata":
+                $this->I->canSee("Zhang");
                 break;
             default:
                 throw new \PHPUnit\Framework\IncompleteTestError("Step `I can see the changes to the :arg1 displayed` is not defined");

--- a/tests/_support/Steps/CuratorSteps.php
+++ b/tests/_support/Steps/CuratorSteps.php
@@ -183,6 +183,9 @@ class CuratorSteps extends \Codeception\Actor
             case "sample metadata":
                 $this->I->updateInDatabase('sample_attribute', ['value' => 'value from automated tests'],['sample_id' => 154,'attribute_id' => 376 ]);
                 break;
+            case "file metadata":
+                $this->I->updateInDatabase('file', ['description' => 'description from automated tests'],['id' => 95366]);
+                break;
             default:
                 throw new \PHPUnit\Framework\IncompleteTestError("Step `I make an update to the non-public dataset :arg1's :arg2 in the admin pages` is not defined");
         }
@@ -198,6 +201,14 @@ class CuratorSteps extends \Codeception\Actor
     }
 
     /**
+     * @Given file :file_id is associated with dataset :doi
+     */
+    public function fileIsAssociatedWithDataset($file_id, $doi)
+    {
+        $dataset_id = $this->I->grabFromDatabase('dataset', 'id', array('identifier' => '200070'));
+        $this->I->updateInDatabase('file', ['dataset_id' => $dataset_id],['id' => $file_id]);
+    }
+    /**
      * @Then I can see the changes to the :changeType displayed
      */
     public function iCanSeeTheChangesToTheDisplayed($changeType)
@@ -209,6 +220,9 @@ class CuratorSteps extends \Codeception\Actor
             case "sample metadata":
                 $this->I->cantSee("1.32");
                 $this->I->canSee("value from automated tests");
+                break;
+            case "file metadata":
+                $this->I->canSee("description from automated tests");
                 break;
             default:
                 throw new \PHPUnit\Framework\IncompleteTestError("Step `I can see the changes to the :arg1 displayed` is not defined");

--- a/tests/_support/Steps/CuratorSteps.php
+++ b/tests/_support/Steps/CuratorSteps.php
@@ -171,19 +171,33 @@ class CuratorSteps extends \Codeception\Actor
      }
 
     /**
-     * @Given I make an update to the non-public dataset :arg1's :arg2 in the admin pages
+     * @Given I make an update to the non-public dataset :doi's :changeType in the admin pages
      */
-    public function iMakeAnUpdateToTheNonpublicDatasetsInTheAdminPages($arg1, $arg2)
+    public function iMakeAnUpdateToTheNonpublicDatasetsInTheAdminPages($doi, $changeType)
     {
-        throw new \PHPUnit\Framework\IncompleteTestError("Step `I make an update to the non-public dataset :arg1's :arg2 in the admin pages` is not defined");
+        $dataset_id = $this->I->grabFromDatabase('dataset', 'id', array('identifier' => $doi));
+        switch ($changeType) {
+            case "dataset metadata":
+                $this->I->updateInDatabase('dataset', ['description' => "lorem ipsum from automated tests"], ['id' => $dataset_id]);
+                break;
+            default:
+                throw new \PHPUnit\Framework\IncompleteTestError("Step `I make an update to the non-public dataset :arg1's :arg2 in the admin pages` is not defined");
+        }
     }
 
     /**
-     * @Then I can see the changes to the :arg1 displayed
+     * @Then I can see the changes to the :changeType displayed
      */
-    public function iCanSeeTheChangesToTheDisplayed($arg1)
+    public function iCanSeeTheChangesToTheDisplayed($changeType)
     {
-        throw new \PHPUnit\Framework\IncompleteTestError("Step `I can see the changes to the :arg1 displayed` is not defined");
+        switch ($changeType) {
+            case "dataset metadata":
+                $this->I->canSee("lorem ipsum from automated tests");
+                break;
+            default:
+                throw new \PHPUnit\Framework\IncompleteTestError("Step `I can see the changes to the :arg1 displayed` is not defined");
+        }
+
     }
 
 }

--- a/tests/_support/Steps/CuratorSteps.php
+++ b/tests/_support/Steps/CuratorSteps.php
@@ -221,8 +221,8 @@ class CuratorSteps extends \Codeception\Actor
                 $this->I->canSee("lorem ipsum from automated tests");
                 break;
             case "sample metadata":
-                $this->I->cantSee("1.32");
-                $this->I->canSee("value from automated tests");
+                $this->I->cantSeeInSource("1.32");
+                $this->I->canSeeInSource("value from automated tests");
                 break;
             case "file metadata":
                 $this->I->canSee("description from automated tests");

--- a/tests/acceptance/AdminTablesFilter.feature
+++ b/tests/acceptance/AdminTablesFilter.feature
@@ -150,7 +150,7 @@ Feature: filter tables on admin page
   @ok
   Scenario: Attribute
     Given I am on "/attribute/admin"
-    When I fill in the field of "name" "Attribute[attribute_name]" with "location"
+    When I fill in the field of "name" "Attributes[attribute_name]" with "location"
     And I press return on the element "(//input)[2]"
     And I wait "1" seconds
     Then I should see "Geographic"

--- a/tests/acceptance/DatasetMockupPage.feature
+++ b/tests/acceptance/DatasetMockupPage.feature
@@ -1,0 +1,37 @@
+@issue-1528 @wip
+Feature: A curator opens the mockup page
+  As a curator
+  I want to see my changes appear in the pre-publication view of the dataset page
+  So that I can confirm the changes are correct and show the relevant users the private mockup page displaying the correct information
+
+  Background:
+    Given I have signed in as admin
+    And I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
+
+  Scenario: Dataset metadata changes
+    Given I make an update to the non-public dataset "200070"'s "dataset metadata" in the admin pages
+    When I am on "/adminDataset/update/id/668"
+    And I follow "Open Private URL"
+    Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
+    And I can see the changes to the "dataset metadata" displayed
+
+  Scenario: Sample metadata changes
+    Given I make an update to the non-public dataset "200070"'s "sample metadata" in the admin pages
+    When I am on "/adminDataset/update/id/668"
+    And I follow "Open Private URL"
+    Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
+    And I can see the changes to the "sample metadata" displayed
+
+  Scenario: File metadata changes
+    Given I make an update to the non-public dataset "200070"'s "file metadata" in the admin pages
+    When I am on "/adminDataset/update/id/668"
+    And I follow "Open Private URL"
+    Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
+    And I can see the changes to the "file metadata" displayed
+
+  Scenario: Author metadata changes
+    Given I make an update to the non-public dataset "200070"'s "author metadata" in the admin pages
+    When I am on "/adminDataset/update/id/668"
+    And I follow "Open Private URL"
+    Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
+    And I can see the changes to the "author metadata" displayed

--- a/tests/acceptance/DatasetMockupPage.feature
+++ b/tests/acceptance/DatasetMockupPage.feature
@@ -16,7 +16,7 @@ Feature: A curator opens the mockup page
     Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
     And I can see the changes to the "dataset metadata" displayed
 
-  @wip
+
   Scenario: Sample metadata changes
     Given sample "154" is associated with dataset "2000070"
     And I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
@@ -26,8 +26,11 @@ Feature: A curator opens the mockup page
     Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
     And I can see the changes to the "sample metadata" displayed
 
+  @wip
   Scenario: File metadata changes
-    Given I make an update to the non-public dataset "200070"'s "file metadata" in the admin pages
+    Given file "95366" is associated with dataset "2000070"
+    And I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
+    And I make an update to the non-public dataset "200070"'s "file metadata" in the admin pages
     When I am on "/adminDataset/update/id/668"
     And I follow "Open Private URL"
     Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"

--- a/tests/acceptance/DatasetMockupPage.feature
+++ b/tests/acceptance/DatasetMockupPage.feature
@@ -1,4 +1,4 @@
-@issue-1528 @wip
+@issue-1528
 Feature: A curator opens the mockup page
   As a curator
   I want to see my changes appear in the pre-publication view of the dataset page
@@ -8,6 +8,7 @@ Feature: A curator opens the mockup page
     Given I have signed in as admin
     And I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
 
+
   Scenario: Dataset metadata changes
     Given I make an update to the non-public dataset "200070"'s "dataset metadata" in the admin pages
     When I am on "/adminDataset/update/id/668"
@@ -15,8 +16,11 @@ Feature: A curator opens the mockup page
     Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
     And I can see the changes to the "dataset metadata" displayed
 
+  @wip
   Scenario: Sample metadata changes
-    Given I make an update to the non-public dataset "200070"'s "sample metadata" in the admin pages
+    Given sample "154" is associated with dataset "2000070"
+    And I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
+    And I make an update to the non-public dataset "200070"'s "sample metadata" in the admin pages
     When I am on "/adminDataset/update/id/668"
     And I follow "Open Private URL"
     Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"

--- a/tests/acceptance/DatasetMockupPage.feature
+++ b/tests/acceptance/DatasetMockupPage.feature
@@ -26,7 +26,7 @@ Feature: A curator opens the mockup page
     Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
     And I can see the changes to the "sample metadata" displayed
 
-  @wip
+
   Scenario: File metadata changes
     Given file "95366" is associated with dataset "2000070"
     And I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
@@ -36,6 +36,7 @@ Feature: A curator opens the mockup page
     Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
     And I can see the changes to the "file metadata" displayed
 
+  @wip
   Scenario: Author metadata changes
     Given I make an update to the non-public dataset "200070"'s "author metadata" in the admin pages
     When I am on "/adminDataset/update/id/668"

--- a/tests/acceptance/DatasetMockupPage.feature
+++ b/tests/acceptance/DatasetMockupPage.feature
@@ -8,7 +8,7 @@ Feature: A curator opens the mockup page
     Given I have signed in as admin
     And I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
 
-
+  @ok
   Scenario: Dataset metadata changes
     Given I make an update to the non-public dataset "200070"'s "dataset metadata" in the admin pages
     When I am on "/adminDataset/update/id/668"
@@ -16,7 +16,7 @@ Feature: A curator opens the mockup page
     Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
     And I can see the changes to the "dataset metadata" displayed
 
-
+  @ok
   Scenario: Sample metadata changes
     Given sample "154" is associated with dataset "2000070"
     And I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
@@ -26,7 +26,7 @@ Feature: A curator opens the mockup page
     Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
     And I can see the changes to the "sample metadata" displayed
 
-
+  @ok
   Scenario: File metadata changes
     Given file "95366" is associated with dataset "2000070"
     And I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
@@ -36,7 +36,7 @@ Feature: A curator opens the mockup page
     Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
     And I can see the changes to the "file metadata" displayed
 
-  @wip
+  @ok
   Scenario: Author metadata changes
     Given I make an update to the non-public dataset "200070"'s "author metadata" in the admin pages
     When I am on "/adminDataset/update/id/668"

--- a/tests/unit/ResourcedDatasetFilesTest.php
+++ b/tests/unit/ResourcedDatasetFilesTest.php
@@ -11,7 +11,7 @@ class ResourcedDatasetFilesTest extends CDbTestCase
     protected $fixtures = array( //careful, the order matters here because of foreign key constraints
         'species' => 'Species',
         'datasets' => 'Dataset',
-        'attributes' => 'Attribute',
+        'attributes' => 'Attributes',
         'file_formats' => 'FileFormat',
         'file_types' => 'FileType',
         'files' => 'File',

--- a/tests/unit/SampleTest.php
+++ b/tests/unit/SampleTest.php
@@ -4,7 +4,7 @@ class SampleTest extends CDbTestCase
 {
     protected $fixtures = array(
         'samples' => 'Sample',
-        'attributes' => 'Attribute',
+        'attributes' => 'Attributes',
         'sample_attribute' => 'SampleAttribute',
     );
 

--- a/tests/unit/StoredDatasetFilesTest.php
+++ b/tests/unit/StoredDatasetFilesTest.php
@@ -11,7 +11,7 @@ class StoredDatasetFilesTest extends CDbTestCase
     protected $fixtures = array( //careful, the order matters here because of foreign key constraints
         'species' => 'Species',
         'datasets' => 'Dataset',
-        'attributes' => 'Attribute',
+        'attributes' => 'Attributes',
         'file_formats' => 'FileFormat',
         'file_types' => 'FileType',
         'files' => 'File',

--- a/tests/unit/StoredDatasetMainSectionTest.php
+++ b/tests/unit/StoredDatasetMainSectionTest.php
@@ -11,7 +11,7 @@ class StoredDatasetMainSectionTest extends CDbTestCase
 {
     protected $fixtures = array( //careful, the order matters here because of foreign key constraints
         'publishers' => 'Publisher',
-        'attribute' => 'Attribute',
+        'attribute' => 'Attributes',
         'datasets' => 'Dataset',
         'types' => 'Type',
         'dataset_types' => 'DatasetType',

--- a/tests/unit/StoredDatasetSamplesTest.php
+++ b/tests/unit/StoredDatasetSamplesTest.php
@@ -10,7 +10,7 @@ class StoredDatasetSamplesTest extends CDbTestCase
 	protected $fixtures=array( //careful, the order matters here because of foreign key constraints
         'species'=>'Species',
         'datasets'=>'Dataset',
-        'attributes'=>'Attribute',
+        'attributes'=>'Attributes',
         'samples'=>'Sample',
         'dataset_samples'=>'DatasetSample',
         'sample_attribute'=>'SampleAttribute',


### PR DESCRIPTION
# Pull request for issue: #1528

This is a pull request for the following functionalities:

*  Do not use the cache when loading mockup pages
* Always enable caching by default on the development environment


## How to test?

### Automatically

After checking out this branch and starting Gigadb website with `up.sh`,
you can run the automated tests with:
```
$ docker-compose run --rm codecept run --no-redirect --debug acceptance tests/acceptance/DatasetMockupPage.feature
```

### Manually

After login as an admin, navigate to the dataset admin form http://gigadb.gigasciencejournal.com:9170/adminDataset/update/id/668 and click-open on a separate tab the "Open Private URL" link to show the mockup page on a separate tab, then manually perform the acceptance criteria listed in #1528 as guided below

In parallel, do open the Docker Desktop dashboard, ensure you are on the "Containers" screen, and click on the "deployment" stack in the list, then in the list of services from that stack, click on "deployment-application-1", you will see the log of that container service. Make sure it's empty by clicking the trash icon "Clear terminal" on the right  before you run each test. The log should not show anything log entries related to caching (HIT or MISS) after your ran the test (This work for both manual and automated testing).

#### changing dataset metadata

On the dataset update form, just change the content of the title or the description then save, then refresh the mockup page, it should show the changes.

### changing samples metadata 

From the admin dashboard, navigate to the "Dataset:Samples", click the "Edit" button for the first sample and assign it to the "200070" DOI, then refresh the mockup page, it should show the sample in the samples tab.

### changing files metadata 

From the admin dashboard, navigate to the "Dataset:Files", click the "Edit" button for the first file and assign it to the "200070" DOI, then refresh the mockup page, it should show the file in the files tab

### changing author metadata 

From the admin dashboard, navigate to the "Dataset:Authors", click the "Edit" button for the first author and assign it to the "200070" DOI, then refresh the mockup page, it should show the author name in the main section.

### On AWS Deployment

After pushing this branch remotely to you fork, and deploying the resulting pipeline to your staging on AWS, you can reiterate the manual testing steps above on your staging environment

## How have functionalities been implemented?

### Enabling caching by default on development environment

Motivations:

* In general, there should no be no reasons for caching to be disabled locally. If there are issues locally that we think is related to caching, chances are there are also happening on production and should be investigated and fixed. Having cache disabled locally increases the risks of not discovering bug in caching before they hit production.
* Locally, if we really need to disable caching, we can do so by replacing `CApcCache` with `CDummyCache` in the Yii configuration file, which is the clean way of doing it
* It makes testing cache related feature easier

### Disabling caching for mockup page

The gathering of the the various sets of information that make a dataset pages is done in the class `DatasetPageAssembly.php`, before being summoned in the `actionView()` method of `DatasetController.php`

It relies on an onion-like architecture that allows:
*  keeping the various concerns related to bringing the data to the users (formatting, authorisation, caching, database query) independent of each other so that if need to change one of them, there is a dedicated layer to go and change without having to touch any other layers
* keeping each domain object (the things we care and talk about as a business: dataset, samples, files,...) in their own vertical structure, so that if a domain object need internal change, only the classes that implement the domain interface are impacted by the change and the calling code (data assembly and controller) should be oblivious to this.
* flexibility that comes from using interfaces. When constructing the layers in  `DatasetPageAssembly.php`, we can use any object that implement the domain interface, so that we can skip and add  layers as needed

The layers that we have are 
```
Formatting -> Authorisation -> Caching -> Retrieval from the database
```
>note: There is a good argument that the caching should be the first layer rather than being in the middle, but that's what we have at the moment. And we are not going to change that here.


Not all domain objects use all the layers (E.g: Authorisation is only used for a handful of them), but at the moment, in `develop`, they all use the Caching layer when displaying the dataset page and the mockup page.

The goal of this PR is to distinguish the code path for showing the dataset page and for showing the mock-up page, and in the latter case, the caching layer should not be used.

This is done by introducing a new configuration option called `skip_cache`, that we wrap in a configuration array passed as parameter to the `assemble()` static method and then to the constructor of `DatasetPageAssembly.php`.

If we take the example of the dataset domain object.
On `develop`, whether we show the dataset page or the mockup page, the assembly will construct the following "onion":
```
$this->_mainSection = new FormattedDatasetMainSection(
            new CachedDatasetMainSection(
                $this->_app->cache,
                $this->_cacheDependency,
                new StoredDatasetMainSection(
                    $this->_dataset->id,
                    $this->_app->db
                )
            )
```

What we want is to keep that for showing the public dataset page, but for the mockup page we want to skip the `CachedDatasetMainSection` layer and do something like:

```
$this->_mainSection = new FormattedDatasetMainSection(
                new StoredDatasetMainSection(
                    $this->_dataset->id,
                    $this->_app->db
                )

```

We can actually do that because all the `*MainSection.php` classes implements the same interface `DatasetMainSectionInterface.php`

And we do the same for all the other page components.

 

## Any issues with implementation?

N/a

## Any changes to automated tests?

There is a new feature file that implements the user story and acceptance criteria scenarios from #1528:

tests/acceptance/DatasetMockupPage.feature 

The steps that implement the scenarios are in:

tests/_support/Steps/CuratorSteps.php

The one thing to note when coming up with the steps to reproduce the issue are to ensure all the scenarios load the mockup page first. Before the fix is implemented, such action will trigger the page components to be cached, that's why in the "Background" section, we make sure the mockup page is loaded.

The other aspect worth commenting about implementation is that we don't want to create steps that go through the web form to create the changes:
* because introducing changes in the database directly is enough to reproduce the issue
* in real situation, that's how the problem first manifest to users anyway, after the spreadsheet uploader and post-upload script have in sequences updated the database directly.
  



## Any changes to documentation?

N/a

## Any technical debt repayment?

Once the main purpose of the PR is approved, I will perform the following tech debts repayments:

~~* [ ] Remove the index action from all controllers as following a question from Luis, curators confirmed those endpoints are not needed~~
* [ ] Replace the `Attribute.php` class implementing the Attribute domain object with `Attributes` as PHP 8.0 introduces a non-namespaced `Attribute` class to manage PHP Attributes that combined with other changes/deprecation in PHP 8.1/8.2 causes a [server error](https://github.com/yiisoft/yii/issues/4539) due to conflict between the two classes when running GigaDB against PHP 8.2. 
* [ ] Remove `google/apiclient` as it is not used by feature used by users and will cause dependencies issues with PHP 8.2

## Any improvements to CI/CD pipeline?

N/a
