### PR TITLE
Fix acceptance tests in AdminDatasetForm.feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1654: Fix AdminDatasetForm acceptance tests
 - Feat #1569: Display horizontal scroll bar in dataset files table when required
 - Fix #1645: Fix failing ResetPasswordCest for FUW
 - Feat #588: Re-enable the old, initial work on File Upload Wizard behind a new Gitlab-based feature flag

--- a/ops/infrastructure/bastion_playbook.yml
+++ b/ops/infrastructure/bastion_playbook.yml
@@ -54,7 +54,7 @@
 
     - rpm_key:
         state: present
-        key: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+        key: https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL
 
     - name: Install PostgreSQL repo
       become: yes

--- a/ops/infrastructure/roles/centos-eol-fix/tasks/main.yml
+++ b/ops/infrastructure/roles/centos-eol-fix/tasks/main.yml
@@ -17,7 +17,7 @@
 - name:
   ansible.builtin.rpm_key:
     state: present
-    key: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+    key: https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL
 
 - name: install PostgreSQL repository
   yum:

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -178,7 +178,7 @@ Feature: form to update dataset details
     And I fill in the field of "name" "Dataset[ftp_site]" with "ftp://test"
     And I press the button "Create"
     And I wait "1" seconds
-    Then I am on "/adminDataset/update/id/2343"
+    Then I am on "/adminDataset/update/id/2741"
     And I should see "AuthorReview"
     And I should see "123789"
     And I should see "Create/Reset Private URL"
@@ -197,7 +197,7 @@ Feature: form to update dataset details
     And I fill in the field of "name" "Dataset[ftp_site]" with "ftp://test"
     And I press the button "Create"
     And I wait "1" seconds
-    And I am on "/adminDataset/update/id/2343"
+    And I am on "/adminDataset/update/id/2741"
     And I follow "Open Private URL"
     And I wait "1" seconds
     Then I should see current url contains "/dataset/123789/token/"


### PR DESCRIPTION
# Pull request for issue: #1654

This is a pull request for the following functionalities:

* Fixes for acceptance tests in AdminDatasetForm.feature
* Fix for Ansible bastion script `failed to fetch RPM-GPG-KEY-PGDG key` and `Failed to validate GPG signature for pgdg-redhat-repo-42.0-38PGDG.noarch` errors

## How to test?

### Local testing
```
# Spin up local GigaDB instance using code from this PR
$ ./up.sh 
# Execute tests in AdminDatasetForm.feature
$ $ docker-compose run --rm codecept run --no-redirect acceptance AdminDatasetForm.feature
```

### CI pipeline

Push your branch containing code from this PR into your Github repository. The `a_gigadb` job in your CI/CD pipeline should run successfully without any errors. 

## Any changes to automated tests?

The PR https://github.com/gigascience/gigadb-website/pull/1649 included a new dataset 102484 added into `dev` data which broke the `AuthorReview dataset with private URL buttons` and `Open Private URL from AuthorReview dataset` acceptance tests in AdminDatasetForm.feature. Fixing these two tests involved correcting the id integer in the  code for AdminDatasetForm.feature containing `/adminDataset/update/id/2343`. 

## Any technical debt repayment?

The Ansible bastion script was broken when testing this PR on my staging server:

```
TASK [../../roles/centos-eol-fix : ansible.builtin.rpm_key] *******************************************************************
fatal: [3.114.200.169]: FAILED! => {"changed": false, "msg": "failed to fetch key at https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG , error was: HTTP Error 404: Not Found"}
```

This was fixed by updating the URL for the `RPM-GPG-KEY-PGDG` key.

There was then another error when running the bastion script:

```
TASK [../../roles/centos-eol-fix : install PostgreSQL repository] *************************************************************
fatal: [3.114.200.169]: FAILED! => {"changed": false, "msg": "Failed to validate GPG signature for pgdg-redhat-repo-42.0-38PGDG.noarch: Public key for pgdg-redhat-repo-latest.noarchpjudbabx.rpm is not installed"}
```

This was fixed by using another different key: `PGDG-RPM-GPG-KEY-RHEL` instead of `RPM-GPG-KEY-PGDG`.

