### PR TITLE
Create dataset spreadsheet template update instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1259: Document how to update dataset spreadsheet template
+
 ## v4.0.3 - 2023-12-04 - c2869d0
 
 - Fix #1561: show app version in footer on AWS deployment

--- a/gigadb/app/tools/excel-spreadsheet-uploader/template/UPDATE_INSTRUCTIONS.md
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/template/UPDATE_INSTRUCTIONS.md
@@ -1,0 +1,59 @@
+# Update the dataset spreadsheet template
+
+Below are instructions for safely making changes to the dataset spreadsheet template.
+For more  information about that document's usage, check the corresponding [Giganet user guide](https://sites.google.com/gigasciencejournal.com/giganet/gigadb/curation/excel-submission-sheet-guidelines)
+
+1. Ensure you have a personal [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of https://github.com/gigascience/gigadb-website
+
+2. Clone your fork of the gigadb-website repository
+
+```
+$ git clone https://github.com/<your GitHub username>/gigadb-website
+```
+
+3. Change to the directory where the template is: 
+
+```
+$ cd gigadb-website/gigadb/app/tools/excel-spreadsheet-uploader/template/
+```
+
+4. At present, there should only be two files in that directory, this `UPDATE_INSTRUCTIONS.md` file and the dataset spreadsheet template
+
+5. If you need to make a change, create a new branch
+
+```
+$ git checkout -b <meaningful name with no spaces/special characters>
+```
+
+6. Now, feel free to make the changes you feel is necessary to that file.
+
+>note: [Do not encode some kind of version in the file name](https://carpentries-incubator.github.io/git-novice-branch-pr/01-basics/), as Git is already versioned, and [it's easy](https://github.com/gigascience/gigadb-website/commits/develop/gigadb/app/tools/excel-spreadsheet-uploader/template) accessing previous versions of the file. So adding some kind of version in the file name will confuse everyone who need interacting with only the latest version of that file and defeats the purpose of storing this file in Git in the first place
+
+7. Stage and commit the change locally (you may want to have multiple rounds of that step)
+
+```
+$ git add .
+$ git commit -m "description of the changes"
+```
+
+8. When you are ready to share the changes, you can push them to the remote repository
+
+```
+$ git push --set-upstream origin
+```
+
+9. Now you can create [a pull request](https://carpentries-incubator.github.io/git-novice-branch-pr/10-pull-requests/) that will notify the tech team that a change need to be reviewed and merged in the codebase
+
+Navigate to your fork on Github and switch to the branch `<meaningful name with no spaces/special characters>`, click on the `Contribute` drop-down menu and press the "Open pull request",
+Then fill in the form as guided and save it. 
+The developers will be notified of the pull request and will schedule its reviewing.
+
+10. Reviewing
+
+During the reviewing, comments may be exchange on the pull requests directly between reviewers and author.
+
+If additional changes to the spreadsheet are necessary, a number of rounds of steps 6, 7 and 8 are to be performed again. When the pull request has been approved by two members of the tech team, it will be merged to the codebase
+
+11. Merging and sharing with the users
+
+The developers will merge the pull request and will send a general email announcing the change with description and instructions for downloading the file.

--- a/gigadb/app/tools/excel-spreadsheet-uploader/template/UPDATE_INSTRUCTIONS.md
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/template/UPDATE_INSTRUCTIONS.md
@@ -3,52 +3,39 @@
 Below are instructions for safely making changes to the dataset spreadsheet template.
 For more  information about that document's usage, check the corresponding [Giganet user guide](https://sites.google.com/gigasciencejournal.com/giganet/gigadb/curation/spreadsheet-upload-scripts)
 
-1. Ensure you have a personal [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of https://github.com/gigascience/gigadb-website
+>note: It's fine to keep past file-name encoded versions of the template for compatbility with already circulating documents, but going forward, [Do not encode some kind of version in the file name](https://carpentries-incubator.github.io/git-novice-branch-pr/01-basics/), as Git is already versioned, and [it's easy](https://github.com/gigascience/gigadb-website/commits/develop/gigadb/app/tools/excel-spreadsheet-uploader/template) accessing previous versions of the file. So adding some kind of version in the file name will confuse everyone who need interacting with only the latest version of that file and defeats the purpose of storing this file in Git in the first place
 
-2. Clone your fork of the gigadb-website repository
+## Using Github Desktop
 
-```
-$ git clone https://github.com/<your GitHub username>/gigadb-website
-```
+1. Assuming you have already cloned Gigascience's gigadb-website Github project in Github Desktop
+2. Open Github Desktop, and ensure that:
+    * The `gigadb-website` project is selected as the "Current repository` in the toolbar
+    * The `develop` branch is selected as the "Current branch" in the toolbar
+    * Click "Fetch origin" to ensure you have the latest state of the truth from the server
+    * The "Changes" column on the left should be empty
+3. Identify where Github Desktop has clone the repository on your computer and navigate to it.
+4. On your computer, make the change you want to the file in `gigadb/app/tools/excel-spreadsheet-uploader/template`
+5. Then return to Github Desktop, you should see that the "Changes" column on the left is not empty and reflects the changes your made
+6. Create a new branch by clicking on the drop-down menu right of "Current branch" in the toolbar
+7. Click on "New branch", choose a meaningful name (e.g: incorrect-doi-hint), and click "Create branch"
+8. Then make sure that out of the two options shown, you select "Bring my changes to (name of the branch just created)"
+9. Click "Switch branch", "Current branch" in the toolbar should now show the name of the just created branch
+10. It is time to commit the changes by adding a summary and description to the commit message form at the bottom left, and then click "commit to (name of the just created branch)"
+11. The main pane will show a list of what to do next. Choose the top one (already highlighted) "Publish your branch" by clicking the "Publish branch" button
+12. The top option in the main pane is highlighted and says "Preview the pull request from you current branch", and has a button "Preview Pull Request" that you click
+13. a preview pane will pop up, check that it says:
+    *  "commit into base:develop from (name of the branch you have created)
+    *  the main pane contain the change you want to publish and be reviewed
+    *  At the bottom left, it should have a green tick "Able to merge"
+14. If all good, you can click "Create Pull Request"
+15. Your web browser will open on a new Pull request form on the Gigascience's gigadb-website repository
+16. Fill in the form as instructed inline
+17. Click on "Create Pull Request" (if instead you see "Draft Pull Request", click the drop-down menu to bring the other option)
+18. in the "Projects" section in the right-hand sidebar, add the pull request to the current sprint project
 
-3. Change to the directory where the template is: 
 
-```
-$ cd gigadb-website/gigadb/app/tools/excel-spreadsheet-uploader/template/
-```
 
-4. At present, there should only be two files in that directory, this `UPDATE_INSTRUCTIONS.md` file and the dataset spreadsheet template
-
-5. If you need to make a change, create a new branch
-
-```
-$ git checkout -b <meaningful name with no spaces/special characters>
-```
-
-6. Now, feel free to make the changes you feel is necessary to that file.
-
->note: [Do not encode some kind of version in the file name](https://carpentries-incubator.github.io/git-novice-branch-pr/01-basics/), as Git is already versioned, and [it's easy](https://github.com/gigascience/gigadb-website/commits/develop/gigadb/app/tools/excel-spreadsheet-uploader/template) accessing previous versions of the file. So adding some kind of version in the file name will confuse everyone who need interacting with only the latest version of that file and defeats the purpose of storing this file in Git in the first place
-
-7. Stage and commit the change locally (you may want to have multiple rounds of that step)
-
-```
-$ git add .
-$ git commit -m "description of the changes"
-```
-
-8. When you are ready to share the changes, you can push them to the remote repository
-
-```
-$ git push --set-upstream origin
-```
-
-9. Now you can create [a pull request](https://carpentries-incubator.github.io/git-novice-branch-pr/10-pull-requests/) that will notify the tech team that a change need to be reviewed and merged in the codebase
-
-Navigate to your fork on Github and switch to the branch `<meaningful name with no spaces/special characters>`, click on the `Contribute` drop-down menu and press the "Open pull request",
-Then fill in the form as guided and save it. 
-The developers will be notified of the pull request and will schedule its reviewing.
-
-10. Reviewing
+## Reviewing
 
 During the reviewing, comments may be exchange on the pull requests directly between reviewers and author.
 

--- a/gigadb/app/tools/excel-spreadsheet-uploader/template/UPDATE_INSTRUCTIONS.md
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/template/UPDATE_INSTRUCTIONS.md
@@ -41,6 +41,6 @@ During the reviewing, comments may be exchange on the pull requests directly bet
 
 If additional changes to the spreadsheet are necessary, a number of rounds of steps 6, 7 and 8 are to be performed again. When the pull request has been approved by two members of the tech team, it will be merged to the codebase
 
-11. Merging and sharing with the users
+## Merging and sharing with the users
 
-The developers will merge the pull request and will send a general email announcing the change with description and instructions for downloading the file.
+When two developers have approved the pull request, We will merge the pull request and will send a general email announcing the change with description and instructions for downloading the file.

--- a/gigadb/app/tools/excel-spreadsheet-uploader/template/UPDATE_INSTRUCTIONS.md
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/template/UPDATE_INSTRUCTIONS.md
@@ -23,7 +23,7 @@ For more  information about that document's usage, check the corresponding [Giga
 10. It is time to commit the changes by adding a summary and description to the commit message form at the bottom left, and then click "commit to (name of the just created branch)"
 11. The main pane will show a list of what to do next. Choose the top one (already highlighted) "Publish your branch" by clicking the "Publish branch" button
 12. The top option in the main pane is highlighted and says "Preview the pull request from you current branch", and has a button "Preview Pull Request" that you click
-13. a preview pane will pop up, check that it says:
+13. A preview pane will pop up, check that it says:
     *  "commit into base:develop from (name of the branch you have created)
     *  the main pane contain the change you want to publish and be reviewed
     *  At the bottom left, it should have a green tick "Able to merge"
@@ -31,7 +31,7 @@ For more  information about that document's usage, check the corresponding [Giga
 15. Your web browser will open on a new Pull request form on the Gigascience's gigadb-website repository
 16. Fill in the form as instructed inline
 17. Click on "Create Pull Request" (if instead you see "Draft Pull Request", click the drop-down menu to bring the other option)
-18. in the "Projects" section in the right-hand sidebar, add the pull request to the current sprint project
+18. In the "Projects" section in the right-hand sidebar, add the pull request to the current sprint project
 
 
 

--- a/gigadb/app/tools/excel-spreadsheet-uploader/template/UPDATE_INSTRUCTIONS.md
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/template/UPDATE_INSTRUCTIONS.md
@@ -23,8 +23,8 @@ For more  information about that document's usage, check the corresponding [Giga
 10. It is time to commit the changes by adding a summary and description to the commit message form at the bottom left, and then click "commit to (name of the just created branch)"
 11. The main pane will show a list of what to do next. Choose the top one (already highlighted) "Publish your branch" by clicking the "Publish branch" button
 12. The top option in the main pane is highlighted and says "Preview the pull request from you current branch", and has a button "Preview Pull Request" that you click
-13. A preview pane will pop up, check that it says:
-    *  "commit into base:develop from (name of the branch you have created)
+13. A preview pane will pop up, check that:
+    *  it says "commit into base:develop from (name of the branch with your changes)"
     *  the main pane contain the change you want to publish and be reviewed
     *  At the bottom left, it should have a green tick "Able to merge"
 14. If all good, you can click "Create Pull Request"
@@ -37,10 +37,10 @@ For more  information about that document's usage, check the corresponding [Giga
 
 ## Reviewing
 
-During the reviewing, comments may be exchange on the pull requests directly between reviewers and author.
+During the reviewing, comments may be exchanged on the pull requests directly between reviewers and author.
 
 If additional changes to the spreadsheet are necessary, a number of rounds of steps 9, 10 and 11 are to be performed again. When the pull request has been approved by two members of the tech team, it will be merged to the codebase
 
 ## Merging and sharing with the users
 
-When two developers have approved the pull request, We will merge the pull request and will send a general email announcing the change with description and instructions for downloading the file.
+When two developers have approved the pull request, we will merge the pull request and will send a general email announcing the change with description and instructions for downloading the file.

--- a/gigadb/app/tools/excel-spreadsheet-uploader/template/UPDATE_INSTRUCTIONS.md
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/template/UPDATE_INSTRUCTIONS.md
@@ -1,7 +1,7 @@
 # Update the dataset spreadsheet template
 
 Below are instructions for safely making changes to the dataset spreadsheet template.
-For more  information about that document's usage, check the corresponding [Giganet user guide](https://sites.google.com/gigasciencejournal.com/giganet/gigadb/curation/excel-submission-sheet-guidelines)
+For more  information about that document's usage, check the corresponding [Giganet user guide](https://sites.google.com/gigasciencejournal.com/giganet/gigadb/curation/spreadsheet-upload-scripts)
 
 1. Ensure you have a personal [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of https://github.com/gigascience/gigadb-website
 

--- a/gigadb/app/tools/excel-spreadsheet-uploader/template/UPDATE_INSTRUCTIONS.md
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/template/UPDATE_INSTRUCTIONS.md
@@ -31,7 +31,7 @@ For more  information about that document's usage, check the corresponding [Giga
 15. Your web browser will open on a new Pull request form on the Gigascience's gigadb-website repository
 16. Fill in the form as instructed inline
 17. Click on "Create Pull Request" (if instead you see "Draft Pull Request", click the drop-down menu to bring the other option)
-18. In the "Projects" section in the right-hand sidebar, add the pull request to the current sprint project
+18. Add the pull request to the current sprint project by pasting its link into a new note in the Tasks To Do column. Sprint projects are listed in [Projects (classic)](https://github.com/orgs/gigascience/projects?type=classic). Then slide the note in the "👆 Reviewing required" section
 
 
 

--- a/gigadb/app/tools/excel-spreadsheet-uploader/template/UPDATE_INSTRUCTIONS.md
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/template/UPDATE_INSTRUCTIONS.md
@@ -17,9 +17,9 @@ For more  information about that document's usage, check the corresponding [Giga
 4. On your computer, make the change you want to the file in `gigadb/app/tools/excel-spreadsheet-uploader/template`
 5. Then return to Github Desktop, you should see that the "Changes" column on the left is not empty and reflects the changes your made
 6. Create a new branch by clicking on the drop-down menu right of "Current branch" in the toolbar
-7. Click on "New branch", choose a meaningful name (e.g: incorrect-doi-hint), and click "Create branch"
+7. Click on "New branch", choose a meaningful name (e.g: fix-doi-hint), and click "Create branch"
 8. Then make sure that out of the two options shown, you select "Bring my changes to (name of the branch just created)"
-9. Click "Switch branch", "Current branch" in the toolbar should now show the name of the just created branch
+9. Click "Switch branch", "Current branch" in the toolbar should now show the name of the branch with your changes
 10. It is time to commit the changes by adding a summary and description to the commit message form at the bottom left, and then click "commit to (name of the just created branch)"
 11. The main pane will show a list of what to do next. Choose the top one (already highlighted) "Publish your branch" by clicking the "Publish branch" button
 12. The top option in the main pane is highlighted and says "Preview the pull request from you current branch", and has a button "Preview Pull Request" that you click
@@ -39,7 +39,7 @@ For more  information about that document's usage, check the corresponding [Giga
 
 During the reviewing, comments may be exchange on the pull requests directly between reviewers and author.
 
-If additional changes to the spreadsheet are necessary, a number of rounds of steps 6, 7 and 8 are to be performed again. When the pull request has been approved by two members of the tech team, it will be merged to the codebase
+If additional changes to the spreadsheet are necessary, a number of rounds of steps 9, 10 and 11 are to be performed again. When the pull request has been approved by two members of the tech team, it will be merged to the codebase
 
 ## Merging and sharing with the users
 


### PR DESCRIPTION
First draft of the instructions to update the dataset spreadsheet templates.

# Pull request for issue: #1259

This is a pull request for the following functionalities:

* [x] The body of the instructions for updating the dataset spreadsheet template as a markdown file in the same directory
* [x] Made minor correction to [Giganet page](https://sites.google.com/gigasciencejournal.com/giganet/gigadb/curation/spreadsheet-upload-scripts) that explain how to upload spreadsheets
* [x] Updated the Giganet documentation to [reference](https://sites.google.com/gigasciencejournal.com/giganet/gigadb/curation/spreadsheet-upload-scripts) the new template updating instructions

## How to test?

Follow the instructions in the documentation, at the end there should be a new PR created (we can delete it later)


## How have functionalities been implemented?

l have change to the template in gigascience's gigadb-website checkout , then used Github Desktop to create a pull request and documented the process


