### PR TITLE
Fix post upload file size and url errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1527: Make the postUpload script use the image `production-files-metadata-console:production_environment` in the staging and live environments
+
 ## v4.1.0 - 2024-01-24 - d0495bee
 
 - Fix #1654: Fix AdminDatasetForm acceptance tests

--- a/gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh
@@ -37,11 +37,11 @@ if [[ $(uname -n) =~ compute ]];then
   . /home/centos/.bash_profile
 
   echo -e "$updateFileSizeStartMessage"
-  docker run --rm "registry.gitlab.com/$GITLAB_PROJECT/production-files-metadata-console:latest" ./yii update/file-size --doi="$DOI" | tee "$outputDir/updating-file-size-$DOI.txt"
+  docker run --rm "registry.gitlab.com/$GITLAB_PROJECT/production-files-metadata-console:$GIGADB_ENV" ./yii update/file-size --doi="$DOI" | tee "$outputDir/updating-file-size-$DOI.txt"
   echo -e "$updateFileSizeEndMessage"
 
   echo -e "$checkValidUrlsStartMessage"
-  docker run --rm "registry.gitlab.com/$GITLAB_PROJECT/production-files-metadata-console:latest" ./yii check/valid-urls --doi="$DOI" | tee "$outputDir/invalid-urls-$DOI.txt"
+  docker run --rm "registry.gitlab.com/$GITLAB_PROJECT/production-files-metadata-console:$GIGADB_ENV" ./yii check/valid-urls --doi="$DOI" | tee "$outputDir/invalid-urls-$DOI.txt"
   echo -e "$checkValidUrlsEndMessage"
 
   echo -e "$updateMD5ChecksumStartMessage"

--- a/gigadb/app/tools/files-metadata-console/docker-compose.production-envs.yml
+++ b/gigadb/app/tools/files-metadata-console/docker-compose.production-envs.yml
@@ -6,4 +6,4 @@ services:
       context: ../../../..
       dockerfile: gigadb/app/tools/files-metadata-console/Dockerfile-Production
       cache_from:
-        - "registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:latest"
+        - "registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV"

--- a/gigadb/app/tools/files-metadata-console/gitlab-config-live-build.yml
+++ b/gigadb/app/tools/files-metadata-console/gitlab-config-live-build.yml
@@ -27,11 +27,11 @@ FilesMetadataConsoleBuildLive:
     - cp .secrets gigadb/app/tools/files-metadata-console/
     - cp .env gigadb/app/tools/files-metadata-console/
     - cd gigadb/app/tools/files-metadata-console
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:latest || true
+    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV  || true
     - docker-compose -f ./docker-compose.yml run --rm configure
     - docker-compose -f ./docker-compose.yml run --rm composer install
     - docker-compose -f ./docker-compose.production-envs.yml build production-files-metadata-console
-    - docker tag ${CI_PROJECT_NAME}_production-files-metadata-console:latest registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
+    - docker tag ${CI_PROJECT_NAME}_production-files-metadata-console:$GIGADB_ENV  registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
     - docker push registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
   artifacts:
     untracked: true

--- a/gigadb/app/tools/files-metadata-console/gitlab-config-live-build.yml
+++ b/gigadb/app/tools/files-metadata-console/gitlab-config-live-build.yml
@@ -27,11 +27,11 @@ FilesMetadataConsoleBuildLive:
     - cp .secrets gigadb/app/tools/files-metadata-console/
     - cp .env gigadb/app/tools/files-metadata-console/
     - cd gigadb/app/tools/files-metadata-console
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV  || true
+    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV || true
     - docker-compose -f ./docker-compose.yml run --rm configure
     - docker-compose -f ./docker-compose.yml run --rm composer install
     - docker-compose -f ./docker-compose.production-envs.yml build production-files-metadata-console
-    - docker tag ${CI_PROJECT_NAME}_production-files-metadata-console:$GIGADB_ENV  registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
+    - docker tag ${CI_PROJECT_NAME}_production-files-metadata-console:latest  registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
     - docker push registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
   artifacts:
     untracked: true

--- a/gigadb/app/tools/files-metadata-console/gitlab-config-staging-build.yml
+++ b/gigadb/app/tools/files-metadata-console/gitlab-config-staging-build.yml
@@ -29,7 +29,7 @@ FilesMetadataConsoleBuildStaging:
     - docker-compose -f ./docker-compose.yml run --rm configure
     - docker-compose -f ./docker-compose.yml run --rm composer install
     - docker-compose -f ./docker-compose.production-envs.yml build production-files-metadata-console
-    - docker tag ${CI_PROJECT_NAME}_production-files-metadata-console:$GIGADB_ENV registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
+    - docker tag ${CI_PROJECT_NAME}_production-files-metadata-console:latest registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
     - docker push registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
   artifacts:
     untracked: true

--- a/gigadb/app/tools/files-metadata-console/gitlab-config-staging-build.yml
+++ b/gigadb/app/tools/files-metadata-console/gitlab-config-staging-build.yml
@@ -25,11 +25,11 @@ FilesMetadataConsoleBuildStaging:
     - cp .secrets gigadb/app/tools/files-metadata-console/
     - cp .env gigadb/app/tools/files-metadata-console/
     - cd gigadb/app/tools/files-metadata-console
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:latest || true
+    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV || true
     - docker-compose -f ./docker-compose.yml run --rm configure
     - docker-compose -f ./docker-compose.yml run --rm composer install
     - docker-compose -f ./docker-compose.production-envs.yml build production-files-metadata-console
-    - docker tag ${CI_PROJECT_NAME}_production-files-metadata-console:latest registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
+    - docker tag ${CI_PROJECT_NAME}_production-files-metadata-console:$GIGADB_ENV registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
     - docker push registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
   artifacts:
     untracked: true

--- a/protected/commands/FilesCommand.php
+++ b/protected/commands/FilesCommand.php
@@ -48,7 +48,6 @@ class FilesCommand extends CConsoleCommand
 
             # Download and parse dataset md5 file
             $url = $this->findDatasetMd5FileUrl($dataset);
-            echo "Processing $url".PHP_EOL;
             $contents = DownloadService::downloadFile($url);
             $lines = explode("\n", $contents);
             foreach ($lines as $line) {
@@ -95,6 +94,7 @@ class FilesCommand extends CConsoleCommand
         foreach ($dataset::RANGES as $range) {
             $url = Yii::app()->params['ftp_connection_url']."/pub/gigadb/pub/10.5524/$range/$doi/$doi.md5";
             // Check URL resolves to a real file
+            echo "Processing $url" . PHP_EOL;
             $file_exists = DownloadService::fileExists($url);
             if ($file_exists)
                 return $url;


### PR DESCRIPTION
# Pull request for issue: #1527 

This is a pull request for the following functionalities:

The postUpload script can be executed successfully in both staging and live bastion servers.

## Pre-requisites

Make sure the variable `FTP_CONNECTION_URL`  with value `https://ftp.cngb.org` with all three environments `dev`, `staging` and `dev` has been set in your gitlab CI/CD variable page. 


## How to test?

Describe how the new functionalities can be tested by PR reviewers

```
# checkout this PR
% git checkout -b kencho51-fix-postUpload-file-size-and-url-errors 
% git pull https://github.com/kencho51/gigadb-website.git fix-postUpload-file-size-and-url-errors
# follow the release process doc to tag this PR, eg
% git tag -as v1.1.1-testing <the latest commit hash from this PR> -m "testing postUpload script"
% git push origin v1.1.1-testing 
# wait for a few minutes, a complete gitlab pipeline with live jobs are visible
# spin up the production staging servers, eg:
% cd ops/infrastructure/envs/staging
% /../../scripts/tf_init.sh --project gigascience/forks/kencho-gigadb-website --env staging
% terraform apply
% terraform refresh
% ../../../scripts/ansible_init.sh --env staging
% env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES TF_KEY_NAME=private_ip ansible-playbook -i ../../inventories webapp_playbook.yml --extra-vars="gigadb_env=staging"
% env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook -i ../../inventories bastion_playbook.yml -e "backupDate=latest" --extra-vars="gigadb_env=staging"
# spin up the production live servers, eg:
% /../../scripts/tf_init.sh --project gigascience/forks/kencho-gigadb-website --env live
% terraform apply
% terraform refresh
% ../../../scripts/ansible_init.sh --env live
% env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES TF_KEY_NAME=private_ip ansible-playbook -i ../../inventories webapp_playbook.yml --extra-vars="gigadb_env=live"
% env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook -i ../../inventories bastion_playbook.yml -e "backupDate=latest" --extra-vars="gigadb_env=live"
# create a user account in the live bastion server
% ansible-playbook -i ../../inventories users_playbook.yml -e "newuser=ken" --extra-vars="gigadb_env=live"
# then login to the live bastion server as a user
% ssh -i output/privkeys-3.36.8.228/ken ken@3.36.8.228
Activate the web console with: systemctl enable --now cockpit.socket

Last failed login: Thu Jan  4 03:51:19 UTC 2024 from 218.189.31.218 on ssh:notty
There was 1 failed login attempt since the last successful login.
[ken@ip-10-99-0-123 ~]$ 
[ken@ip-10-99-0-123 ~]$ ls -al uploadDir/
total 0
drwx------. 2 ken ken  6 Jan  4 03:40 .
drwx------. 4 ken ken   91 Jan  4 03:40 ..
[ken@ip-10-99-0-123 ~]$ sudo /home/centos/postUpload.sh 102462

* About to update files' size for 102462
nb. changes: 27

Done with updating files' size for 102462. Nb of successful changes saved in file: /home/centos/uploadLogs/updating-file-size-102462.txt

* About to check that file urls are valid for 102462
| URL | Issue |

Done with checking that file urls are valid for 102462. Invalid Urls (if any) are save in file: /home/centos/uploadLogs/invalid-urls-102462.txt

* About to update files' MD5 Checksum as file attribute for 102462
Processing https://ftp.cngb.org/pub/gigadb/pub/10.5524/104001_105000/102462/102462.md5
No file found at https://ftp.cngb.org/pub/gigadb/pub/10.5524/104001_105000/102462/102462.md5
Processing https://ftp.cngb.org/pub/gigadb/pub/10.5524/103001_104000/102462/102462.md5
No file found at https://ftp.cngb.org/pub/gigadb/pub/10.5524/103001_104000/102462/102462.md5
Processing https://ftp.cngb.org/pub/gigadb/pub/10.5524/102001_103000/102462/102462.md5
Saved md5 file attribute with id: 674001
Saved md5 file attribute with id: 674002
Saved md5 file attribute with id: 674003
Saved md5 file attribute with id: 674004
Saved md5 file attribute with id: 674005
Saved md5 file attribute with id: 674006
Saved md5 file attribute with id: 674007
Saved md5 file attribute with id: 674008
Saved md5 file attribute with id: 674009
Saved md5 file attribute with id: 674010
Saved md5 file attribute with id: 674011
Saved md5 file attribute with id: 674012
Saved md5 file attribute with id: 674013
Saved md5 file attribute with id: 674014
Saved md5 file attribute with id: 674015
Saved md5 file attribute with id: 674016
Saved md5 file attribute with id: 674017
Saved md5 file attribute with id: 674018
Saved md5 file attribute with id: 674019
Saved md5 file attribute with id: 674020
Saved md5 file attribute with id: 674021
Saved md5 file attribute with id: 674022
Saved md5 file attribute with id: 674023
Saved md5 file attribute with id: 674024
Saved md5 file attribute with id: 674025
Saved md5 file attribute with id: 674026
Saved md5 file attribute with id: 674548

Done with updating files' MD5 Checksum as file attribute for 102462. Process status is saved in file: /home/centos/uploadLogs/updating-md5checksum-102462.txt

* About to create the README file for 102462
[DOI] 10.5524/102462

[Title] Supporting data for "Evolutionary genomics of three agricultural pest
moths reveals rapid evolution of host adaptation and immune-related genes"

[Release Date] 2023-11-13

[Citation] Kawahara, AY; Plotkin, D; Weng, Y; Pathour, SR; Godfrey, KR; Parker,
BM; Wist, T (2023): Supporting data for "Evolutionary genomics of three
agricultural pest moths reveals rapid evolution of host adaptation and
immune-related genes" GigaScience Database. https://dx.doi.org/10.5524/102462

[Data Type] Genomic,Bioinformatics

[Data Summary] Understanding the genotype of pest species provides an important
baseline for designing integrated pest management (IPM) strategies. Recently
developed long-read sequence technologies make it possible to compare genomic
features of non-model pest species to disclose the evolutionary path underlying
the pest species profiles. While hundreds of published genomes of lepidopteran
species (moths and butterflies) are now available, only a few genome assemblies
are publicly available from this diverse and notorious agricultural pest family,
Gelechiidae. <br>We sequenced and assembled genomes for three gelechiids:
<i>Phthorimaea absoluta</i> (tomato leafminer), <i>Keiferia lycopersicella</i>
(tomato pinworm), and <i>Scrobipalpa atriplicella</i> (goosefoot groundling
moth). We compared these genomes with published genomes of <i>Phthorimaea
operculella</i> and <i>Pectinophora gossypiella</i>, and found that the three
solanaceous feeding species, <i>Ph. absoluta, K. lycopersicella</i>, and <i>Ph.
operculella</i> are clustered together. Gene family evolution analyses with the
five species show clear gene family expansions on hostplant associated genes for
the three solanaceous feeding species. These genes are involved in host compound
sensing (e.g., gustatory receptors), detoxification (e.g., Cytochrome P450,
Glucose-methanol-choline oxidoreductase, Glutathione S-transferase, Insect
cuticle proteins, and UDP-glucuronosyl), and digestion (e.g., serine proteases
and Aminopeptidase N-type). A gene ontology enrichment analysis of rapidly
evolving genes also suggests enriched functions in host sensing and immunity.
Our results indicate that host plant adaptation and pathogen defense could be
important drivers in species diversification among gelechiid moths.

[File Location] https://ftp.cngb.org/pub/gigadb/pub/10.5524/102001_103000/102462/

[File name] - [File Description]
astral_species_tree.tre  -  The species tree drawn with ASTRAL3 based on the 4,876 single copy gene trees
0_pope_result_uniq  -  The result of gene family expansion/contraction analysis on *Phthorimaea operculella* using CAFE v5.0.0 with significant cutoff at p-value=0.01
1_kely_result_uniq  -  The result of gene family expansion/contraction analysis on *Keiferia lycopersicella* using CAFE v5.0.0 with significant cutoff at p-value=0.01
2_tuta_result_uniq  -  The result of gene family expansion/contraction analysis on *Phthorimaea absoluta* using CAFE v5.0.0 with significant cutoff at p-value=0.01
3_0_result_uniq  -  The result of gene family expansion/contraction analysis on internal node #3 (see header of HOGs_gamma_change_matrix.tsv) using CAFE v5.0.0 with significant cutoff at p-value=0.01 and functional annotation of *Phthorimaea operculella*
3_1_result_uniq  -  The result of gene family expansion/contraction analysis on internal node #3 (see header of HOGs_gamma_change_matrix.tsv) using CAFE v5.0.0 with significant cutoff at p-value=0.01 and functional annotation of *Keiferia lycopersicella*
4_scat_result_uniq  -  The result of gene family expansion/contraction analysis on *Scrobipalpa atriplicella* using CAFE v5.0.0 with significant cutoff at p-value=0.01
5_0_result_uniq  -  The result of gene family expansion/contraction analysis on internal node #5 (see header of HOGs_gamma_change_matrix.tsv) using CAFE v5.0.0 with significant cutoff at p-value=0.01 and functional annotation of *Phthorimaea operculella*
5_1_result_uniq  -  The result of gene family expansion/contraction analysis on internal node #5 (see header of HOGs_gamma_change_matrix.tsv) using CAFE v5.0.0 with significant cutoff at p-value=0.01 and functional annotation of *Keiferia lycopersicella*
readme_102462.txt  -  
5_2_result_uniq  -  The result of gene family expansion/contraction analysis on internal node #5 (see header of HOGs_gamma_change_matrix.tsv) using CAFE v5.0.0 with significant cutoff at p-value=0.01 and functional annotation of *Phthorimaea absoluta*
6_pego_result_uniq  -  The result of gene family expansion/contraction analysis on *Pectinophora gossypiella* using CAFE v5.0.0 with significant cutoff at p-value=0.01
7_0_result_uniq  -  The result of gene family expansion/contraction analysis on internal node #7 (see header of HOGs_gamma_change_matrix.tsv) using CAFE v5.0.0 with significant cutoff at p-value=0.01 and functional annotation of *Phthorimaea operculella*
7_1_result_uniq  -  The result of gene family expansion/contraction analysis on internal node #7 (see header of HOGs_gamma_change_matrix.tsv) using CAFE v5.0.0 with significant cutoff at p-value=0.01 and functional annotation of *Keiferia lycopersicella*
7_5_result_uniq  -  The result of gene family expansion/contraction analysis on internal node #7 (see header of HOGs_gamma_change_matrix.tsv) using CAFE v5.0.0 with significant cutoff at p-value=0.01 and functional annotation of *Pectinophora gossypiella*
HOGs_gamma_change_matrix.tsv  -  The raw family size change output of CAFE v5.0.0
significant_change_HOGs.tsv  -  All HOGs passed through the significant cutoff at p-vlaue=0.01
supermatrix_tree.tre  -  The molecular phylogeny drawn with the concatinated supermatrix from the 4,876 single copy gene sequences using IQ-TREE v2.2.2
super_matrix_alignment.fasta  -  The concatinated supermatrix from the 4,876 aligned single copy gene sequences
Table_S1_gFACs_results.csv  -  Supplemental table S1, the gene model summaries using gFACs
Table_S2_list_of_rapidly_evolve_HOGs.csv  -  Supplemental table S2, the list of significanly expanding/contracting HOGs
Table_S3_immunity_HOGs.csv  -  Supplemental table S3, the significanly expanding/contracting HOGs that are associated with immunity
Table_S4_host_adaptation_HOGs.csv  -  Supplemental table S4, the significanly expanding/contracting HOGs that are associated with host adaptation
Table_S5_enriched_GO_summary.csv  -  Supplemental table S5, the enriched gene ontology (GO) terms based on the significanly expanding/contracting HOGs
genome_assembling_of_gelechiid_moths-main.zip  -  Archival copy of the GitHub repository https://github.com/yimingweng/genome_assembling_of_gelechiid_moths, downloaded 5-Oct-2023. The genome assembly project for the Tomato Pinworm, Keiferia lycopersicella (Walsingham), Phthorimaea absoluta (Tuta absoluta, tomato leafminer), and Scrobipalpa atriplicella (goosefoot groundling moth). Released under a MIT license. Please see the current GitHub repository for the most recent updates.
7_2_result_uniq  -  The result of gene family expansion/contraction analysis on internal node #7 (see header of HOGs_gamma_change_matrix.tsv) using CAFE v5.0.0 with significant cutoff at p-value=0.01 and functional annotation of *Phthorimaea absoluta*
HOG_for_cafe.tsv  -  The Hierarchical Orthologous Groups (HOGs) data matrix generated from OrthoFinder for CAFE v5.0.0 analysis

[License]
All files and data are distributed under the CC0 1.0 Universal (CC0 1.0) Public
Domain Dedication (https://creativecommons.org/publicdomain/zero/1.0/), unless
specifically stated otherwise, see http://gigadb.org/site/term for more details.

[Comments]

[End]

Done with creating the README file for 102462. The README file is saved in file: /home/centos/uploadLogs/readme-102462.txt

All postUpload logs have been moved to: /home/ken/uploadDir

PostUpload jobs done!
[ken@ip-10-99-0-123 ~]$
[ken@ip-10-99-0-123 ~]$ ls -al uploadDir/
total 20
drwx------. 2 ken ken  138 Jan  4 03:55 .
drwx------. 4 ken ken   91 Jan  4 03:52 ..
-rw-r--r--. 1 ken ken   16 Jan  4 03:54 invalid-urls-102462.txt
-rw-r--r--. 1 ken ken 7661 Jan  4 03:55 readme-102462.txt
-rw-r--r--. 1 ken ken   16 Jan  4 03:54 updating-file-size-102462.txt
-rw-r--r--. 1 ken ken 1554 Jan  4 03:55 updating-md5checksum-102462.txt
```

## How have functionalities been implemented?

Describe how the new functionalities have been implemented by the
changed code at a high level

Currently, the postUpload.sh uses image `registry.gitlab.com/$GITLAB_PROJECT/production-files-metadata-console:latest` to update file size and check urls, but actually it is redundant as it is not used in both staging build and live build.

The files meta console will be built to `$user-gigadb-website_production-files-metadata-console:latest` and then tagged as `registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV` which will be pushed to the gitlab registry.

So in the postUpload.sh, the image used should be `registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV` as it contains the right env variables and the updated code.

## Any issues with implementation?

None.

## Any changes to automated tests?
None.

## Any changes to documentation?

None.

## Any technical debt repayment?

When trying to provision a bastion server, an error would occur:
```
% env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook -i ../../inventories bastion_playbook.yml -e "backupDate=latest" --extra-vars="gigadb_env=staging"
.
.
.
TASK [../../roles/centos-eol-fix : ansible.builtin.rpm_key] ***********************************************************************************************************************************************************************
fatal: [10.99.0.248]: FAILED! => {"changed": false, "msg": "failed to fetch key at https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG , error was: HTTP Error 404: Not Found"}
```

By looking into https://download.postgresql.org/pub/repos/yum, it appears that the rpm key url has been relocated to keys directory. 
After the updating the key url to https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL, the ansible plays can be executed and install postgresql repo.


## Any improvements to CI/CD pipeline?

None.