### PR TITLE
Implement scenario for checking the updated release year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1530: Implement scenario for checking the updated values in the mockup page
+
 ## v4.0.3 - 2023-12-04 - c2869d0
 
 - Fix #1561: show app version in footer on AWS deployment

--- a/tests/acceptance/DatasetMockupPage.feature
+++ b/tests/acceptance/DatasetMockupPage.feature
@@ -44,7 +44,7 @@ Feature: A curator opens the mockup page
     Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
     And I can see the changes to the "author metadata" displayed
 
-  @ok
+  @ok @release-year
   Scenario: Check for updating the release year
     Given I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
     And I should not see "Zhang G (2020)"

--- a/tests/acceptance/DatasetMockupPage.feature
+++ b/tests/acceptance/DatasetMockupPage.feature
@@ -43,3 +43,14 @@ Feature: A curator opens the mockup page
     And I follow "Open Private URL"
     Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
     And I can see the changes to the "author metadata" displayed
+
+  @ok
+  Scenario: Check for updating the release year
+    Given I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
+    And I should not see "Zhang G (2020)"
+    When I make an update to the non-public dataset "200070"'s "author metadata" in the admin pages
+    And I am on "/adminDataset/update/id/668"
+    And I fill in the field of "id" "Dataset_publication_date" with "2020-01-01"
+    And I press the button "Save"
+    Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
+    And I should see "Zhang G (2020)"

--- a/tests/acceptance/DatasetMockupPage.feature
+++ b/tests/acceptance/DatasetMockupPage.feature
@@ -47,7 +47,6 @@ Feature: A curator opens the mockup page
   @ok @release-year
   Scenario: Check for updating the release year
     Given I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
-    And I should not see "Zhang G (2020)"
     When I make an update to the non-public dataset "200070"'s "author metadata" in the admin pages
     And I am on "/adminDataset/update/id/668"
     And I fill in the field of "id" "Dataset_publication_date" with "2020-01-01"


### PR DESCRIPTION
# Pull request for issue: #1530

This is a pull request for the following functionalities:

To make sure that the value, eg. `release year` after updating the private dataset from admin dataset form can be seen in the private mockup page.

## How to test?

Describe how the new functionalities can be tested by PR reviewers

```
# checkout this PR
% ./up.sh
% docker-compose run --rm codecept run --no-redirect --debug acceptance tests/acceptance/DatasetMockupPage.feature -g release-year
```

## How have functionalities been implemented?

Describe how the new functionalities have been implemented by the
changed code at a high level

In current production environments, the gigadb website together with the mock up page is cached, so the mockup page will only display the cached value, instead of the updated value.

With the main implementation in PR #1560 to turn off the caching for the mockup page, so it can always show the latest values after every update. This PR is trying to increase the test coverage by adding an scenario on checking the updated value of the release year.

## Any issues with implementation?

None.

## Any changes to automated tests?

Implement scenario for checking the release year in the private mockup page.

## Any changes to documentation?

None.

## Any technical debt repayment?

None.

## Any improvements to CI/CD pipeline?

None.