### PR TITLE
Show more button on Dataset:Sample admin page works after filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1722: Show more button on Dataset:Sample admin page works after filtering
 - Fix #1714: Visually hide long description in guide workflow, so that it's only visible to screen readers
 - Fix #1657: Fix the broken tests from release 4.2.0, fix curation log form and spreadsheet upload consent checkbox
 - Feat #1627: FUW - Migrate to Uppy version 2

--- a/protected/views/adminDatasetSample/admin.php
+++ b/protected/views/adminDatasetSample/admin.php
@@ -1,4 +1,4 @@
-<div class="container">
+<div id="adminDatasetContainer" class="container">
 	<?php
 	$this->widget('TitleBreadcrumb', [
 		'pageTitle' => 'Manage Dataset - Samples',
@@ -29,22 +29,32 @@
 			CustomGridView::getDefaultActionButtonsConfig()
 		),
 	)); ?>
-
-	<?php
-	$clientScript = Yii::app()->clientScript;
-	$register_script = <<<EO_SCRIPT
-      jQuery(".js-desc").click(function(e) {
-        const isExpanded = $(this).attr('aria-expanded') === 'true';
-        e.preventDefault();
-        id = $(this).attr('data');
-        $(this).attr('aria-label', isExpanded ? 'show less' : 'show more');
-        $(this).attr('aria-expanded', !isExpanded);
-        jQuery(this).hide();
-        jQuery('.js-short-'+id).toggle();
-        jQuery('.js-long-'+id).toggle();
-      })
-  EO_SCRIPT;
-	$clientScript->registerScript('register_script', $register_script, CClientScript::POS_READY);
-	?>
-
 </div>
+
+<script>
+function toggleShowMore(btnEl) {
+  const isExpanded = btnEl.attr('aria-expanded') === 'true';
+  id = btnEl.attr('data');
+  btnEl.attr('aria-label', isExpanded ? 'show less' : 'show more');
+  btnEl.attr('aria-expanded', !isExpanded);
+  btnEl.hide();
+  $('.js-short-'+id).toggle();
+  $('.js-long-'+id).toggle();
+}
+
+function handleClick(e) {
+  const target = $(e.target);
+
+  if (!target.hasClass('js-desc')) {
+    return;
+  }
+
+  e.preventDefault();
+  toggleShowMore(target);
+}
+
+$(document).ready(function() {
+  // NOTE targeting container because on filter, content gets rerendered and any event listeners are destroyed
+  $("#adminDatasetContainer").on("click", handleClick)
+})
+</script>


### PR DESCRIPTION
# Pull request for issue: #1722

This is a pull request for the following functionalities:

* Make show more button work after filtering results in http://gigadb.gigasciencejournal.com/adminDatasetSample/admin

## How to test?

Navigate to above page, filter by DOI to the result tha contains a + button and toggle it to test that it works

## How have functionalities been implemented?

* An event listener was attached to the button to toggle the content. Filtering destroys the button and renders a new one so the event listener was also destroyed. The event listener is now attached to the container that does not rerender on filter, so it does not get destroyed
* I added the script directly to the page, without registering it using Yii, mainly for better dev readability and because I see no need to register it. I believe there is no difference between using Yii registration and simply adding the script to the page within a script tag. I think the only difference will be that using Yii registration, the script is guaranteed to be added only once, whereas with script tags, it might be added multiple times, if, for example, the script was part of a php partial that was added multiple times to the same page, but this is not the case here