### PR TITLE
Make live tideways only available in tagged pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-
+- Fix #1562: Make live tideways jobs only available in the tagged GitLab pipeline
 
 ## v4.0.0 - 2023-11-06 - 9c012f7b
 

--- a/ops/pipelines/gitlab-tideways-jobs.yml
+++ b/ops/pipelines/gitlab-tideways-jobs.yml
@@ -46,7 +46,9 @@ TidewaysBuildLive:
   stage: live build
   variables:
     GIGADB_ENV: "live"
-  extends: .pb_tideways
+  extends:
+    - .tag_only
+    - .pb_tideways
   tags:
     - $GITLAB_USER_LOGIN
   needs: ["build_live"]
@@ -116,7 +118,9 @@ TidewaysDeployLive:
   stage: live deploy
   variables:
     GIGADB_ENV: "live"
-  extends: .deploy_tideways
+  extends:
+    - .tag_only
+    - .deploy_tideways
   tags:
     - $GITLAB_USER_LOGIN
   needs: ["ld_gigadb","TidewaysBuildLive"]

--- a/ops/pipelines/gitlab-tideways-jobs.yml
+++ b/ops/pipelines/gitlab-tideways-jobs.yml
@@ -47,7 +47,6 @@ TidewaysBuildLive:
   variables:
     GIGADB_ENV: "live"
   extends:
-    - .tag_only
     - .pb_tideways
   tags:
     - $GITLAB_USER_LOGIN
@@ -57,6 +56,8 @@ TidewaysBuildLive:
     deployment_tier: production
     url: $REMOTE_HOME_URL
   when: manual
+  rules:
+    - if: $CI_COMMIT_TAG
 
 .deploy_tideways:
   variables:
@@ -119,7 +120,6 @@ TidewaysDeployLive:
   variables:
     GIGADB_ENV: "live"
   extends:
-    - .tag_only
     - .deploy_tideways
   tags:
     - $GITLAB_USER_LOGIN
@@ -128,3 +128,5 @@ TidewaysDeployLive:
     name: "live"
     url: $REMOTE_HOME_URL
   when: manual
+  rules:
+    - if: $CI_COMMIT_TAG


### PR DESCRIPTION
# Pull request for issue: #1562 

This is a pull request for the following functionalities:

This PR allows non tagged gitlab pipeline got triggered successfully, which is useful for executing non release works after merging developer's work in the upstream develop branch. 

## How to test?

Describe how the new functionalities can be tested by PR reviewers

```
# checkout this PR from the upstream project repo
% git checkout -b $revieweInput-make-upstream-develop-branch-independent-to-live-tideways
% git pull https://github.com/kencho51/gigadb-website.git make-upstream-develop-branch-independent-to-live-tideways --rebase
# make sure you have upstream gitlab added into your local git
% git remote add upstream-gitlab https://gitlab.com/gigascience/upstream/gigadb-website.git 
$ git remote -v
origin  https://github.com/gigascience/gigadb-website.git (fetch)
origin  https://github.com/gigascience/gigadb-website.git (push)
upstream-gitlab https://gitlab.com/gigascience/upstream/gigadb-website.git (fetch)
upstream-gitlab https://gitlab.com/gigascience/upstream/gigadb-website.git (push)
# push this PR to upstream gitlab pipeline
% git push -f upstream-gitlab $revieweInput-make-upstream-develop-branch-independent-to-live-tideways
# go to gitlab dashboard of the upstream, all the live build and live deploy jobs would be unavailable
# apply tag to the current commit for testing
% git tag -as v9.9.9-live-tideways-available -m "testing live tideways only available after tag"
% git push origin v9.9.9-live-tideways-available
# after a few minutes, you should see the tagged pipeline with live build and live deploy jobs of tideways are available
```

## How have functionalities been implemented?

Describe how the new functionalities have been implemented by the
changed code at a high level

The jobs `TidewaysBuildLive` and `TidewaysDeployLive` have dependency on `build_live` and `ld_gigadb`, which are only available in a tagged upstream gitlab pipeline.

At first, I have tried the following configuration for the live tideways jobs:
```
  extends:
    - .pb_tideways
    -  .tag_only
 ```
The above configuration supposedly would make the jobs only available with tagged pipeline, but the pipeline was still was with the same error as described in #1562, this seems that the `tag_only` cannot work if the `needs` job, eg, `build_live` and `ld_gigadb` has used `tag_only` already.

The work around is to explicitly add in the rules block as below:
```
  rules:
    - if: $CI_COMMIT_TAG
```
So the jobs `TidewaysBuildLive` and `TidewaysDeployLive`  would not available in any non tagged job and the pipeline still can be triggered successfully. If the pipeline is tagged, the jobs would be then available again as the other live jobs.

## Any issues with implementation?

None.

## Any changes to automated tests?

None.

## Any changes to documentation?

None.

## Any technical debt repayment?

None.

## Any improvements to CI/CD pipeline?

None.
