### PR TITLE
Hide remove image record button and show loading icon after submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1591: Hide the remove image record button and show loading icon after submit
+
 ## v4.1.0 - 2024-01-24 - d0495bee
 
 - Fix #1654: Fix AdminDatasetForm acceptance tests

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -454,10 +454,13 @@ class AdminDatasetController extends Controller
             $model->image_id = Image::GENERIC_IMAGE_ID;
             if ($model->save()) {
                 try {
-                    if ( Image::model()->findByPk($oldImageID)->delete() )
+                    sleep(5);
+                    if (Image::model()->findByPk($oldImageID)->delete()) {
                         $result['status'] = true;
-                    else
+                        Yii::app()->user->setFlash('removeSuccess', 'Image records removed successfully!');
+                    } else {
                         Yii::log("Failed deleting image record $oldImageID", "error");
+                    }
                 } catch (CDbException $e) {
                     Yii::log($e->getMessage(),"error");
                 }

--- a/protected/views/adminDataset/_form.php
+++ b/protected/views/adminDataset/_form.php
@@ -10,6 +10,12 @@
     </div>
 <?php } ?>
 
+<?php if ($flashSuccess = Yii::app()->user->getFlash('removeSuccess')) { ?>
+    <div class="alert alert-success" role="alert">
+        <?= $flashSuccess ?>
+    </div>
+<?php } ?>
+
 <?php
 $cs = Yii::app()->getClientScript();
 $cssCoreUrl = $cs->getCoreScriptUrl();

--- a/protected/views/adminDataset/_form.php
+++ b/protected/views/adminDataset/_form.php
@@ -20,7 +20,6 @@ $cs->registerCssFile('/css/jquery.tag-editor.css');
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/caret/1.0.0/jquery.caret.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/tag-editor/1.0.20/jquery.tag-editor.min.js"></script>
-
 <?php $form=$this->beginWidget('CActiveForm', array(
     'id'=>'dataset-form',
     'enableAjaxValidation'=>false,
@@ -56,13 +55,13 @@ echo $form->hiddenField($model, "image_id");
                         <div class="controls">
                             <?php
                             $criteria = new CDbCriteria;
-                            $criteria->condition='role=\'admin\' and email like \'%gigasciencejournal.com\''; 
+                            $criteria->condition='role=\'admin\' and email like \'%gigasciencejournal.com\'';
                             ?>
                             <?php echo $form->dropDownList($model,'curator_id',CHtml::listData(User::model()->findAll($criteria),'id','email'),array('prompt'=>'','style'=>'margin-top:-40px')); ?>
                             <?php echo $form->error($model,'curator_id'); ?>
                         </div>
                     </div>
-                     <div class="control-group">
+                    <div class="control-group">
                         <?php echo $form->labelEx($model,'manuscript_id',array('class'=>'control-label')); ?>
                         <div class="controls">
                             <?php echo $form->textField($model,'manuscript_id',array('size'=>60,'maxlength'=>200,'style'=>'margin-top:-40px')); ?>
@@ -80,34 +79,34 @@ echo $form->hiddenField($model, "image_id");
 
                     <div class="control-group">
                         <fieldset class="checkboxes">
-                                <legend class="checkboxes-legend">Types</legend>
-                                <?
-                                    $datasetTypes = CHtml::listData(Type::model()->findAll(),'id','name');
-                                    $checkedTypes = CHtml::listData($model->datasetTypes,'id','id');
-                                    foreach ($datasetTypes as $id => $datasetType) {
+                            <legend class="checkboxes-legend">Types</legend>
+                            <?
+                            $datasetTypes = CHtml::listData(Type::model()->findAll(),'id','name');
+                            $checkedTypes = CHtml::listData($model->datasetTypes,'id','id');
+                            foreach ($datasetTypes as $id => $datasetType) {
 //                                        echo '<div class="control-group">';
-                                        echo $form->labelEx($model,"$datasetType",array('class'=>'checkbox-label'));
-                                        $checkedHtml = in_array($id,$checkedTypes,true) ? 'checked="checked"' : '';
-                                        $checkboxId="Dataset_$datasetType";
-                                        echo '<div class="controls">';
-                                        echo '<input id="'.$checkboxId.'" type="checkbox" name="datasettypes['.$id.']" value="1"'.$checkedHtml.' style="margin-top:-25px"/>';
-                                        echo '</div>';
+                                echo $form->labelEx($model,"$datasetType",array('class'=>'checkbox-label'));
+                                $checkedHtml = in_array($id,$checkedTypes,true) ? 'checked="checked"' : '';
+                                $checkboxId="Dataset_$datasetType";
+                                echo '<div class="controls">';
+                                echo '<input id="'.$checkboxId.'" type="checkbox" name="datasettypes['.$id.']" value="1"'.$checkedHtml.' style="margin-top:-25px"/>';
+                                echo '</div>';
 //                                        echo '</div>';
 
-                                    }
-                                ?>
+                            }
+                            ?>
                         </fieldset>
                     </div>
 
 
 
-<!--                    <div class="control-group">-->
-<!--                        --><?php //echo $form->labelEx($model,'dataset_size',array('label'=>'Dataset Size in Bytes','class'=>'control-label')); ?>
-<!--                        <div class="controls">-->
-<!--                            --><?php //echo $form->textField($model,'dataset_size',array('size'=>60,'maxlength'=>200,'style'=>'margin-top:-40px')); ?>
-<!--                            --><?php //echo $form->error($model,'dataset_size'); ?>
-<!--                        </div>-->
-<!--                    </div>-->
+                    <!--                    <div class="control-group">-->
+                    <!--                        --><?php //echo $form->labelEx($model,'dataset_size',array('label'=>'Dataset Size in Bytes','class'=>'control-label')); ?>
+                    <!--                        <div class="controls">-->
+                    <!--                            --><?php //echo $form->textField($model,'dataset_size',array('size'=>60,'maxlength'=>200,'style'=>'margin-top:-40px')); ?>
+                    <!--                            --><?php //echo $form->error($model,'dataset_size'); ?>
+                    <!--                        </div>-->
+                    <!--                    </div>-->
 
                 </div>
                 <div class="span1">
@@ -154,15 +153,22 @@ echo $form->hiddenField($model, "image_id");
                             </div>
                             <label for="image_upload_image" class="control-label">Image Status</label>
                             <?php if($model->image && 0 != $model->image->id ){ ?>
-                            <div class="controls">
-                                <ul>
-                                    <li style="list-style: none;"><?php echo CHtml::fileField('datasetImage'); ?></li>
-                                    <li style="list-style: none;"><?php echo CHtml::ajaxLink('Remove image record (file+metadata)',Yii::app()->createUrl('/adminDataset/removeImage/'),
-                                            array(
-                                                'type'=>'POST',
-                                                'data'=> array('doi'=>'js:$("#Dataset_identifier").val()'),
-                                                'dataType'=>'json',
-                                                'success'=>'js:function(output){
+                                <div class="controls">
+                                    <ul>
+                                        <li style="list-style: none;"><?php echo CHtml::fileField('datasetImage'); ?></li>
+                                        <li style="list-style: none;">
+                                            <?php echo CHtml::ajaxLink('Remove image record (file+metadata)',Yii::app()->createUrl('/adminDataset/removeImage/'),
+                                                array(
+                                                    'type'=>'POST',
+                                                    'data'=> array('doi'=>'js:$("#Dataset_identifier").val()'),
+                                                    'dataType'=>'json',
+                                                    'beforeSend' => 'function() {
+                                                    // Show the loading indicator
+                                                    $("#loadingIndicator").show();
+                                                    // Disable the removeButton
+                                                    $("#removeButton").css("display", "none");
+                                                }',
+                                                    'success'=>'js:function(output){
                                                     console.log(output);
                                                     if(output.status){
                                                         $("#showImage").src = "https://assets.gigadb-cdn.net/images/datasets/no_image.png";
@@ -174,17 +180,29 @@ echo $form->hiddenField($model, "image_id");
                                                         $("#removing").html("Failed removing image");
                                                     }
                                                 }',
-                                            ),array('class'=>'btn btn-sm',
+                                                    'complete' => 'function() {
+                                                    // Hide the loading indicator
+                                                    $("#loadingIndicator").hide();
+                                                    // Enable the removeButton
+                                                    $("#removeButton").prop("disabled", false);
+                                                }'
+                                                ),array('class'=>'btn btn-sm',
                                                     'id' =>'removeButton',
                                                     'style'=>'width:90%;font-size: smaller; font-weight: lighter;color: #fff ; background: #c12e2a',
                                                     'title' => 'the dataset will be associated with the generic image record afterward',
                                                     'confirm'=>'Are you sure? This will take effect immediately',
 
-                                            ));
-     ?></li>
-                                    <li style="list-style: none;"><div id="removing"></div></li>
-                                </ul>
-                            </div>
+                                                ));
+                                            ?>
+                                        </li>
+                                        <li style="list-style: none;">
+                                            <div id="loadingIndicator" style="display: none; font-size: 20px;">
+                                                <i class="fa fa-spinner fa-spin"></i><span>Please wait, removing image records...</span>
+                                            </div>
+                                        </li>
+                                        <li style="list-style: none;"><div id="removing"></div></li>
+                                    </ul>
+                                </div>
                             <?php } else { ?>
                                 <div class="controls">
                                     <?php echo CHtml::fileField('datasetImage'); ?>
@@ -269,11 +287,11 @@ echo $form->hiddenField($model, "image_id");
                                         <?php
                                         $status_array = array('Submitted', 'UserStartedIncomplete', 'Curation');
                                         echo CHtml::ajaxLink('Mint DOI',Yii::app()->createUrl('/adminDataset/mint/'),
-                                        array(
-                                            'type'=>'POST',
-                                            'data'=> array('doi'=>'js:$("#Dataset_identifier").val()'),
-                                            'dataType'=>'json',
-                                            'success'=>'js:function(output){
+                                            array(
+                                                'type'=>'POST',
+                                                'data'=> array('doi'=>'js:$("#Dataset_identifier").val()'),
+                                                'dataType'=>'json',
+                                                'success'=>'js:function(output){
                                                 console.log(output);
                                                 if(output.status){
                                                     $("#minting").html("new DOI successfully minted");
@@ -283,22 +301,22 @@ echo $form->hiddenField($model, "image_id");
                                                 }
                                                 $("#mint_doi_button").toggleClass("active");
                                             }',
-                                        ),array('class'=>'btn btn-green',
+                                            ),array('class'=>'btn btn-green',
                                                 'id' =>'mint_doi_button',
                                                 'disabled'=>in_array($model->upload_status, $status_array),
                                                 'style'=>'width:40%; margin-top:-30px;',
-                                                
-                                        ));
+
+                                            ));
 
                                         ?>
                                         <div id="minting"></div>
-                                    
+
                                         <?php
-                                            if("Curation" === $model->upload_status) {
-                                                echo CHtml::link("Move files to public ftp",
-                                                    "/adminDataset/moveFiles/doi/{$model->identifier}",
-                                                    ["class" => "btn btn-green btn-mini", "style"=>"margin-left:2px;margin-top:2px;"]);
-                                            }
+                                        if("Curation" === $model->upload_status) {
+                                            echo CHtml::link("Move files to public ftp",
+                                                "/adminDataset/moveFiles/doi/{$model->identifier}",
+                                                ["class" => "btn btn-green btn-mini", "style"=>"margin-left:2px;margin-top:2px;"]);
+                                        }
                                         ?>
                                     </div>
 
@@ -321,24 +339,24 @@ echo $form->hiddenField($model, "image_id");
                     <div class="control-group">
                         <?php echo $form->labelEx($model,'fairnuse',array('class'=>'control-label')); ?>
                         <div class="controls">
-                        <?php echo $form->textField($model,'fairnuse',array('class'=>'span4 date', 'style'=>'margin-top:-40px')); ?>
-                        <?php echo $form->error($model,'fairnuse'); ?>
+                            <?php echo $form->textField($model,'fairnuse',array('class'=>'span4 date', 'style'=>'margin-top:-40px')); ?>
+                            <?php echo $form->error($model,'fairnuse'); ?>
                         </div>
                     </div>
 
                     <div class="control-group">
                         <?php echo $form->labelEx($model,'publication_date',array('class'=>'control-label')); ?>
                         <div class="controls">
-                        <?php echo $form->textField($model,'publication_date',array('class'=>'span4 date js-date-pub', 'disabled'=>$model->upload_status == 'Published', 'style'=>'margin-top:-40px')); ?>
-                        <?php echo $form->error($model,'publication_date'); ?>
+                            <?php echo $form->textField($model,'publication_date',array('class'=>'span4 date js-date-pub', 'disabled'=>$model->upload_status == 'Published', 'style'=>'margin-top:-40px')); ?>
+                            <?php echo $form->error($model,'publication_date'); ?>
                         </div>
                     </div>
 
                     <div class="control-group">
                         <?php echo $form->labelEx($model,'modification_date',array('class'=>'control-label')); ?>
                         <div class="controls">
-                        <?php echo $form->textField($model,'modification_date',array('class'=>'span4 date', 'style'=>'margin-top:-40px')); ?>
-                        <?php echo $form->error($model,'modification_date'); ?>
+                            <?php echo $form->textField($model,'modification_date',array('class'=>'span4 date', 'style'=>'margin-top:-40px')); ?>
+                            <?php echo $form->error($model,'modification_date'); ?>
                         </div>
                     </div>
 
@@ -387,9 +405,9 @@ echo $form->hiddenField($model, "image_id");
                     </div>
                 </div>
             </div> <!-- end of row of one column -->
-            
-           <!-- <?php echo CHtml::link('Curation Log', $this->createAbsoluteUrl('curationlog/admin',array('id'=>$model->id))); ?> -->
-            
+
+            <!-- <?php echo CHtml::link('Curation Log', $this->createAbsoluteUrl('curationlog/admin',array('id'=>$model->id))); ?> -->
+
             <?php if ( isset($dataset_id) ) {
                 echo $this->renderPartial("curationLog",array('dataset_id'=>$dataset_id,'model'=>$curationlog));
             }
@@ -403,116 +421,136 @@ echo $form->hiddenField($model, "image_id");
 <div class="span12" style="text-align:center">
     <a href="<?=Yii::app()->createUrl('/adminDataset/admin')?>" class="btn"/>Cancel</a>
     <?= CHtml::submitButton($model->isNewRecord ? 'Create' : 'Save', array('class' => 'btn-green')); ?>
-        <?php if( "hidden" === $datasetPageSettings->getPageType() || "draft" === $datasetPageSettings->getPageType() ) { ?>
-    <a href="<?=Yii::app()->createUrl('/adminDataset/private/identifier/'.$model->identifier)?>" class="btn-green"/>Create/Reset Private URL</a>
-            <?php if($model->token){?>
+    <?php if( "hidden" === $datasetPageSettings->getPageType() || "draft" === $datasetPageSettings->getPageType() ) { ?>
+        <a href="<?=Yii::app()->createUrl('/adminDataset/private/identifier/'.$model->identifier)?>" class="btn-green"/>Create/Reset Private URL</a>
+        <?php if($model->token){?>
             <a href="<?= Yii::app()->createUrl('/dataset/'.$model->identifier.'/token/'.$model->token) ?>">Open Private URL</a>
-            <?php }?>
-        <?php } elseif ( "mockup" === $datasetPageSettings->getPageType() ) { 
-                echo CHtml::link('Generate mockup for reviewers','#', array('class' => 'btn btn-primary', 'data-toggle' => "modal", 'data-target' => "#mockupCreation"));
-            }
-            ?>
+        <?php }?>
+    <?php } elseif ( "mockup" === $datasetPageSettings->getPageType() ) {
+        echo CHtml::link('Generate mockup for reviewers','#', array('class' => 'btn btn-primary', 'data-toggle' => "modal", 'data-target' => "#mockupCreation"));
+    }
+    ?>
 
 </div>
 <?php $this->endWidget(); ?>
 <div class="modal fade" id="mockupCreation" tabindex="-1" role="dialog" aria-labelledby="generateMockup">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title">Generate unique and time-limited mockup url for reviewers</h4>
-      </div>
-    <?php echo CHtml::beginForm("/adminDataset/mockup/id/".$model->id,"POST",["id" =>"mockupform"]); ?>
-      <div class="modal-body">
-            <label for="reviewerEmail" class="control-label">Reviewer's email</label>
-            <input type="text" name="revieweremail" class="form-control" />
-            <div class="btn-group" data-toggle="buttons">
-              <label class="btn btn-primary active">
-                <input type="radio" name="monthsofvalidity" id="nbMonths1" value="1" autocomplete="off" checked>1 month
-              </label>
-              <label class="btn btn-primary">
-                <input type="radio" name="monthsofvalidity" id="nbMonths3" value="3" autocomplete="off">3 months
-              </label>
-              <label class="btn btn-primary">
-                <input type="radio" name="monthsofvalidity" id="nbMonths6" value="6" autocomplete="off">6 months
-              </label>
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Generate unique and time-limited mockup url for reviewers</h4>
             </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-        <?php echo CHtml::submitButton("Generate mockup",[ "class" => "btn-green mockup"]); ?>
-      </div>
-    <?php echo CHtml::endForm(); ?>
-    </div><!-- /.modal-content -->
-  </div><!-- /.modal-dialog -->
+            <?php echo CHtml::beginForm("/adminDataset/mockup/id/".$model->id,"POST",["id" =>"mockupform"]); ?>
+            <div class="modal-body">
+                <label for="reviewerEmail" class="control-label">Reviewer's email</label>
+                <input type="text" name="revieweremail" class="form-control" />
+                <div class="btn-group" data-toggle="buttons">
+                    <label class="btn btn-primary active">
+                        <input type="radio" name="monthsofvalidity" id="nbMonths1" value="1" autocomplete="off" checked>1 month
+                    </label>
+                    <label class="btn btn-primary">
+                        <input type="radio" name="monthsofvalidity" id="nbMonths3" value="3" autocomplete="off">3 months
+                    </label>
+                    <label class="btn btn-primary">
+                        <input type="radio" name="monthsofvalidity" id="nbMonths6" value="6" autocomplete="off">6 months
+                    </label>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                <?php echo CHtml::submitButton("Generate mockup",[ "class" => "btn-green mockup"]); ?>
+            </div>
+            <?php echo CHtml::endForm(); ?>
+        </div><!-- /.modal-content -->
+    </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
 <script type="text/javascript">
 
-$(function() {
+    $(function() {
 
-    var publication_date = $('.js-date-pub');
-    var months = new Array('Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec');
+        var publication_date = $('.js-date-pub');
+        var months = new Array('Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec');
 
-    function today() {
-        var d = new Date();
-        return new Array(
-            ("0" + d.getDate()).slice(-2) + '-' + months[d.getMonth()] + '-' + d.getFullYear(),
-            d.getFullYear() + '-' + ("0" + (d.getMonth() + 1)).slice(-2) + '-' + ("0" + d.getDate()).slice(-2)
-        );
-    }
-
-    //$("#myModal").modal();
-    $('.date').datepicker({'dateFormat': 'yy-mm-dd'});
-
-    // On Published show modal if date != date today
-    $('.js-pub').on('change', function(e) {
-        if ($(this).val() === 'Published') {
-            var d = today();
-            if (publication_date.val() && publication_date.val() !== d[1]) {
-                var current = new Date(publication_date.val());
-                var textDate = ("0" + current.getDate()).slice(-2) + '-' + months[current.getMonth()] + '-' + current.getFullYear();
-                $("#current").text(textDate);
-                $("#today").text(d[0]);
-                $("#myModal").modal('show');
-            } else if (!publication_date.val()) {
-                publication_date.val(d[1]);
-            }
+        function today() {
+            var d = new Date();
+            return new Array(
+                ("0" + d.getDate()).slice(-2) + '-' + months[d.getMonth()] + '-' + d.getFullYear(),
+                d.getFullYear() + '-' + ("0" + (d.getMonth() + 1)).slice(-2) + '-' + ("0" + d.getDate()).slice(-2)
+            );
         }
+
+        //$("#myModal").modal();
+        $('.date').datepicker({'dateFormat': 'yy-mm-dd'});
+
+        // On Published show modal if date != date today
+        $('.js-pub').on('change', function(e) {
+            if ($(this).val() === 'Published') {
+                var d = today();
+                if (publication_date.val() && publication_date.val() !== d[1]) {
+                    var current = new Date(publication_date.val());
+                    var textDate = ("0" + current.getDate()).slice(-2) + '-' + months[current.getMonth()] + '-' + current.getFullYear();
+                    $("#current").text(textDate);
+                    $("#today").text(d[0]);
+                    $("#myModal").modal('show');
+                } else if (!publication_date.val()) {
+                    publication_date.val(d[1]);
+                }
+            }
+        });
+
+        // Change the publication date with date today
+        $('.changeToday').on('click', function(e) {
+            var d = today();
+            publication_date.val(d[1]);
+            $("#myModal").modal('hide');
+        });
+
     });
 
-    // Change the publication date with date today
-    $('.changeToday').on('click', function(e) {
-        var d = today();
-        publication_date.val(d[1]);
-        $("#myModal").modal('hide');
-    });
-
-});
-
-<?php
-$js_array = json_encode($model->getSemanticKeywords());
-echo "var existingTags = ". $js_array . ";\n";
-?>
+    <?php
+    $js_array = json_encode($model->getSemanticKeywords());
+    echo "var existingTags = ". $js_array . ";\n";
+    ?>
     $('#keywords').tagEditor({
-    initialTags:
+        initialTags:
         existingTags,
-    delimiter: ',', /* comma */
-    placeholder: 'Enter keywords (separated by commas) ...'
-});
-
-$(function(){
-    $('#mint_doi_button').click(function() {
-        $('#minting').html('minting under way, please wait');
-        $(this).toggleClass('active');
+        delimiter: ',', /* comma */
+        placeholder: 'Enter keywords (separated by commas) ...'
     });
-});
 
-var image = document.getElementById("showImage");
-var image_id = document.getElementById("Dataset_image_id").value;
+    $(function(){
+        $('#mint_doi_button').click(function() {
+            $('#minting').html('minting under way, please wait');
+            $(this).toggleClass('active');
+        });
+    });
 
-//Show image meta data, preview uploaded image in update page
-if(image.src != 'https://assets.gigadb-cdn.net/images/datasets/no_image.png') {
-    $('.meta-fields').css('display', '');
+    var image = document.getElementById("showImage");
+    var image_id = document.getElementById("Dataset_image_id").value;
+
+    //Show image meta data, preview uploaded image in update page
+    if(image.src != 'https://assets.gigadb-cdn.net/images/datasets/no_image.png') {
+        $('.meta-fields').css('display', '');
+        document.getElementById("datasetImage").addEventListener('change', (event) => {
+            if(event.target.files.length != 0) {
+                var src = URL.createObjectURL(event.target.files[0]);
+                var preview = document.getElementById("imagePreview");
+                preview.src = src;
+                preview.style.display = "block";
+                $('.meta-fields').css('display', '');
+                $('#showImage').css('display', 'none');
+                $('#removeButton').css('display', 'none');
+            } else {
+                $('.meta-fields').css('display', '');
+                $('#showImage').css('display', 'block');
+                $('#removeButton').css('display', '');
+                $('#imagePreview').css('display', 'none');
+            }
+        })
+    };
+
+    //Show image meta data, preview uploaded image in create page
+
     document.getElementById("datasetImage").addEventListener('change', (event) => {
         if(event.target.files.length != 0) {
             var src = URL.createObjectURL(event.target.files[0]);
@@ -521,40 +559,20 @@ if(image.src != 'https://assets.gigadb-cdn.net/images/datasets/no_image.png') {
             preview.style.display = "block";
             $('.meta-fields').css('display', '');
             $('#showImage').css('display', 'none');
-            $('#removeButton').css('display', 'none');
         } else {
-            $('.meta-fields').css('display', '');
+            $('.meta-fields').css('display', 'none');
             $('#showImage').css('display', 'block');
-            $('#removeButton').css('display', '');
             $('#imagePreview').css('display', 'none');
         }
-    })
-};
+    });
 
-//Show image meta data, preview uploaded image in create page
+    // if no image loaded and no image selected for upload, don't show metadata fields (unless there is a custom image associated with the dataset)
+    if ('' == image.src && 0 == document.getElementById("datasetImage").files.length) {
 
-document.getElementById("datasetImage").addEventListener('change', (event) => {
-    if(event.target.files.length != 0) {
-        var src = URL.createObjectURL(event.target.files[0]);
-        var preview = document.getElementById("imagePreview");
-        preview.src = src;
-        preview.style.display = "block";
-        $('.meta-fields').css('display', '');
-        $('#showImage').css('display', 'none');
-    } else {
-        $('.meta-fields').css('display', 'none');
-        $('#showImage').css('display', 'block');
-        $('#imagePreview').css('display', 'none');
+        if (0 == image_id || null == image_id) {
+            $('.meta-fields').css('display', 'none');
+        }
     }
-});
-
-// if no image loaded and no image selected for upload, don't show metadata fields (unless there is a custom image associated with the dataset)
-if ('' == image.src && 0 == document.getElementById("datasetImage").files.length) {
-
-    if (0 == image_id || null == image_id) {
-        $('.meta-fields').css('display', 'none');
-    }
-}
 
 </script>
 

--- a/protected/views/layouts/main.php
+++ b/protected/views/layouts/main.php
@@ -9,6 +9,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.js" ></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.ba-bbq/1.2.1/jquery.ba-bbq.min.js" ></script>
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.0.4/css/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" defer></script>
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
         <!--[if lt IE 9]>

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -204,23 +204,26 @@ Feature: form to update dataset details
     And I should see "https://doi.org/10.5524/123789"
 
   @ok
-  Scenario:  Can remove custom image
+  Scenario:  Can remove custom image and display loading message
     When I am on "/adminDataset/update/id/200"
     And I follow "Remove image"
     And I confirm to "Are you sure? This will take effect immediately"
-    And I wait "1" seconds
-    Then I should not see "Image URL"
+    And I should see "Please wait, removing image records..."
+    Then I wait "10" seconds
+    And I should not see "Image URL"
     And I should not see "Image Source"
     And I should not see "Image Tag"
     And I should not see "Image License"
     And I should not see "Image Photographer"
     And I should see an image located in "/images/datasets/no_image.png"
+    And I should see "Image records removed successfully!"
 
   @ok
   Scenario: Can remove custom image and immediately upload a new image
     When I am on "/adminDataset/update/id/22"
     And I follow "Remove image"
     And I confirm to "Are you sure? This will take effect immediately"
+    And I should see "Please wait, removing image records..."
     And I wait "1" seconds
     And I attach the file "bgi_logo_new.png" to the file input element "datasetImage"
     And I wait "1" seconds
@@ -267,7 +270,8 @@ Feature: form to update dataset details
     And I wait "2" seconds
     And I follow "Remove image"
     And I confirm to "Are you sure? This will take effect immediately"
-    And I wait "1" seconds
+    And I should see "Please wait, removing image records..."
+    And I wait "10" seconds
     Then I should not see "Image URL"
     And I should not see "Image Source"
     And I should not see "Image Tag"


### PR DESCRIPTION
# Pull request for issue: #1591

This is a pull request for the following functionalities:

The `button Remove image record (file + metadata)`  will be hidden when it is clicked, and a message `Please wait, Please wait, removing image records...` will be displayed when the delete action has not yet finished. When the delete action is finished, a flash message `Image records removed successfully!` will be displayed at the form's top left corner.

 
## How to test?

Describe how the new functionalities can be tested by PR reviewers

##### In dev
```
% cd gigadb-website
% ./up.sh
# execute the acceptance test
% docker-compose run --rm codecept run --no-redirect acceptance tests/acceptance/AdminDatasetForm.feature -vvv
```
1. then go to: http://gigadb.gigasciencejournal.com/adminDataset/update/id/22
2. click `Remove image records (file+metadata)`
3. lading icon and `Please wait, removing image records...` are displayed

##### In staging
```
% cd ops/infrastructure/envs/staging
% ../../../scripts/tf_init.sh --project gigascience/forks/kencho-gigadb-website --env staging
% terraform apply
% terraform refresh
% ../../../scripts/ansible_init.sh --env staging
% env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES TF_KEY_NAME=private_ip ansible-playbook -i ../../inventories webapp_playbook.yml
% env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook -i ../../inventories bastion_playbook.yml -e "backupDate=latest"'
```

1. make sure the staging gigadb website has been deploye via gitlab CICD pipeline 
2. then go to staging gigadb website, and then go to `adminDataset/update/id/369`
3. click `Remove image records (file+metadata)`
4. loading icon and `Please wait, removing image records...` are displayed

##### In live
```
# git tag the latest commit, so it can be deployed to live
% git tag -as testing-v4.1.0-pr1602 dcedc6cb8 -m "test after updated scenario"
# push tagged commit gitlab CICD pipeline
% git push origin testing-v4.1.0-pr1602 
% cd ops/infrastructure/envs/live
% ../../../scripts/tf_init.sh --project gigascience/forks/kencho-gigadb-website --env live
% terraform apply
% terraform refresh
% ../../../scripts/ansible_init.sh --env live
% env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES TF_KEY_NAME=private_ip ansible-playbook -i ../../inventories webapp_playbook.yml
% env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook -i ../../inventories bastion_playbook.yml -e "backupDate=latest"'
```
1. make sure the live gigadb website has been deploye via gitlab CICD pipeline 
2. then go to staging gigadb website, and then go to `adminDataset/update/id/369`
3. click `Remove image records (file+metadata)`
4. loading icon and `Please wait, removing image records...` are displayed

## How have functionalities been implemented?

Describe how the new functionalities have been implemented by the
changed code at a high level

The controller `removeImage` action takes time to process, the `Remove image records (file+metadata)` will be hidden and also display the loading message while processing by adding this JS function in the ajax link:
```
 'beforeSend' => 'function() {
    // Show the loading indicator
    $("#loadingIndicator").show();
    // Disable the removeButton
    $("#removeButton").css("display", "none");
}',
```
So, the `removeImage` action will not be triggered multiple times.

A flash message `Image records removed successfully!` will also be displayed if the `removeImage` action executed successfully.

## Any issues with implementation?

None.

## Any changes to automated tests?

None.

## Any changes to documentation?

None.

## Any technical debt repayment?

None.

## Any improvements to CI/CD pipeline?

None.
