### PR TITLE
Add readme file functionality into post upload script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1527: Make the postUpload script use the image `production-files-metadata-console:production_environment` in the staging and live environments
 - Feat #1384: Improve accessibility of login page: input focus state, form errors, aria labels, required
 
 ## v4.0.5 - 2024-01-02 - d4deab10

--- a/gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh
@@ -37,11 +37,11 @@ if [[ $(uname -n) =~ compute ]];then
   . /home/centos/.bash_profile
 
   echo -e "$updateFileSizeStartMessage"
-  docker run --rm "registry.gitlab.com/$GITLAB_PROJECT/production-files-metadata-console:latest" ./yii update/file-size --doi="$DOI" | tee "$outputDir/updating-file-size-$DOI.txt"
+  docker run --rm "registry.gitlab.com/$GITLAB_PROJECT/production-files-metadata-console:$GIGADB_ENV" ./yii update/file-size --doi="$DOI" | tee "$outputDir/updating-file-size-$DOI.txt"
   echo -e "$updateFileSizeEndMessage"
 
   echo -e "$checkValidUrlsStartMessage"
-  docker run --rm "registry.gitlab.com/$GITLAB_PROJECT/production-files-metadata-console:latest" ./yii check/valid-urls --doi="$DOI" | tee "$outputDir/invalid-urls-$DOI.txt"
+  docker run --rm "registry.gitlab.com/$GITLAB_PROJECT/production-files-metadata-console:$GIGADB_ENV" ./yii check/valid-urls --doi="$DOI" | tee "$outputDir/invalid-urls-$DOI.txt"
   echo -e "$checkValidUrlsEndMessage"
 
   echo -e "$updateMD5ChecksumStartMessage"

--- a/gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh
@@ -8,9 +8,9 @@ display_help() {
     echo ""
     echo "Options:"
     echo "  --doi <value>           Specify the DOI value"
-    echo "  --wasabi                Copy the readme file to wasabi bucket in dry-run mode"
-    echo "  --apply                 Copy the readme file to wasabi non live bucket"
-    echo "  --use-live-data         Copy the readme file to wasabi live bucket"
+    echo "  --wasabi                (Optional) Copy the readme file to wasabi bucket in dry-run mode"
+    echo "  --apply                 (Optional) Copy the readme file to wasabi non live bucket"
+    echo "  --use-live-data         (Optional) Copy the readme file to wasabi live bucket"
     echo "  -h, --help              Display this help message"
     echo ""
 }

--- a/gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh
@@ -4,7 +4,7 @@ set -e
 
 # Display the help message
 display_help() {
-    echo "Usage: $0 [OPTIONS]"
+    echo "Usage: $0 [Options]"
     echo ""
     echo "Options:"
     echo "  --doi <value>           Specify the DOI value"
@@ -58,7 +58,7 @@ else
 fi
 
 if [ -z "$DOI" ];then
-  echo -e "Usage: ./postUpload.sh <DOI>\n"
+  display_help
   exit 1;
 fi
 

--- a/gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh
@@ -2,6 +2,19 @@
 
 set -e
 
+# Display the help message
+display_help() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --doi <value>           Specify the DOI value"
+    echo "  --wasabi                Copy the readme file to wasabi bucket in dry-run mode"
+    echo "  --apply                 Copy the readme file to wasabi non live bucket"
+    echo "  --use-live-data         Copy the readme file to wasabi live bucket"
+    echo "  -h, --help              Display this help message"
+    echo ""
+}
+
 PATH=/usr/local/bin:$PATH
 export PATH
 
@@ -22,6 +35,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --use-live-data)
       options+=("--use-live-data")
+      ;;
+    -h|--help)
+      display_help
+      exit 0
       ;;
     *)
       echo "Invalid option: $1"
@@ -73,7 +90,7 @@ if [[ $(uname -n) =~ compute ]];then
   echo -e "$updateMD5ChecksumEndMessage"
 
   echo -e "$createReadMeFileStartMessage"
-  sudo /home/centos/createReadme.sh --doi "$DOI" --outdir $outputDir "${options[@]}" | tee "$outputDir/readme-$DOI.txt"
+  sudo /home/centos/createReadme.sh --doi "$DOI" --outdir /app/readmeFiles "${options[@]}" | tee "$outputDir/readme-$DOI.txt"
   echo -e "$createReadMeFileEndMessage"
 
   if [[ $userOutputDir != "$outputDir" && -n "$(ls -A $outputDir)" ]];then

--- a/gigadb/app/tools/files-metadata-console/docker-compose.production-envs.yml
+++ b/gigadb/app/tools/files-metadata-console/docker-compose.production-envs.yml
@@ -6,4 +6,4 @@ services:
       context: ../../../..
       dockerfile: gigadb/app/tools/files-metadata-console/Dockerfile-Production
       cache_from:
-        - "registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:latest"
+        - "registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV"

--- a/gigadb/app/tools/files-metadata-console/gitlab-config-live-build.yml
+++ b/gigadb/app/tools/files-metadata-console/gitlab-config-live-build.yml
@@ -27,11 +27,11 @@ FilesMetadataConsoleBuildLive:
     - cp .secrets gigadb/app/tools/files-metadata-console/
     - cp .env gigadb/app/tools/files-metadata-console/
     - cd gigadb/app/tools/files-metadata-console
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:latest || true
+    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV  || true
     - docker-compose -f ./docker-compose.yml run --rm configure
     - docker-compose -f ./docker-compose.yml run --rm composer install
     - docker-compose -f ./docker-compose.production-envs.yml build production-files-metadata-console
-    - docker tag ${CI_PROJECT_NAME}_production-files-metadata-console:latest registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
+    - docker tag ${CI_PROJECT_NAME}_production-files-metadata-console:$GIGADB_ENV  registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
     - docker push registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
   artifacts:
     untracked: true

--- a/gigadb/app/tools/files-metadata-console/gitlab-config-live-build.yml
+++ b/gigadb/app/tools/files-metadata-console/gitlab-config-live-build.yml
@@ -27,11 +27,11 @@ FilesMetadataConsoleBuildLive:
     - cp .secrets gigadb/app/tools/files-metadata-console/
     - cp .env gigadb/app/tools/files-metadata-console/
     - cd gigadb/app/tools/files-metadata-console
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV  || true
+    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV || true
     - docker-compose -f ./docker-compose.yml run --rm configure
     - docker-compose -f ./docker-compose.yml run --rm composer install
     - docker-compose -f ./docker-compose.production-envs.yml build production-files-metadata-console
-    - docker tag ${CI_PROJECT_NAME}_production-files-metadata-console:$GIGADB_ENV  registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
+    - docker tag ${CI_PROJECT_NAME}_production-files-metadata-console:latest  registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
     - docker push registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
   artifacts:
     untracked: true

--- a/gigadb/app/tools/files-metadata-console/gitlab-config-staging-build.yml
+++ b/gigadb/app/tools/files-metadata-console/gitlab-config-staging-build.yml
@@ -29,7 +29,7 @@ FilesMetadataConsoleBuildStaging:
     - docker-compose -f ./docker-compose.yml run --rm configure
     - docker-compose -f ./docker-compose.yml run --rm composer install
     - docker-compose -f ./docker-compose.production-envs.yml build production-files-metadata-console
-    - docker tag ${CI_PROJECT_NAME}_production-files-metadata-console:$GIGADB_ENV registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
+    - docker tag ${CI_PROJECT_NAME}_production-files-metadata-console:latest registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
     - docker push registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
   artifacts:
     untracked: true

--- a/gigadb/app/tools/files-metadata-console/gitlab-config-staging-build.yml
+++ b/gigadb/app/tools/files-metadata-console/gitlab-config-staging-build.yml
@@ -25,11 +25,11 @@ FilesMetadataConsoleBuildStaging:
     - cp .secrets gigadb/app/tools/files-metadata-console/
     - cp .env gigadb/app/tools/files-metadata-console/
     - cd gigadb/app/tools/files-metadata-console
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:latest || true
+    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV || true
     - docker-compose -f ./docker-compose.yml run --rm configure
     - docker-compose -f ./docker-compose.yml run --rm composer install
     - docker-compose -f ./docker-compose.production-envs.yml build production-files-metadata-console
-    - docker tag ${CI_PROJECT_NAME}_production-files-metadata-console:latest registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
+    - docker tag ${CI_PROJECT_NAME}_production-files-metadata-console:$GIGADB_ENV registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
     - docker push registry.gitlab.com/$CI_PROJECT_PATH/production-files-metadata-console:$GIGADB_ENV
   artifacts:
     untracked: true

--- a/gigadb/app/tools/readme-generator/createReadme.sh
+++ b/gigadb/app/tools/readme-generator/createReadme.sh
@@ -77,8 +77,12 @@ done
 #   None
 #######################################
 function set_up_logging() {
-  LOGDIR="$APP_SOURCE/logs"
-  LOGFILE="$LOGDIR/readme_${doi}_$(date +'%Y%m%d_%H%M%S').log"
+  if [[ $(uname -n) =~ compute ]];then
+    LOGDIR="/home/centos/uploadLogs"
+  else
+    LOGDIR="$APP_SOURCE/logs"
+  fi
+  LOGFILE="$LOGDIR/readme_${doi}_$(date +'%Y%m%d').log"
   mkdir -p "${LOGDIR}"
   touch "${LOGFILE}"
 }

--- a/gigadb/app/tools/readme-generator/createReadme.sh
+++ b/gigadb/app/tools/readme-generator/createReadme.sh
@@ -82,7 +82,7 @@ function set_up_logging() {
   else
     LOGDIR="$APP_SOURCE/logs"
   fi
-  LOGFILE="$LOGDIR/readme_${doi}_$(date +'%Y%m%d').log"
+  LOGFILE="$LOGDIR/readme-${doi}-$(date +'%Y%m%d').log"
   mkdir -p "${LOGDIR}"
   touch "${LOGFILE}"
 }

--- a/gigadb/app/tools/readme-generator/tests/createReadme.bats
+++ b/gigadb/app/tools/readme-generator/tests/createReadme.bats
@@ -4,7 +4,10 @@ teardown () {
     echo "executing teardown code"
     FILES="runtime/curators/readme_100142.txt
     runtime/curators/readme_100006.txt
-    runtime/curators/readme_100020.txt"
+    runtime/curators/readme_100020.txt
+    logs/readme_100005_$(date +'%Y%m%d').log
+    logs/readme_100006_$(date +'%Y%m%d').log
+    logs/readme_100142_$(date +'%Y%m%d').log"
 
     for file in $FILES
     do
@@ -19,10 +22,14 @@ teardown () {
     ./createReadme.sh --doi 100142 --outdir /home/curators
     # Check readme file has been created
     [ -f runtime/curators/readme_100142.txt ]
+    # check rclone log has been created
+    [ -f logs/readme_100142_$(date +'%Y%m%d').log ]
 }
 
 @test "check does not create readme with invalid doi and exits" {
     ./createReadme.sh --doi 100005 --outdir /home/curators
+    # Ensure invalid doi is not found
+    [[ "$output" = "Dataset 100005 not found" ]]
     # Check readme file does not exist
     [ ! -f runtime/curators/readme_100005.txt ]
     # Ensure script has exited by checking it does not go on to create readme file

--- a/gigadb/app/tools/readme-generator/tests/createReadme.bats
+++ b/gigadb/app/tools/readme-generator/tests/createReadme.bats
@@ -5,9 +5,9 @@ teardown () {
     FILES="runtime/curators/readme_100142.txt
     runtime/curators/readme_100006.txt
     runtime/curators/readme_100020.txt
-    logs/readme_100005_$(date +'%Y%m%d').log
-    logs/readme_100006_$(date +'%Y%m%d').log
-    logs/readme_100142_$(date +'%Y%m%d').log"
+    logs/readme-100005-$(date +'%Y%m%d').log
+    logs/readme-100006-$(date +'%Y%m%d').log
+    logs/readme-100142-$(date +'%Y%m%d').log"
 
     for file in $FILES
     do
@@ -23,7 +23,7 @@ teardown () {
     # Check readme file has been created
     [ -f runtime/curators/readme_100142.txt ]
     # check rclone log has been created
-    [ -f logs/readme_100142_$(date +'%Y%m%d').log ]
+    [ -f logs/readme-100142-$(date +'%Y%m%d').log ]
 }
 
 @test "check does not create readme with invalid doi and exits" {

--- a/ops/infrastructure/bastion_playbook.yml
+++ b/ops/infrastructure/bastion_playbook.yml
@@ -54,7 +54,7 @@
 
     - rpm_key:
         state: present
-        key: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+        key: https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL
 
     - name: Install PostgreSQL repo
       become: yes

--- a/ops/infrastructure/roles/bastion-users/tasks/main.yml
+++ b/ops/infrastructure/roles/bastion-users/tasks/main.yml
@@ -28,7 +28,7 @@
 - name: Add curator to sudoers
   ansible.builtin.lineinfile:
     path: "/etc/sudoers.d/91-add-{{ newuser }}"
-    line: "{{ newuser }} ALL=(ALL)       NOPASSWD: /home/centos/datasetUpload.sh, /home/centos/postUpload.sh\n"
+    line: "{{ newuser }} ALL=(ALL)       NOPASSWD: /home/centos/datasetUpload.sh, /home/centos/postUpload.sh, /home/centos/createReadme.sh\n"
     owner: root
     group: root
     mode: 440

--- a/ops/infrastructure/roles/centos-eol-fix/tasks/main.yml
+++ b/ops/infrastructure/roles/centos-eol-fix/tasks/main.yml
@@ -17,7 +17,7 @@
 - name:
   ansible.builtin.rpm_key:
     state: present
-    key: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+    key: https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL
 
 - name: install PostgreSQL repository
   yum:

--- a/protected/commands/FilesCommand.php
+++ b/protected/commands/FilesCommand.php
@@ -48,7 +48,6 @@ class FilesCommand extends CConsoleCommand
 
             # Download and parse dataset md5 file
             $url = $this->findDatasetMd5FileUrl($dataset);
-            echo "Processing $url".PHP_EOL;
             $contents = DownloadService::downloadFile($url);
             $lines = explode("\n", $contents);
             foreach ($lines as $line) {
@@ -95,6 +94,7 @@ class FilesCommand extends CConsoleCommand
         foreach ($dataset::RANGES as $range) {
             $url = Yii::app()->params['ftp_connection_url']."/pub/gigadb/pub/10.5524/$range/$doi/$doi.md5";
             // Check URL resolves to a real file
+            echo "Processing $url" . PHP_EOL;
             $file_exists = DownloadService::fileExists($url);
             if ($file_exists)
                 return $url;

--- a/tests/postUpload.bats
+++ b/tests/postUpload.bats
@@ -3,7 +3,7 @@
 teardown () {
     echo "executing teardown code"
     FILES="gigadb/app/tools/readme-generator/runtime/curators/readme_100020.txt
-    gigadb/app/tools/readme-generator/logs/readme_100020_$(date +'%Y%m%d').log"
+    gigadb/app/tools/readme-generator/logs/readme-100020-$(date +'%Y%m%d').log"
 
     for file in $FILES
         do
@@ -43,5 +43,5 @@ teardown () {
     # Check readme file has been created
     [ -f gigadb/app/tools/readme-generator/runtime/curators/readme_100020.txt ]
      # check rclone log has been created
-    [ -f gigadb/app/tools/readme-generator/logs/readme_100020_$(date +'%Y%m%d').log ]
+    [ -f gigadb/app/tools/readme-generator/logs/readme-100020-$(date +'%Y%m%d').log ]
 }

--- a/tests/postUpload.bats
+++ b/tests/postUpload.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+teardown () {
+    echo "executing teardown code"
+    FILES="gigadb/app/tools/readme-generator/runtime/curators/readme_100020.txt
+    gigadb/app/tools/readme-generator/logs/readme_100020_$(date +'%Y%m%d').log"
+
+    for file in $FILES
+        do
+          echo "Deleting $file"
+          if [ -f "$file" ] ; then
+              rm "$file"
+          fi
+        done
+}
+
+@test "display help message with help option" {
+    run ./gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh --help
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "Usage: ./gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh [Options]" ]
+    [ "${lines[1]}" = "Options:" ]
+    [ "${lines[2]}" = "  --doi <value>           Specify the DOI value" ]
+    [ "${lines[3]}" = "  --wasabi                (Optional) Copy the readme file to wasabi bucket in dry-run mode" ]
+    [ "${lines[4]}" = "  --apply                 (Optional) Copy the readme file to wasabi non live bucket" ]
+    [ "${lines[5]}" = "  --use-live-data         (Optional) Copy the readme file to wasabi live bucket" ]
+    [ "${lines[6]}" = "  -h, --help              Display this help message" ]
+}
+
+@test "display help message without any option" {
+    run ./gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh
+    [ "$status" -eq 1 ]
+    [ "${lines[0]}" = "Usage: ./gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh [Options]" ]
+    [ "${lines[1]}" = "Options:" ]
+    [ "${lines[2]}" = "  --doi <value>           Specify the DOI value" ]
+    [ "${lines[3]}" = "  --wasabi                (Optional) Copy the readme file to wasabi bucket in dry-run mode" ]
+    [ "${lines[4]}" = "  --apply                 (Optional) Copy the readme file to wasabi non live bucket" ]
+    [ "${lines[5]}" = "  --use-live-data         (Optional) Copy the readme file to wasabi live bucket" ]
+    [ "${lines[6]}" = "  -h, --help              Display this help message" ]
+}
+
+@test "create readme file and rclone log" {
+    run ./gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh --doi 100020
+    # Check readme file has been created
+    [ -f gigadb/app/tools/readme-generator/runtime/curators/readme_100020.txt ]
+     # check rclone log has been created
+    [ -f gigadb/app/tools/readme-generator/logs/readme_100020_$(date +'%Y%m%d').log ]
+}


### PR DESCRIPTION
# Pull request for issue: #1637 

This is a pull request for the following functionalities:

* Describe functionality 1
* Describe functionality 2
* *Etc.*

## How to test?

Describe how the new functionalities can be tested by PR reviewers

```
 % ./gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh --help                              
Usage: ./gigadb/app/tools/excel-spreadsheet-uploader/postUpload.sh [OPTIONS]

Options:
  --doi <value>           Specify the DOI value
  --wasabi                (Optional) Copy the readme file to wasabi bucket in dry-run mode
  --apply                 (Optional) Copy the readme file to wasabi non live bucket
  --use-live-data         (Optional) Copy the readme file to wasabi live bucket
  -h, --help              Display this help message

% ansible-playbook -i ../../inventories users_playbook.yml -e "newuser=ken" --extra-vars="gigadb_env=staging"
% scp -i ops/infrastructure/envs/staging/output/privkeys-3.36.204.163/ken gigadb/app/tools/excel-spreadsheet-uploader/xls/GigaDBUpload_v18-23-00272_102495-au3.xls ken@3.36.204.163:/home/ken/GigaDBUpload_v18-23-00272_102495-au3.xls                                    

# log into staging bastion server
% ssh -i output/privkeys-3.36.204.163/ken ken@3.36.204.163
Activate the web console with: systemctl enable --now cockpit.socket

[ken@ip-10-99-0-247 ~]$ ls uploadDir/
GigaDBUpload_v18-23-00272_102495-au3.xls
[ken@ip-10-99-0-247 ~]$ sudo /home/centos/datasetUpload.sh
DROP TRIGGER
DROP TRIGGER
DROP TRIGGER
CREATE TRIGGER
CREATE TRIGGER
CREATE TRIGGER
Done.
[ken@ip-10-99-0-247 ~]$ ls
uploadDir
[ken@ip-10-99-0-247 ~]$ ls -al uploadDir/
total 0
drwx------. 2 ken ken  6 Jan 11 05:34 .
drwx------. 4 ken ken 91 Jan 11 05:34 ..
[ken@ip-10-99-0-247 ~]$ sudo /home/centos/postUpload.sh
Usage: /home/centos/postUpload.sh [Options]

Options:
  --doi <value>           Specify the DOI value
  --wasabi                (Optional) Copy the readme file to wasabi bucket in dry-run mode
  --apply                 (Optional) Copy the readme file to wasabi non live bucket
  --use-live-data         (Optional) Copy the readme file to wasabi live bucket
  -h, --help              Display this help message

[ken@ip-10-99-0-247 ~]$ sudo /home/centos/postUpload.sh --help
Usage: /home/centos/postUpload.sh [Options]

Options:
  --doi <value>           Specify the DOI value
  --wasabi                (Optional) Copy the readme file to wasabi bucket in dry-run mode
  --apply                 (Optional) Copy the readme file to wasabi non live bucket
  --use-live-data         (Optional) Copy the readme file to wasabi live bucket
  -h, --help              Display this help message

[ken@ip-10-99-0-247 ~]$ 
# create readme file
[ken@ip-10-99-0-32 ~]$ sudo /home/centos/postUpload.sh --doi 100020
[ken@ip-10-99-0-247 ~]$ ls -al uploadDir/
total 20
drwx------. 2 ken ken  172 Jan 11 05:40 .
drwx------. 4 ken ken   91 Jan 11 05:34 ..
-rw-r--r--. 1 ken ken   16 Jan 11 05:40 invalid-urls-100020.txt
-rw-r--r--. 1 ken ken 2050 Jan 11 05:40 readme-100020.txt
-rw-r--r--. 1 ken ken  114 Jan 11 05:40 readme-100020-20240111.log
-rw-r--r--. 1 ken ken   15 Jan 11 05:40 updating-file-size-100020.txt
-rw-r--r--. 1 ken ken 1087 Jan 11 05:40 updating-md5checksum-100020.txt
[ken@ip-10-99-0-247 ~]$ less -S uploadDir/readme_100020_20240111.log 
# the readme file should contain `INFO  : Created readme file for DOI 100020 in /home/centos/runtime/curators/readme_100020.txt`

# upload readme file to wasabi in dry run mode
[ken@ip-10-99-0-247 ~]$ sudo /home/centos/postUpload.sh --doi 100020 --wasabi
[ken@ip-10-99-0-247 ~]$ ls -al uploadDir/
total 20
drwx------. 2 ken ken  172 Jan 11 05:44 .
drwx------. 4 ken ken   91 Jan 11 05:34 ..
-rw-r--r--. 1 ken ken   16 Jan 11 05:43 invalid-urls-100020.txt
-rw-r--r--. 1 ken ken 2050 Jan 11 05:44 readme-100020.txt
-rw-r--r--. 1 ken ken  838 Jan 11 05:44 readme-100020-20240111.log
-rw-r--r--. 1 ken ken   15 Jan 11 05:43 updating-file-size-100020.txt
-rw-r--r--. 1 ken ken 1087 Jan 11 05:43 updating-md5checksum-100020.txt
[ken@ip-10-99-0-247 ~]$ less -S uploadDir/readme_100020_20240111.log 
# the readme log should contain `readme_100020.txt: Skipped copy as --dry-run is set (size 2.002Ki)`

# upload readme file to wasabi staging
[ken@ip-10-99-0-247 ~]$ sudo /home/centos/postUpload.sh --doi 100020 --wasabi --apply
[ken@ip-10-99-0-247 ~]$ ls -al uploadDir/
total 20
drwx------. 2 ken ken  172 Jan 11 05:49 .
drwx------. 4 ken ken  107 Jan 11 05:47 ..
-rw-r--r--. 1 ken ken   16 Jan 11 05:48 invalid-urls-100020.txt
-rw-r--r--. 1 ken ken 2050 Jan 11 05:49 readme-100020.txt
-rw-r--r--. 1 ken ken  652 Jan 11 05:49 readme-100020-20240111.log
-rw-r--r--. 1 ken ken   15 Jan 11 05:48 updating-file-size-100020.txt
-rw-r--r--. 1 ken ken 1087 Jan 11 05:49 updating-md5checksum-100020.txt
[ken@ip-10-99-0-247 ~]$ less -S uploadDir/readme_100020_20240111.log 
# the readme log should contain `wasabi:gigadb-datasets/staging/pub/`

# upload readme file to wasabi live
[ken@ip-10-99-0-247 ~]$ sudo /home/centos/postUpload.sh --doi 100020 --wasabi --apply --use-live-data
[ken@ip-10-99-0-247 ~]$ ls -al uploadDir/
[ken@ip-10-99-0-247 ~]$ ls -al uploadDir/
total 20
drwx------. 2 ken ken  172 Jan 11 05:52 .
drwx------. 4 ken ken  107 Jan 11 05:47 ..
-rw-r--r--. 1 ken ken   16 Jan 11 05:52 invalid-urls-100020.txt
-rw-r--r--. 1 ken ken 2050 Jan 11 05:52 readme-100020.txt
-rw-r--r--. 1 ken ken  722 Jan 11 05:52 readme-100020-20240111.log
-rw-r--r--. 1 ken ken   15 Jan 11 05:52 updating-file-size-100020.txt
-rw-r--r--. 1 ken ken 1087 Jan 11 05:52 updating-md5checksum-100020.txt
[ken@ip-10-99-0-247 ~]$ less -S uploadDir/readme_100020_20240111.log 
# the readme file should contain `INFO  : Copying readme file into LIVE data directory"`

```

## How have functionalities been implemented?

Describe how the new functionalities have been implemented by the
changed code at a high level

## Any issues with implementation?

Describe any problems with your implementation

## Any changes to automated tests?

Describe any automated tests that have been developed for the new 
functionalities

```
% cd gigadb-website
% ./up.sh
% bats tests --verbose-run 
postUpload.bats
 ✓ display help message with help option
 ✓ display help message without any option
 ✓ create readme file and rclone log

3 tests, 0 failures

```

## Any changes to documentation?

Describe changes to the documentation

## Any technical debt repayment?

Describe changes to code that repays any technical debt

Refactored the `gigadb/app/tools/readme-generator/tests/createReadme.bats` to delete the rclone log files after each test, and also detect the screen output `"Dataset 100005 not found"` when DOI input in invalid.


## Any improvements to CI/CD pipeline?

Describe any improvements to the Gitlab pipeline
