### PR TITLE
Fix file sizes unit based on 1000 byte system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## v4.2.2 - 2024-03-25 - 3cf500fe8
 
+- Fix #1593: Display the units of file size based on 1000 byte system
 - Feat #1759: Replace Google Analytics script by Matomo script in all layouts
 - Feat #1652: Update API doc for usage of retrieve known datasets by DOI endpoint
 

--- a/protected/components/FormattedDatasetFiles.php
+++ b/protected/components/FormattedDatasetFiles.php
@@ -51,7 +51,7 @@ class FormattedDatasetFiles extends DatasetComponents implements DatasetFilesInt
         $files =   $this->_cachedDatasetFiles->getDatasetFiles();
         foreach ($files as &$file) {
             $file['nameHtml'] = "<div title=\"" . $file['description'] . "\"><a href=\"" . $file['location'] . "\" target='_blank'>" . $file['name'] . "</a></div>";
-            $file['sizeUnit'] = File::specifySizeUnits($file['size']);
+            $file['sizeUnit'] = UnitHelper::specifySizeUnits($file['size']);
             $attribute_strings = [];
             foreach ($file['file_attributes'] as $file_attribute) {
                 $attribute_strings[] = implode(array_keys($file_attribute)) . ": " . implode(array_values($file_attribute)) . "<br>";

--- a/protected/helpers/UnitHelper.php
+++ b/protected/helpers/UnitHelper.php
@@ -10,7 +10,7 @@
 class UnitHelper
 {
     /**
-     * Return the human readable binary size of files with configurable formatting
+     * Return the human readable size of files with configurable formatting
      *
      * It's extracted out of getSizeWithFormat so the functionality can be used in other contexts as well.
      *

--- a/protected/helpers/UnitHelper.php
+++ b/protected/helpers/UnitHelper.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This is a utility component for parsing, formatting, converting and manipulating byte units in various formats.
+ * @uses gabrielelana/byte-units package
+ *
+ * It supports both Metric (1000-byte) system and Binary (1024-byte) system.
+ *
+ */
+class UnitHelper
+{
+    /**
+     * Return the human readable binary size of files with configurable formatting
+     *
+     * It's extracted out of getSizeWithFormat so the functionality can be used in other contexts as well.
+     *
+     * @param int $bytes size in bytes to format/convert
+     * @param string $unit unit to convert to kB, MB, GB, TB, B or null
+     * @param int $precision number of decimals after the dot
+     * @uses ByteUnits\Metric
+     * @return string formatted size
+     */
+    public static function specifySizeUnits(int $bytes, string $unit = null, int $precision = null): string
+    {
+        if ($bytes<0) {
+            return (string) $bytes;
+        }
+        if ( null == $precision ) {
+            $precision = 2;
+        }
+        $metric = new ByteUnits\Metric($bytes);
+        $formatted_size = $metric->format("$unit/$precision"," ");
+        return $formatted_size ;
+    }
+
+}

--- a/protected/models/File.php
+++ b/protected/models/File.php
@@ -233,30 +233,6 @@ class File extends CActiveRecord
 		));
 	}
 
-    /**
-     * Return the human readable binary size of files with configurable formatting
-     *
-     * It's extracted out of getSizeWithFormat so the functionality can be used in other contexts as well.
-     *
-     * @param int $bytes size in bytes to format/convert
-     * @param string $unit unit to convert to. kB, MB, GB, TB, B or null
-     * @param int $precision number of decimals after the dot
-     * @return string formatted size
-     * @todo move this function in a Helper class as it's not specific ot the File model class
-     */
-	public static function specifySizeUnits(int $bytes, string $unit = null, int $precision = null): string
-	{
-		if ($bytes<0) {
-			return (string) $bytes;
-		}
-		if ( null == $precision ) {
-			$precision = 2;
-		}
-		$metric = new ByteUnits\Metric($bytes);
-		$formatted_size = $metric->format("$unit/$precision"," ");
-		return $formatted_size ;
-	}
-
 	/**
 	 * return the size of the file formatted for display using Binary notation
 	 *
@@ -265,11 +241,10 @@ class File extends CActiveRecord
 	 *
 	 * @return string formatted size
 	 *
-	 * @uses ByteUnits\Metric
 	 **/
 	public function getSizeWithFormat($unit = null, $precision = 2)
 	{
-		return File::specifySizeUnits($this->size, $unit, $precision);
+		return UnitHelper::specifySizeUnits($this->size, $unit, $precision);
 	}
 
 

--- a/protected/models/File.php
+++ b/protected/models/File.php
@@ -239,7 +239,7 @@ class File extends CActiveRecord
      * It's extracted out of getSizeWithFormat so the functionality can be used in other contexts as well.
      *
      * @param int $bytes size in bytes to format/convert
-     * @param string $unit unit to convert to. KiB, MiB, GiB, TiB, B or null
+     * @param string $unit unit to convert to. kB, MB, GB, TB, B or null
      * @param int $precision number of decimals after the dot
      * @return string formatted size
      * @todo move this function in a Helper class as it's not specific ot the File model class
@@ -252,7 +252,7 @@ class File extends CActiveRecord
 		if ( null == $precision ) {
 			$precision = 2;
 		}
-		$metric = new ByteUnits\Binary($bytes);
+		$metric = new ByteUnits\Metric($bytes);
 		$formatted_size = $metric->format("$unit/$precision"," ");
 		return $formatted_size ;
 	}
@@ -260,12 +260,12 @@ class File extends CActiveRecord
 	/**
 	 * return the size of the file formatted for display using Binary notation
 	 *
-	 * @param string $unit KiB, MiB, GiB, TiB, B or null
+	 * @param string $unit kB, MB, GB, TB, B or null
 	 * @param int $precision number of decimals after the dot
 	 *
 	 * @return string formatted size
 	 *
-	 * @uses ByteUnits\Binary
+	 * @uses ByteUnits\Metric
 	 **/
 	public function getSizeWithFormat($unit = null, $precision = 2)
 	{

--- a/protected/tests/support/CommonDataProviders.php
+++ b/protected/tests/support/CommonDataProviders.php
@@ -22,11 +22,11 @@ trait CommonDataProviders
      **/
     public function adminFileExamplesOfAppropriateMetricDisplayOfFileSize() {
         return [
-            'millet.chr.version2.3.fa.gz: 109000000B' => ["109.92", "MiB"],
-            'Millet.fa.glean.cds.v3.gz: 13000000B' => ["13.10", "MiB"],
-            'Millet.fa.glean.pep.v3.gz: 8500000B' => ["8.50", "MiB"],
-            'Millet.fa.glean.v3.gff: 14000000B' => ["14.04", "MiB"],
-            'Millet_scaffoldVersion2.3.fa.gz: 109000000B' => ["109.37", "MiB"],
+            'millet.chr.version2.3.fa.gz: 109000000B' => ["115.26", "MB"],
+            'Millet.fa.glean.cds.v3.gz: 13000000B' => ["13.74", "MB"],
+            'Millet.fa.glean.pep.v3.gz: 8500000B' => ["8.92", "MB"],
+            'Millet.fa.glean.v3.gff: 14000000B' => ["14.72", "MB"],
+            'Millet_scaffoldVersion2.3.fa.gz: 109000000B' => ["114.68", "MB"],
         ];
     }
 }

--- a/protected/views/search/_new_result.php
+++ b/protected/views/search/_new_result.php
@@ -90,7 +90,7 @@
                                 <div class="search-result-content file-content row">
                                     <div class="col-xs-5 file-name truncate-text"><a class="file-link" href="<?php echo $file['location'] ?>" aria-label="<?= $file['name'] . ' file' ?>"><?php echo $file['name'] ?></a></div>
                                     <div class="col-xs-3 file-type"><?php echo $file['file_type'] ?></div>
-                                    <div class="col-xs-3 file-size"><?php echo CHtml::encode(File::specifySizeUnits($file['size'], null, 2)) ?></div>
+                                    <div class="col-xs-3 file-size"><?php echo CHtml::encode(UnitHelper::specifySizeUnits($file['size'], null, 2)) ?></div>
                                 </div>
                             </li>
                         <?php } ?>

--- a/tests/acceptance/001-Search.feature
+++ b/tests/acceptance/001-Search.feature
@@ -15,12 +15,12 @@ Feature: main search function
     And I should see a link "Pygoscelis_adeliae" to "/dataset/100006"
     And I should see the files:
     | download link title | download link url| file type | size |
-    | Pygoscelis_adeliae.pep.gz | https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/phylogeny_study_update/Pygoscelis_adeliae.pep.gz              | Protein sequence | 4.17 MiB |
-    | Pygoscelis_adeliae.gff.gz | https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/phylogeny_study_update/Pygoscelis_adeliae.gff.gz | Annotation       | 1.59 MiB   |
-    | Pygoscelis_adeliae.fa.gz | https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/phylogeny_study_update/Pygoscelis_adeliae.fa.gz | Sequence assembly | 350.48 MiB |
-    | Pygoscelis_adeliae.RepeatMasker.out.gz | https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/phylogeny_study_update/Pygoscelis_adeliae.RepeatMasker.out.gz | Repeat sequence | 7.49 MiB |
-    | Pygoscelis_adeliae.cds.gz | https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/phylogeny_study_update/Pygoscelis_adeliae.cds.gz              | Coding sequence | 6.43 MiB |
-    | Pygoscelis_adeliae.scaf.fa.gz | https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/Pygoscelis_adeliae.scaf.fa.gz | Sequence assembly | 350.61 MiB |
+    | Pygoscelis_adeliae.pep.gz | https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/phylogeny_study_update/Pygoscelis_adeliae.pep.gz              | Protein sequence | 4.37 MB |
+    | Pygoscelis_adeliae.gff.gz | https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/phylogeny_study_update/Pygoscelis_adeliae.gff.gz | Annotation       | 1.67 MB   |
+    | Pygoscelis_adeliae.fa.gz | https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/phylogeny_study_update/Pygoscelis_adeliae.fa.gz | Sequence assembly | 367.50 MB |
+    | Pygoscelis_adeliae.RepeatMasker.out.gz | https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/phylogeny_study_update/Pygoscelis_adeliae.RepeatMasker.out.gz | Repeat sequence | 7.86 MB |
+    | Pygoscelis_adeliae.cds.gz | https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/phylogeny_study_update/Pygoscelis_adeliae.cds.gz              | Coding sequence | 6.75 MB |
+    | Pygoscelis_adeliae.scaf.fa.gz | https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/Pygoscelis_adeliae.scaf.fa.gz | Sequence assembly | 367.64 MB |
     | readme.txt | https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100006/readme.txt | Readme | 138 B |
 
   @todo @broken

--- a/tests/unit/FileTest.php
+++ b/tests/unit/FileTest.php
@@ -20,7 +20,7 @@ class FileTest extends CDbTestCase
     {
         $system_under_test = $this->files(0);
 
-        $expectation = "1.23 GiB";
+        $expectation = "1.32 GB";
         $this->assertEquals($expectation, $system_under_test->getSizeWithFormat());
     }
 
@@ -32,26 +32,32 @@ class FileTest extends CDbTestCase
         $this->assertEquals($expectation, $system_under_test->getSizeWithFormat());
     }
 
+    /**
+     * This method is a data provider that returns an array of test cases for the testItShouldReturnSizeWithFormat method.
+     * The test cases are in the format ["kB", 3, "1291135.786 kB"],
+     * where the first element is the format, the second element is the precision,
+     * and the third element is the expected result.
+     */
     public function sizeFormatsProvider()
     {
         return [
-            ["KiB",3, "1291135.786 KiB"],
-            ["MiB",2, "1260.87 MiB"],
-            ["GiB",2, "1.23 GiB"],
-            ["TiB",5, "0.00120 TiB"],
+            ["kB",3, "1322123.045 kB"],
+            ["MB",2, "1322.12 MB"],
+            ["GB",2, "1.32 GB"],
+            ["TB",5, "0.00132 TB"],
             ["B",2, "1322123045 B"],
-            ["KiB",9, "1291135.786132812 KiB"],
-            ["MiB",9, "1260.874791145 MiB"],
-            ["GiB",9, "1.231323038 GiB"],
-            ["TiB",9, "0.001202464 TiB"],
+            ["kB",9, "1322123.045000000 kB"],
+            ["MB",9, "1322.123045000 MB"],
+            ["GB",9, "1.322123045 GB"],
+            ["TB",9, "0.001322123 TB"],
             ["B",9, "1322123045 B"],
-            [null,null, "1.23 GiB"],
-            ["KiB",null, "1291135.79 KiB"],
-            ["MiB",null, "1260.87 MiB"],
-            ["GiB",null, "1.23 GiB"],
-            ["TiB",null, "0.00 TiB"],
+            [null,null, "1.32 GB"],
+            ["kB",null, "1322123.04 kB"],
+            ["MB",null, "1322.12 MB"],
+            ["GB",null, "1.32 GB"],
+            ["TB",null, "0.00 TB"],
             ["B",null, "1322123045 B"],
-            [null,9, "1.231323038 GiB"],
+            [null,9, "1.322123045 GB"],
         ];
     }
 }

--- a/tests/unit/FileTest.php
+++ b/tests/unit/FileTest.php
@@ -1,35 +1,44 @@
 <?php
 
-class FileTest extends CDbTestCase
+class FileTest extends \Codeception\Test\Unit
 {
-    protected $fixtures = array(
-        'files' => 'File',
-    );
+    /**
+     * @var File model
+     */
+    private $systemUnderTest;
+
+    /**
+     * Create a new File object for every test
+     */
+    protected function _before()
+    {
+        $this->systemUnderTest = new File();
+        $this->systemUnderTest->size = "1322123045";
+    }
 
     /**
      * @dataProvider sizeFormatsProvider
      */
     public function testItShouldReturnSizeWithFormat($unit, $precision, $expectation)
     {
-        $system_under_test = $this->files(0);
-
-        $this->assertEquals($expectation, $system_under_test->getSizeWithFormat($unit, $precision));
+        $result = $this->systemUnderTest->getSizeWithFormat($unit, $precision);
+        $this->assertEquals($expectation, $result);
     }
 
     public function testItShouldReturnSizeWithFormatAndNoArguments()
     {
-        $system_under_test = $this->files(0);
+        $result = $this->systemUnderTest->getSizeWithFormat();
 
         $expectation = "1.32 GB";
-        $this->assertEquals($expectation, $system_under_test->getSizeWithFormat());
+        $this->assertEquals($expectation, $result);
     }
 
     public function testItShouldReturnZeroByteWhenSizeNegative()
     {
-        $system_under_test = $this->files(1);
-
+        $this->systemUnderTest->size = "-1";
+        $result = $this->systemUnderTest->getSizeWithFormat();
         $expectation = "-1";
-        $this->assertEquals($expectation, $system_under_test->getSizeWithFormat());
+        $this->assertEquals($expectation, $result);
     }
 
     /**

--- a/tests/unit/FileTest.php
+++ b/tests/unit/FileTest.php
@@ -33,7 +33,7 @@ class FileTest extends \Codeception\Test\Unit
         $this->assertEquals($expectation, $result);
     }
 
-    public function testItShouldReturnZeroByteWhenSizeNegative()
+    public function testItShouldReturnNegativeByteAsItIs()
     {
         $this->systemUnderTest->size = "-1";
         $result = $this->systemUnderTest->getSizeWithFormat();

--- a/tests/unit/FormattedDatasetFilesTest.php
+++ b/tests/unit/FormattedDatasetFilesTest.php
@@ -113,7 +113,7 @@ class FormattedDatasetFilesTest extends CTestCase
                             ),
                             'download_count' => 0,
                             'nameHtml' => "<div title=\"just readme\"><a href=\"ftp://foo.bar\" target='_blank'>readme.txt</a></div>",
-                            'sizeUnit' => '1.23 GiB',
+                            'sizeUnit' => '1.32 GB',
                             'attrDesc' => "keyword: some value<br>number of lines: 155<br>",
                         ),
                         array(
@@ -179,7 +179,7 @@ class FormattedDatasetFilesTest extends CTestCase
                             ),
                             'download_count' => 0,
                             'nameHtml' => "<div title=\"just readme\"><a href=\"ftp://foo.bar\" target='_blank'>readme.txt</a></div>",
-                            'sizeUnit' => '1.23 GiB',
+                            'sizeUnit' => '1.32 GB',
                             'attrDesc' => "keyword: some value<br>number of lines: 155<br>",
                         ),
                         array(


### PR DESCRIPTION
# Pull request for issue: #1593

This is a pull request for the following functionalities:

The unit of the file size will be calculated based on the Metric system which is based on a 1000-byte kilobyte and uses standard SI suffixes (kB, MB, GB, TB, PB).


## How to test?

1. Execute the automatic tests
```
# spin up gigadb website
% ./up.sh
% ./tests/unit_function_runner
% ./tests/acceptance_runner
# all tests  should be passing
```

2. Go to http://gigadb.gigasciencejournal.com/dataset/100006, and check the `Files` tab, the unit should be updated:

![image](https://github.com/gigascience/gigadb-website/assets/64770635/290b8aed-6759-418b-8b4f-29753ebc2eda)

3. Check the `Files` tab in the production gigadb website


## How have functionalities been implemented?

By updating the usage from `new ByteUnits\Binary($bytes);` to `new ByteUnits\Metric($bytes);` in the function `specifySizeUnits()`, the file size will then be calculated based on the `1000-byte kilobyte` base.


## Any issues with implementation?

None. 

## Any changes to automated tests?

None.

## Any changes to documentation?

None.

## Any technical debt repayment?

Move the function `specifySizeUnits` in the model `File` to a separate helper class `UnitHelper`, the function is self contained and solely calling the function `new ByteUnits\Metric()` from the package `gabrielelana/byte-units`, this helps to reduce the complexity and increase the readability  of the `File` class.

## Any improvements to CI/CD pipeline?

None.