### PR TITLE
Ensure dataset pages that are not published are not publicly visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1660: Ensure dataset pages that are not published are not publicly visible
+
 ## v4.1.1 - 2024-01-30 - 7bb35726
 
 - Fix #1527: Make the postUpload script use the image `production-files-metadata-console:production_environment` in the staging and live environments

--- a/protected/components/DatasetPageSettings.php
+++ b/protected/components/DatasetPageSettings.php
@@ -33,7 +33,7 @@ class DatasetPageSettings extends yii\base\BaseObject
         parent::__construct();
         $this->_dao = $dao;
         $this->_model = $model;
-        if ($this->_model && !$this->_model->isNewRecord && in_array($this->_model->upload_status, ["UserUploading","DataAvailableForReview", "DataPending", "Curation", "AuthorReview"])) {
+        if ($this->_model && !$this->_model->isNewRecord && in_array($this->_model->upload_status, ["UserUploadingData","DataAvailableForReview", "DataPending", "Curation", "AuthorReview"])) {
             $this->_pageType = "draft";
         } elseif (
             $this->_model && !$this->_model->isNewRecord && "Published" !== $this->_model->upload_status

--- a/protected/controllers/DatasetController.php
+++ b/protected/controllers/DatasetController.php
@@ -146,7 +146,7 @@ class DatasetController extends Controller
         // Different rendering based on page type (invalid, hidden, public)
         if ("invalid" === $datasetPageSettings->getPageType()) {
             $this->render('invalid', array('model' => new Dataset('search'), 'keyword' => $id, 'general_search' => 1));
-        } elseif ("hidden" === $datasetPageSettings->getPageType()) {
+        } elseif (in_array($datasetPageSettings->getPageType(), ["hidden","draft", "mockup"])) {
             // Page private ? Disable robot to index
             $this->metaData['private'] = true;
 

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -361,3 +361,34 @@ Feature: form to update dataset details
     Then I should be on "/adminDataset/update/id/668"
     And I should see "Fail to update!"
     And I should see "Dataset Size must be a number."
+
+  @ok @dataset-status
+  Scenario Outline: Check dataset page with statuses is not publicly visible
+    Given I am on "/adminDataset/update/id/5"
+    And I select <status> from the field "Dataset_upload_status"
+    And I press the button "Save"
+    And I am on "/dataset/100039"
+    Then I should see "The DOI 100039 cannot be displayed."
+    And I should not see "Genomic data of the Puerto Rican Parrot"
+    Examples:
+      | status                   |
+      | "ImportFromEM"           |
+      | "UserStartedIncomplete"  |
+      | "Rejected"               |
+      | "Not required"           |
+      | "Submitted"              |
+      | "Curation"               |
+      | "AuthorReview"           |
+      | "Private"                |
+      | "AssigningFTPbox"        |
+      | "UserUploadingData"      |
+      | "DataAvailableForReview" |
+      | "DataPending"            |
+
+  @ok @dataset-status
+  Scenario: Check dataset page with Published status is publicly visible
+    Given I am on "/adminDataset/update/id/5"
+    And I select "Published" from the field "Dataset_upload_status"
+    And I press the button "Save"
+    And I am on "/dataset/100039"
+    Then I should see "Genomic data of the Puerto Rican Parrot"

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -103,7 +103,7 @@ Feature: form to update dataset details
     And I should see "Image License"
     And I should see "Image Photographer"
 
-  @ok @datasetimage
+  @ok @datasetimage @wip
   Scenario: Can create dataset with image
     When I am on "adminDataset/create"
     And I select "test+14@gigasciencejournal.com" from the field "Dataset_submitter_id"
@@ -116,7 +116,7 @@ Feature: form to update dataset details
     And I fill in the field of "name" "Dataset[ftp_site]" with "ftp://test"
     And I fill in the field of "name" "Dataset[title]" with "test dataset"
     And I press the button "Create"
-    Then I am on "dataset/view/id/400789"
+    Then I should see current url contains "/dataset/400789/token/"
     And I should see an image located in "/images/datasets/e166c2a0-3684-5209-bccd-c4b18ff87be9/bgi_logo_new.png"
 
   @ok @issue-1023

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -103,7 +103,7 @@ Feature: form to update dataset details
     And I should see "Image License"
     And I should see "Image Photographer"
 
-  @ok @datasetimage @wip
+  @ok @datasetimage
   Scenario: Can create dataset with image
     When I am on "adminDataset/create"
     And I select "test+14@gigasciencejournal.com" from the field "Dataset_submitter_id"
@@ -384,6 +384,15 @@ Feature: form to update dataset details
       | "UserUploadingData"      |
       | "DataAvailableForReview" |
       | "DataPending"            |
+
+  @ok @dataset-status
+  Scenario: Check dataset page with Curation status can be viewed using private URL
+    Given I am on "/adminDataset/update/id/5"
+    And I select "Curation" from the field "Dataset_upload_status"
+    And I press the button "Save"
+    And I am on "/adminDataset/private/identifier/100039"
+    Then I should see current url contains "/dataset/100039/token/"
+    And I should see "Genomic data of the Puerto Rican Parrot"
 
   @ok @dataset-status
   Scenario: Check dataset page with Published status is publicly visible


### PR DESCRIPTION
# Pull request for issue: #1660

This is a pull request for the following functionalities:

* Datasets that do not have `Published` as dataset status are not publicly accessible.
* New acceptance tests to check only datasets with `Published` status can be publicly viewed.

## How to test?

### Dev environment

From your project repository, check out a new branch and test the changes:
```
$ git checkout -b pli888-dataset-page-visibility develop
$ git pull https://github.com/pli888/gigadb-website.git dataset-page-visibility
```

On your browser, go to http://gigadb.gigasciencejournal.com/site/login and log into the admin@gigadb.org user account.

Then go to http://gigadb.gigasciencejournal.com/adminDataset/update/id/5 and update the dataset status for dataset 100039 to any status that is not `Published` and click `Save` button. If you now go to http://gigadb.gigasciencejournal.com/dataset/100039 then you will see that the dataset page is not accessible.

Update the dataset status for dataset 100039 to `Published. Now go to http://gigadb.gigasciencejournal.com/dataset/100039 and you will see that the dataset page is displayed.

To run the new acceptance tests:
```
$ docker-compose run --rm codecept run --no-redirect -g dataset-status tests/acceptance/AdminDatasetForm.feature
```

### Staging environment

Deploy your staging environment in the usual manner:
```
$ cd /path/to/gigadb-website/ops/infrastructure/envs/staging

# Copy terraform files to staging environment
$ ../../../scripts/tf_init.sh --project gigascience/forks/$projectname-gigadb-website --env staging

# Provision with Terraform 
$ terraform plan
$ terraform apply
$ terraform refresh

# Copy ansible files
$ ../../../scripts/ansible_init.sh --env staging

# Provision bastion ec2 server and restore RDS with latest database backup
$ env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook -i ../../inventories bastion_playbook.yml --extra-vars="gigadb_env=staging"

# Provision webapp ec2 server with ansible
$ TF_KEY_NAME=private_ip env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook -i ../../inventories webapp_playbook.yml --extra-vars="gigadb_env=staging"
```

Run your Gitlab CI/CD pipeline and deploy the branch to your staging server.

Using a browser, go to the admin page for dataset 200004 at `/adminDataset/update/id/223` on your staging server.

Change the dataset status to `Curation` and click `Save` button.

Go to `/dataset/200004` and you will see that the dataset cannot be displayed.

Go back to `/adminDataset/update/id/223` and click `Save` button. Then click the `Open Private URL` link and you will see the dataset page is displayed using its private URL.

Go back to the dataset admin page at `/adminDataset/update/id/223` and change status to `Published`. If you then go to `/dataset/200004`, you will see the dataset page is displayed.

## How have functionalities been implemented?

The following dataset statuses exist in GigaDB and their dataset page accessibility before and after this PR:
| Status | Page type | Before | After | Comment |
|--------|-----------|--------|---------|---------|
| Published | public | Public | Public | No further status changes are possible after this |
| Submitted | mockup | Public | Private | |
| Curation  | draft  | Public | Private | |
| AuthorReview | draft | Public | Private | |
| DataAvailableForReview | draft | Public | Private | |
| DataPending | draft | Public | Private | |
| UserUploadingData | draft | Public | Private | |
| ImportFromEM | hidden | Private | Private | |
| UserStartedIncomplete | hidden | Private | Private | |
| Rejected | hidden | Private | Private | |
| Not required | hidden | Private | Private | |
| Private | hidden | Private | Private | |
| AssigningFTPbox | hidden | Private | Private | |

The new correct functionality provided by the PR is that datasets which have been annotated with Page type value that is `mockup`, `draft` or `hidden` cannot be publicly viewed using its `/dataset/$identifier` URL.

The conditional statement that decides whether to hide a dataset page if the dataset's page type is `hidden` has been expanded to hide datasets with page type `mockup` and `draft` as well as `hidden`. This means only datasets with `Published` status and therefore has a page type `public` can be publicly viewed.

## Any changes to automated tests?

New acceptance tests have been created at the bottom of `AdminDatasetForm.feature` to test the new functionality.

The create dataset with image test in `AdminDatasetForm.feature` has been updated to test the presence of the image on the now private dataset page. Previously, new datasets are created with `AuthorReview` status which was publicly accessible before.

