### PR TITLE
Replace the deprecated centos ami for the aws instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1586: Make terraform always look for the latest CentOS Stream 8 x86_64 AMI
 - Feat #1530: Implement scenario for checking the updated values in the mockup page
 
 ## v4.0.3 - 2023-12-04 - c2869d0

--- a/ops/infrastructure/modules/aws-instance/aws-instance.tf
+++ b/ops/infrastructure/modules/aws-instance/aws-instance.tf
@@ -76,7 +76,7 @@ data "aws_ami" "centos" {
 
   filter {
     name   = "name"
-    values = ["CentOS Stream 8 x86_64 20230530"]
+    values = ["CentOS Stream 8 x86_64 20231127"]
   }
 
   filter {

--- a/ops/infrastructure/modules/aws-instance/aws-instance.tf
+++ b/ops/infrastructure/modules/aws-instance/aws-instance.tf
@@ -76,7 +76,7 @@ data "aws_ami" "centos" {
 
   filter {
     name   = "name"
-    values = ["CentOS Stream 8 x86_64 20231127"]
+    values = ["CentOS Stream 8 x86_64 *"]
   }
 
   filter {

--- a/ops/infrastructure/modules/bastion-aws-instance/bastion-aws-instance.tf
+++ b/ops/infrastructure/modules/bastion-aws-instance/bastion-aws-instance.tf
@@ -44,7 +44,7 @@ data "aws_ami" "centos" {
 
   filter {
     name   = "name"
-    values = ["CentOS Stream 8 x86_64 20231127"]
+    values = ["CentOS Stream 8 x86_64 *"]
   }
 
   filter {

--- a/ops/infrastructure/modules/bastion-aws-instance/bastion-aws-instance.tf
+++ b/ops/infrastructure/modules/bastion-aws-instance/bastion-aws-instance.tf
@@ -44,7 +44,7 @@ data "aws_ami" "centos" {
 
   filter {
     name   = "name"
-    values = ["CentOS Stream 8 x86_64 20230530"]
+    values = ["CentOS Stream 8 x86_64 20231127"]
   }
 
   filter {


### PR DESCRIPTION
# Pull request for issue: #1586

This is a pull request for the following functionalities:

The ami `CentOS Stream 8 x86_64 20230530` from owner `125523088429` has been deprecated, the latest available ami now is `CentOS Stream 8 x86_64 20231127`.


## How to test?

Describe how the new functionalities can be tested by PR reviewers

##### Provisioning
```
# checkout this PR
% git checkout -b kencho51-replace-deprecated-aws-ami-for-centos
% git pull https://github.com/kencho51/gigadb-website.git replace-deprecated-aws-ami-for-centos
# provision ec2 instances
% cd ops/infrastructure/envs/staging
% ../../../scripts/tf_init.sh --project gigascience/forks/kencho-gigadb-website --env staging
% terraform apply
% terraform refresh
# the aws instances with the ami id `ami-0ab6a460d80df4dc1` should be created, check from the AWS EC2 dashboard
```

##### Confirm the latest available ami
1. Click the [AMIs] dashboard at the side after logging into the AWS EC2 console, 
2. Choose `Public images` from the dropdown box
3. Input `Owner = 125523088429` as the search criteria

## How have functionalities been implemented?

Describe how the new functionalities have been implemented by the
changed code at a high level


#### Update the filtering criteria in the  modules for aws instance and bastion instance, eg:
```
data "aws_ami" "centos" {
  most_recent = true

  filter {
    name   = "name"
    values = ["CentOS Stream 8 x86_64 *]
  }

  filter {
    name   = "virtualization-type"
    values = ["hvm"]
  }

  owners = ["125523088429"]
}
```

Since the `most_recent` argument has been set to true, the above filtering criteria will always return the latest AMI, in this case it will be `CentOS Stream 8 x86_64 20231127`.

The benefit of replacing the hard-coded date in the filter with the wildcard `*` is to prevent the `Error: Your query returned no results. Please change your search criteria and try again.`  when during `terraform apply` due to the deprecation of the AMI.
 


## Any issues with implementation?

None.

## Any changes to automated tests?

None.

## Any changes to documentation?

None.

## Any technical debt repayment?

None.

## Any improvements to CI/CD pipeline?

None.
