### PR TITLE
Update data volume size on home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1595: Update total volume of data on home page
 - Fix #1529: Reload the same admin form page after save for private dataset
 - Feat #1259: Document how to update dataset spreadsheet template
 

--- a/protected/views/site/index.php
+++ b/protected/views/site/index.php
@@ -221,8 +221,8 @@
                                     <div class="home-color-background-block">
                                         <div class="text-icon text-icon-o text-icon-lg">
                                             <img src="/images/new_interface_image/volume.svg" alt="Total Volume of Data"></div>
-                                        <h4>31</h4>
-                                        <p>Data volume(TB)</p>
+                                        <h4>65</h4>
+                                        <p>Data volume (TB)</p>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
# Pull request for issue: #1595

This is a pull request for the following functionalities:

* Updated data volume size displayed on home page

## How to test?

Checkout the code in the this pull request into a new branch containing the latest develop code in your local fork of gigadb-website repo and spin up a local dev instance of GigaDB:
```
git checkout -b pli888-update-total-volume develop
git pull https://github.com/pli888/gigadb-website.git update-total-volume
./up.sh
```

Take a look at the home page on http://gigadb.gigasciencejournal.com:9170 and confirm you can see Data volume (TB) has a value of 65. The same change can also be seen on your staging server if you decide to test this PR on an AWS deployment.

## How have functionalities been implemented?

The size of the 100001_101000, 101001_102000, 102001_103000 and 200001_201000 directories containing published datasets was queried on the Tencent back up server. The total size of all 4 directories was calculated to be approximately 65 TB. This value was then used to update the `protected/views/site/index.php` file.
