### PR TITLE
Upgrade beta submission wizard layout for Study and Author pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1080: Upgrade beta submission wizard layout for Study and Author pages
 - Fix #1714: Visually hide long description in guide workflow, so that it's only visible to screen readers
 - Fix #1657: Fix the broken tests from release 4.2.0, fix curation log form and spreadsheet upload consent checkbox
 - Feat #1627: FUW - Migrate to Uppy version 2

--- a/less/current.less
+++ b/less/current.less
@@ -10,6 +10,7 @@
 @import "current/base/display.less";
 @import "current/base/spacing.less";
 @import "current/modules/buttons.less";
+@import "current/modules/links.less";
 @import "current/modules/dropdowns.less";
 @import "current/modules/forms.less";
 @import "current/modules/images.less";

--- a/less/current.less
+++ b/less/current.less
@@ -65,3 +65,4 @@
 @import "current/modules/team-grid.less";
 @import "current/modules/map.less";
 @import "current/modules/lists.less";
+@import "current/pages/dataset-submission.less";

--- a/less/current/base/variables.less
+++ b/less/current/base/variables.less
@@ -79,6 +79,7 @@
 @white-on-gigadb-green: @color-true-white;
 // on warm-black
 @gray-on-warm-black: @color-medium-gray;
+@gigadb-green-on-warm-black: @color-gigadb-green-400;
 
 //== Scaffolding
 //

--- a/less/current/modules/links.less
+++ b/less/current/modules/links.less
@@ -1,0 +1,3 @@
+.tooltip-link {
+  color: @gigadb-green-on-warm-black!important;
+}

--- a/less/current/pages/admindataset-form.less
+++ b/less/current/pages/admindataset-form.less
@@ -86,6 +86,7 @@
     align-items: center;
     gap: 16px;
     margin-bottom: 30px;
+    padding-right: 0;
   }
   .tag-editor {
     border-color: #cccccc;

--- a/less/current/pages/dataset-submission.less
+++ b/less/current/pages/dataset-submission.less
@@ -122,6 +122,17 @@
       width: 5%;
       text-align: center;
       vertical-align: middle;
+      .delete-author-btn {
+        background: transparent;
+        padding: 0;
+        margin: 0;
+        border: none;
+        height: 18px;
+        width: 18px;
+        &:hover {
+          text-decoration: underline;
+        }
+      }
     }
   }
 }

--- a/less/current/pages/dataset-submission.less
+++ b/less/current/pages/dataset-submission.less
@@ -1,14 +1,15 @@
 @block-spacing: 20px;
 
+.dataset-submission-nav {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
 .dataset-submission-page {
-  .dataset-submission-nav {
-    display: flex;
-    gap: 20px;
-    margin-bottom: 20px;
-  }
   .note {
     color: @color-true-black;
-    margin-bottom: 12px
+    margin-bottom: 12px;
   }
   .form-block-1 {
     margin-block: @block-spacing;
@@ -38,7 +39,6 @@
         max-width: 80%;
       }
     }
-
   }
   .form-group {
     margin-bottom: 10px;
@@ -96,6 +96,32 @@
     border-radius: 4px;
     .placeholder {
       color: @dark-gray-on-light-gray;
+    }
+  }
+  .author-grid {
+    label, th {
+      margin-bottom: 0;
+      color: @color-true-black;
+      font-weight: bold;
+    }
+    td {
+      color: @color-true-black;
+    }
+    .first-name-col,
+    .middle-name-col,
+    .last-name-col {
+      width: 25%;
+    }
+    .author-orcid-col {
+      width: 10%;
+    }
+    .order-col {
+      width: 10%;
+    }
+    .button-column {
+      width: 5%;
+      text-align: center;
+      vertical-align: middle;
     }
   }
 }

--- a/less/current/pages/dataset-submission.less
+++ b/less/current/pages/dataset-submission.less
@@ -16,6 +16,30 @@
   .form-block-2 {
     margin-block: @block-spacing;
   }
+  .form-block-3 {
+    margin-block: @block-spacing;
+  }
+  .full-width-block {
+    margin-block: @block-spacing;
+    // Absolute width values so that there is vertical alignment with fields in blocks 1 and 4
+    .control-label {
+      width: 157px;
+    }
+    .input-wrapper {
+      width: 879px;
+    }
+    @media (max-width: 1199px) {
+      .control-label {
+        width: 130px;
+        max-width: 20%;
+      }
+      .input-wrapper {
+        width: 722px;
+        max-width: 80%;
+      }
+    }
+
+  }
   .form-group {
     margin-bottom: 10px;
     .error {
@@ -51,6 +75,24 @@
           margin-bottom: 4px;
         }
       }
+    }
+  }
+  .form-control-btns {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 16px;
+    margin-bottom: 30px;
+    padding-right: 0;
+    > * {
+      margin: 0;
+    }
+  }
+  .tag-editor {
+    border-color: #cccccc;
+    border-radius: 4px;
+    .placeholder {
+      color: @dark-gray-on-light-gray;
     }
   }
 }

--- a/less/current/pages/dataset-submission.less
+++ b/less/current/pages/dataset-submission.less
@@ -1,0 +1,56 @@
+@block-spacing: 20px;
+
+.dataset-submission-page {
+  .dataset-submission-nav {
+    display: flex;
+    gap: 20px;
+    margin-bottom: 20px;
+  }
+  .note {
+    color: @color-true-black;
+    margin-bottom: 12px
+  }
+  .form-block-1 {
+    margin-block: @block-spacing;
+  }
+  .form-block-2 {
+    margin-block: @block-spacing;
+  }
+  .form-group {
+    margin-bottom: 10px;
+    .error {
+      color: @brand-danger-on-lighter-gray;
+    }
+    .control-label {
+      color: @color-true-black;
+      font-weight: bold;
+    }
+    .help-block {
+      color: @color-true-black;
+    }
+    .sibling-controls {
+      .sibling-control:not(:first-child) {
+        padding-left: 5px;
+      }
+      .sibling-control:not(:last-child) {
+        padding-right: 5px;
+      }
+    }
+  }
+  fieldset {
+    margin-bottom: 10px;
+    legend {
+      font-weight: bold;
+      color: @color-true-black;
+    }
+    .checkbox-group {
+      gap: 6px;
+      .checkbox-horizontal {
+        .control-label {
+          color: @color-true-black;
+          margin-bottom: 4px;
+        }
+      }
+    }
+  }
+}

--- a/less/current/pages/dataset-submission.less
+++ b/less/current/pages/dataset-submission.less
@@ -42,6 +42,9 @@
   }
   .form-group {
     margin-bottom: 10px;
+    input[aria-disabled="true"] {
+      background-color: @color-light-gray;
+    }
     .error {
       color: @brand-danger-on-lighter-gray;
     }

--- a/protected/controllers/AdminDatasetAuthorController.php
+++ b/protected/controllers/AdminDatasetAuthorController.php
@@ -413,7 +413,7 @@ class AdminDatasetAuthorController extends Controller
             $attrs = $_POST['Author'];
 
             if (!(($attrs['first_name']) and ($attrs['last_name']))) {
-                Util::returnJSON(array("success" => false, "message" => Yii::t("app", "You must input first namd and last name.")));
+                Util::returnJSON(array("success" => false, "message" => Yii::t("app", "You must input first name and last name.")));
             }
 
             $da = DatasetAuthor::model()->findByAttributes(array('dataset_id' => $_POST['dataset_id']), array('order' => 'rank desc'));

--- a/protected/controllers/DatasetSubmissionController.php
+++ b/protected/controllers/DatasetSubmissionController.php
@@ -534,6 +534,7 @@ EO_MAIL;
             }
         }
 
+        $this->layout = 'new_datasetpage';
         $this->render('create1', array('model' => $dataset, 'image'=>$image));
     }
 

--- a/protected/controllers/DatasetSubmissionController.php
+++ b/protected/controllers/DatasetSubmissionController.php
@@ -659,6 +659,7 @@ EO_MAIL;
 
             $das = DatasetAuthor::model()->findAllByAttributes(array('dataset_id'=>$dataset->id), array('order'=>'rank asc'));
 
+            $this->layout = 'new_datasetpage';
             $this->render('authorManagement', array('model' => $dataset,'das'=>$das));
         }
     }

--- a/protected/models/Images.php
+++ b/protected/models/Images.php
@@ -77,11 +77,11 @@ class Images extends ImageHaver
     {
         return array(
             'id' => 'ID',
-            'tag' => 'Image Tag',
-            'url' => 'Image URL',
-            'license' => 'Image License',
-            'photographer' => 'Image Photographer',
-            'source' => 'Image Source',
+            'tag' => 'Tag',
+            'url' => 'URL',
+            'license' => 'License',
+            'photographer' => 'Photographer',
+            'source' => 'Source',
             'image_upload' => 'Upload Image',
         );
     }

--- a/protected/views/datasetSubmission/_form1.php
+++ b/protected/views/datasetSubmission/_form1.php
@@ -28,7 +28,7 @@ $cs->registerCssFile('/css/jquery.tag-editor.css');
     <!-- row 1 col 1 -->
     <div class="col-xs-5 form-block-1">
       <div class="form-group">
-        <?php echo $form->labelEx($model, 'submitter_id', array('class' => 'control-label col-xs-4')); ?>
+        <?php echo $form->labelEx($model, 'submitter_id', array('class' => 'control-label col-xs-4', 'for' => 'email')); ?>
         <div class="col-xs-8">
           <?php
           $email = Yii::app()->user->getEmail();
@@ -62,8 +62,7 @@ $cs->registerCssFile('/css/jquery.tag-editor.css');
 
 
       <fieldset class="form-group" aria-label="Dataset size and unit">
-        <?php echo CHtml::label('Estimated Dataset Size', '', array('class' => 'control-label col-xs-4', 'for' => 'Dataset_dataset_size'));
-        ?>
+        <label class="control-label col-xs-4" for="Dataset_dataset_size">Estimated Dataset Size</label>
         <div class="col-xs-8">
           <div class="row sibling-controls">
             <div class="col-xs-7 sibling-control">
@@ -130,7 +129,7 @@ $cs->registerCssFile('/css/jquery.tag-editor.css');
       </div>
 
       <div class="form-group js-image">
-        <label class="control-label col-xs-4">Upload<span aria-hidden="true"> *</span></label>
+        <label class="control-label col-xs-4" for="Images_image_upload">Upload<span aria-hidden="true"> *</span></label>
         <div class="col-xs-8">
           <?php echo $form->fileField(
             $image,

--- a/protected/views/datasetSubmission/_form1.php
+++ b/protected/views/datasetSubmission/_form1.php
@@ -117,104 +117,140 @@ $cs->registerCssFile('/css/jquery.tag-editor.css');
     <?php echo $form->hiddenField($image, 'location', array('size' => 60, 'maxlength' => 200, 'readonly' => "readonly", 'class' => 'image')); ?>
 
     <!-- row 1 col 2 -->
-    <div class="col-xs-offset-1 col-xs-5 form-block-2">
-      <div class="control-group">
-        <font class="control-label">No image</font>
-        <a class="myHint" data-content="check it if you don't want to upload an image"></a>
-        <div class="controls">
-          <?php echo $form->checkBox($image, 'is_no_image', array('id' => 'image-upload')); ?>
-          <!--input id="image-upload" type="checkbox" name="Images[is_no_image]"
-                           style="margin-right:5px"/-->
+    <fieldset class="col-xs-offset-1 col-xs-5 form-block-2">
+      <legend>Image</legend>
+
+      <div class="form-group checkbox-horizontal">
+        <label class="col-md-4 control-label" for="is_no_image">No image</label>
+        <div class="col-md-8 col-xs-1">
+          <?php echo $form->checkBox($image, 'is_no_image', array('id' => 'is_no_image', 'aria-describedby' => 'is_no_image-description')); ?>
+          <div id="is_no_image-description" class="control-description help-block">Check it if you don't want to upload
+            an image</div>
         </div>
       </div>
 
-      <div class="control-group">
-        <label class="control-label">Image Upload</label>
-        <a class="myHint" data-content="upload an image from your local computer/network"></a>
-        <div class="controls">
-          <?php echo $form->fileField($image, 'image_upload', array('class' => 'image')); ?>
-          <?php echo $form->error($image, 'image_upload'); ?>
+      <div class="form-group">
+        <label class="control-label col-xs-4">Upload</label>
+        <div class="col-xs-8">
+          <?php echo $form->fileField($image, 'image_upload', array('class' => 'image form-control', 'aria-describedby' => $form->error($image, 'image_upload') ? 'Images_image_upload-error' : '')); ?>
+          <p class="control-description help-block">Upload an image from your local computer/network</p>
+          <div id="Images_image_upload-error" class="control-error help-block" role="alert">
+            <?php echo $form->error($image, 'image_upload'); ?>
+          </div>
         </div>
       </div>
 
-      <div class="control-group">
-        <?php echo $form->labelEx($image, 'source', array('class' => 'control-label')); ?>
-        <a class="myHint" data-content="from where did you get the image, e.g. wikipedia"></a>
-        <div class="controls">
-          <?php echo $form->textField($image, 'source', array('size' => 60, 'maxlength' => 200, 'class' => 'image')); ?>
-          <?php echo $form->error($image, 'source'); ?>
+      <?php
+      $this->widget('application.components.controls.TextField', [
+        'form' => $form,
+        'model' => $image,
+        'attributeName' => 'source',
+        'description' => 'From where did you get the image, e.g. wikipedia',
+        'inputOptions' => [
+          'size' => 60,
+          'maxlength' => 200,
+          'class' => 'image',
+          'required' => true,
+        ],
+        'labelOptions' => ['class' => 'col-xs-4'],
+        'inputWrapperOptions' => 'col-xs-8',
+      ]);
+
+      $this->widget('application.components.controls.TextField', [
+        'form' => $form,
+        'model' => $image,
+        'attributeName' => 'tag',
+        'description' => 'A brief descriptive title of the image, this will be shown to users if they hover over the image',
+        'inputOptions' => [
+          'size' => 60,
+          'maxlength' => 200,
+          'class' => 'image'
+        ],
+        'labelOptions' => ['class' => 'col-xs-4'],
+        'inputWrapperOptions' => 'col-xs-8',
+      ]);
+      ?>
+
+      <div class="form-group">
+        <?php echo $form->labelEx($image, 'license', array('class' => 'control-label col-xs-4')); ?>
+        <div class="col-xs-8">
+          <?php echo $form->textField($image, 'license', array('size' => 60, 'maxlength' => 300, 'class' => 'form-control image', 'required' => true, 'aria-required' => 'true', 'aria-describedby' => $form->error($image, 'license') ? 'Images_license-error Images_license-desc' : 'Images_license-desc')); ?>
+          <p id="Images_license-desc" class="control-description help-block">GigaScience database will
+            only use images that are free for others to re-use,
+            primarily this is <a target='_blank' href='http://creativecommons.org/about/cc0'>Creative Commons 0 license
+              (CC0)</a></p>
+          <div id="Images_license-error" role="alert" class="control-error help-block">
+            <?php echo $form->error($image, 'license'); ?>
+          </div>
         </div>
       </div>
 
-      <div class="control-group">
-        <?php echo $form->labelEx($image, 'tag', array('class' => 'control-label')); ?>
-        <a class="myHint" data-content="A brief descriptive title of the image,
-                   this will be shown to users if they hover over the image."></a>
-        <div class="controls">
-          <?php echo $form->textField($image, 'tag', array('size' => 60, 'maxlength' => 200, 'class' => 'image')); ?>
-          <?php echo $form->error($image, 'tag'); ?>
-        </div>
-      </div>
 
-      <div class="control-group">
-        <?php echo $form->labelEx($image, 'license', array('class' => 'control-label')); ?>
-        <a class="myHint" data-content="GigaScience database will
-                   only use images that are free for others to re-use,
-                   primarily this is Creative Commons 0 license (CC0)
-                   please see <a target='_blank' href='http://creativecommons.org/about/cc0'>here</a>
-                   for further reading on creative commons licenses."></a>
-        <div class="controls">
-          <?php echo $form->textField($image, 'license', array('size' => 60, 'maxlength' => 200, 'class' => 'image')); ?>
-          <?php echo $form->error($image, 'license'); ?>
-        </div>
-      </div>
+      <?php
 
-      <div class="control-group">
-        <?php echo $form->labelEx($image, 'photographer', array('class' => 'control-label')); ?>
-        <a class="myHint" data-content="The person(s) that should
-                   be credited for the image"></a>
-        <div class="controls">
-          <?php echo $form->textField($image, 'photographer', array('size' => 60, 'maxlength' => 200, 'class' => 'image')); ?>
-          <?php echo $form->error($image, 'photographer'); ?>
-        </div>
-      </div>
-    </div>
+      $this->widget('application.components.controls.TextField', [
+        'form' => $form,
+        'model' => $image,
+        'attributeName' => 'photographer',
+        'description' => 'The person(s) that should be credited for the image',
+        'inputOptions' => [
+          'size' => 60,
+          'maxlength' => 200,
+          'class' => 'image',
+          'required' => true,
+        ],
+        'labelOptions' => ['class' => 'col-xs-4'],
+        'inputWrapperOptions' => 'col-xs-8',
+      ]);
+      ?>
+    </fieldset>
 
-
-    <!-- row 2 -->
-    <div class="">
-      <div class="control-group">
-        <?php echo $form->labelEx($model, 'description', array('class' => 'control-label')); ?>
-        <a class="myHint" data-content="Please provide a full description of the datatset, this may
-                   look like an article abstract giving a brief background of the research and a
-                   description of the results to be found in the dataset
-                   (it should be between 100 and 500 word in length).
-                   Please note this text box accepts HTML code tags for formatting,
-                   so you may use &quot;&lt; br &gt;&quot; for line breaks, &quot;&lt; em &gt;&QUOT; <em>for italics</em> &quot;
-                   &lt; em /&gt;&quot;
-                   and &quot;&lt; b &gt;&quot; <b>for bold</b> &quot;&lt; b/ &gt;&quot;"></a>
-        <div class="controls">
-          <?php echo $form->textArea($model, 'description', array('rows' => 6, 'cols' => 100, 'style' => 'resize:vertical;width:610px')); ?>
-          <?php echo $form->error($model, 'description'); ?>
-        </div>
-      </div>
-    </div>
-    <div class="">
-      <div class="control-group">
-        <?php echo CHtml::label('Keywords', 'keywords', array('class' => 'control-label')); ?>
-        <div class="controls">
-          <?php echo CHtml::textField('keywords', '', array('class' => '', 'size' => 60, 'maxlength' => 300)); ?>
-        </div>
-      </div>
-    </div>
   </div>
 
-  <div class="">
-    <a href="<?php echo Yii::app()->createUrl('/user/view_profile') ?>" class="btn">Cancel</a>
-    <?php echo CHtml::submitButton('Next', array('class' => 'btn-green', 'id' => 'next-btn')); ?>
+  <hr />
+
+  <!-- row 2 -->
+  <div class="row form-block-3 full-width-block">
+
+    <div class="col-xs-12">
+      <?php
+
+      $this->widget('application.components.controls.TextArea', [
+        'form' => $form,
+        'model' => $model,
+        'attributeName' => 'description',
+        'description' => 'Please provide a full description of the datatset, this may look like an article abstract giving a brief background of the research and a
+        description of the results to be found in the dataset
+        (it should be between 100 and 500 word in length).
+        Please note this text box accepts HTML code tags for formatting,
+        so you may use &quot;&lt; br &gt;&quot; for line breaks, &quot;&lt; em &gt;&QUOT; <em>for italics</em> &quot;
+        &lt; em /&gt;&quot;
+        and &quot;&lt; b &gt;&quot; <b>for bold</b> &quot;&lt; b/ &gt;&quot;',
+        'labelOptions' => ['class' => 'col-xs-4'],
+        'inputWrapperOptions' => 'input-wrapper col-xs-6',
+        'inputOptions' => [
+          'rows' => 6,
+          'cols' => 100
+        ],
+      ]);
+
+      ?>
+      <div class="form-group">
+        <?php echo CHtml::label('Keywords', 'keywords', array('class' => 'control-label col-xs-4')); ?>
+        <div class="col-xs-6 input-wrapper">
+          <?php echo CHtml::textArea('keywords', '', array('class' => 'form-control', 'size' => 60, 'maxlength' => 300)); ?>
+        </div>
+      </div>
+    </div>
   </div>
 
 </div>
+
+<div class="col-xs-12 form-control-btns">
+  <a href="<?php echo Yii::app()->createUrl('/user/view_profile') ?>" class="btn background-btn-o">Cancel</a>
+  <?php echo CHtml::submitButton('Next', array('class' => 'btn background-btn submit-btn', 'id' => 'next-btn')); ?>
+</div>
+
 
 <script>
   $('.date').datepicker();

--- a/protected/views/datasetSubmission/_form1.php
+++ b/protected/views/datasetSubmission/_form1.php
@@ -123,17 +123,27 @@ $cs->registerCssFile('/css/jquery.tag-editor.css');
       <div class="form-group checkbox-horizontal">
         <label class="col-md-4 control-label" for="is_no_image">No image</label>
         <div class="col-md-8 col-xs-1">
-          <?php echo $form->checkBox($image, 'is_no_image', array('id' => 'is_no_image', 'aria-describedby' => 'is_no_image-description')); ?>
+          <?php echo $form->checkBox($image, 'is_no_image', array('id' => 'is_no_image', 'aria-describedby' => 'is_no_image-description', 'class' => 'js-no-image')); ?>
           <div id="is_no_image-description" class="control-description help-block">Check it if you don't want to upload
             an image</div>
         </div>
       </div>
 
-      <div class="form-group">
-        <label class="control-label col-xs-4">Upload</label>
+      <div class="form-group js-image">
+        <label class="control-label col-xs-4">Upload<span aria-hidden="true"> *</span></label>
         <div class="col-xs-8">
-          <?php echo $form->fileField($image, 'image_upload', array('class' => 'image form-control', 'aria-describedby' => $form->error($image, 'image_upload') ? 'Images_image_upload-error' : '')); ?>
-          <p class="control-description help-block">Upload an image from your local computer/network</p>
+          <?php echo $form->fileField(
+            $image,
+            'image_upload',
+            array(
+              'class' => 'image form-control',
+              'required' => true,
+              'aria-required' => 'true',
+              'aria-describedby' => $form->error($image, 'image_upload') ? 'Images_image_upload-error Images_image_upload-desc' : 'Images_image_upload-desc'
+            )
+          ); ?>
+          <p id="Images_image_upload-desc" class="control-description help-block">Upload an image from your local
+            computer/network</p>
           <div id="Images_image_upload-error" class="control-error help-block" role="alert">
             <?php echo $form->error($image, 'image_upload'); ?>
           </div>
@@ -146,10 +156,10 @@ $cs->registerCssFile('/css/jquery.tag-editor.css');
         'model' => $image,
         'attributeName' => 'source',
         'description' => 'From where did you get the image, e.g. wikipedia',
+        'groupOptions' => ['class' => 'js-image'],
         'inputOptions' => [
           'size' => 60,
           'maxlength' => 200,
-          'class' => 'image',
           'required' => true,
         ],
         'labelOptions' => ['class' => 'col-xs-4'],
@@ -161,20 +171,20 @@ $cs->registerCssFile('/css/jquery.tag-editor.css');
         'model' => $image,
         'attributeName' => 'tag',
         'description' => 'A brief descriptive title of the image, this will be shown to users if they hover over the image',
+        'groupOptions' => ['class' => 'js-image'],
         'inputOptions' => [
           'size' => 60,
           'maxlength' => 200,
-          'class' => 'image'
         ],
         'labelOptions' => ['class' => 'col-xs-4'],
         'inputWrapperOptions' => 'col-xs-8',
       ]);
       ?>
 
-      <div class="form-group">
+      <div class="form-group js-image">
         <?php echo $form->labelEx($image, 'license', array('class' => 'control-label col-xs-4')); ?>
         <div class="col-xs-8">
-          <?php echo $form->textField($image, 'license', array('size' => 60, 'maxlength' => 300, 'class' => 'form-control image', 'required' => true, 'aria-required' => 'true', 'aria-describedby' => $form->error($image, 'license') ? 'Images_license-error Images_license-desc' : 'Images_license-desc')); ?>
+          <?php echo $form->textField($image, 'license', array('size' => 60, 'maxlength' => 300, 'class' => 'form-control', 'required' => true, 'aria-required' => 'true', 'aria-describedby' => $form->error($image, 'license') ? 'Images_license-error Images_license-desc' : 'Images_license-desc')); ?>
           <p id="Images_license-desc" class="control-description help-block">GigaScience database will
             only use images that are free for others to re-use,
             primarily this is <a target='_blank' href='http://creativecommons.org/about/cc0'>Creative Commons 0 license
@@ -193,10 +203,10 @@ $cs->registerCssFile('/css/jquery.tag-editor.css');
         'model' => $image,
         'attributeName' => 'photographer',
         'description' => 'The person(s) that should be credited for the image',
+        'groupOptions' => ['class' => 'js-image'],
         'inputOptions' => [
           'size' => 60,
           'maxlength' => 200,
-          'class' => 'image',
           'required' => true,
         ],
         'labelOptions' => ['class' => 'col-xs-4'],
@@ -253,48 +263,9 @@ $cs->registerCssFile('/css/jquery.tag-editor.css');
 
 
 <script>
-  $('.date').datepicker();
-
-
   $(".next1").click(function () {
     $("#next-btn").click();
   });
-
-  $(".myHint").popover();
-
-  $(".myHintLink").popover({ trigger: 'manual' }).hover(function (e) {
-    $(this).popover('show');
-    e.preventDefault();
-  });
-
-
-  $('.myHintLink').on('mouseleave', function () {
-    var v = $(this);
-    setTimeout(
-      function () {
-        v.popover('hide');
-      }, 2000);
-  });
-
-  $(function () {
-    $('#image-upload').click(function () {
-      if ($(this).is(':checked')) {
-        $('.image').attr('disabled', true);
-      } else {
-        $('.image').attr('disabled', false);
-      }
-    });
-  });
-
-  function disableImage() {
-    //        alert('here');
-    if ($('#image-upload').is(':checked')) {
-      $('.image').attr('disabled', true);
-    }
-  }
-
-  window.onload = disableImage;
-
 </script>
 <script>
   <?php
@@ -307,4 +278,43 @@ $cs->registerCssFile('/css/jquery.tag-editor.css');
     delimiter: ',', /* comma */
     placeholder: 'Enter keywords (separated by commas) ...'
   });
+
+  const MARKED_REQUIRED = 'js-marked-required';
+  const IMAGE_GROUP_SELECTOR = '.js-image';
+
+  function handleNoImage(el) {
+    const isChecked = $(el).is(':checked');
+
+    $(IMAGE_GROUP_SELECTOR).each(function () {
+      const group = $(this);
+      const input = $(this).find('input:not([type="hidden"])');
+
+      group.addClass('disabled');
+      input.attr('aria-disabled', isChecked);
+
+      if (group.hasClass(MARKED_REQUIRED)) {
+        input.attr('aria-required', !isChecked);
+        input.attr('required', !isChecked);
+      }
+    });
+  }
+
+  $(document).ready(function () {
+    $(IMAGE_GROUP_SELECTOR).each(function () {
+      const group = $(this);
+      const input = $(this).find('input:not([type="hidden"])');
+
+      if (input.prop('required')) {
+        group.addClass(MARKED_REQUIRED);
+      }
+    });
+
+    const noImageCheckbox = $('.js-no-image');
+
+    handleNoImage(noImageCheckbox);
+
+    noImageCheckbox.change(function () {
+      handleNoImage(this);
+    });
+  })
 </script>

--- a/protected/views/datasetSubmission/_form1.php
+++ b/protected/views/datasetSubmission/_form1.php
@@ -66,7 +66,16 @@ $cs->registerCssFile('/css/jquery.tag-editor.css');
         <div class="col-xs-8">
           <div class="row sibling-controls">
             <div class="col-xs-7 sibling-control">
-              <?php echo $form->textField($model, 'dataset_size', array('type' => 'number', 'size' => 60, 'maxlength' => 200, 'class' => 'form-control', 'aria-describedby' => $model->hasErrors('name') ? 'dataset_size-error dataset_size-desc' : 'dataset_size-desc'));
+              <?php echo $form->textField($model, 'dataset_size', array(
+                'type' => 'number',
+                'size' => 60,
+                'maxlength' => 200,
+                'class' => 'form-control',
+                'required' => true,
+                'aria-required' => 'true',
+                'aria-describedby' => $model->hasErrors('name') ? 'dataset_size-error dataset_size-desc' : 'dataset_size-desc'
+              )
+              );
               ?>
             </div>
             <div class="col-xs-5 sibling-control">

--- a/protected/views/datasetSubmission/_form1.php
+++ b/protected/views/datasetSubmission/_form1.php
@@ -1,231 +1,274 @@
 <?
 if (Yii::app()->user->hasFlash('saveSuccess'))
-    echo Yii::app()->user->getFlash('saveSuccess');
+  echo Yii::app()->user->getFlash('saveSuccess');
 
 $cs = Yii::app()->getClientScript();
 $cssCoreUrl = $cs->getCoreScriptUrl();
 $cs->registerCssFile($cssCoreUrl . '/jui/css/base/jquery-ui.css');
 $cs->registerCssFile('/css/jquery.tag-editor.css');
 ?>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
+
 <script src="https://cdnjs.cloudflare.com/ajax/libs/caret/1.0.0/jquery.caret.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/tag-editor/1.0.20/jquery.tag-editor.min.js"></script>
-<div class="span12 form well">
-    <div class="form-horizontal">
-        <p class="note">Fields with <span class="required">*</span> are required.</p>
-        <div class="clear"></div>
-        <?php echo $form->errorSummary($model); ?>
-        <div class="span5">
-            <div class="control-group">
-                <?php echo $form->labelEx($model, 'submitter_id', array('class' => 'control-label')); ?>
-                <div class="controls">
 
-                    <?php
-                    $email = Yii::app()->user->getEmail();
-                    echo CHtml::textField("email", $email, array('size' => 60, 'maxlength' => 300, 'readonly' => "readonly")
-                    );
-                    ?>
-                </div>
-            </div>
+<div class="well col-xs-12">
+  <div class="row">
+    <div class="col-xs-12">
+      <p class="note">Fields with <span class="required">*</span> are required.</p>
 
-            <div class="control-group">
-                <?php echo $form->labelEx($model, 'types', array('class' => 'control-label')); ?>
-                <a class="myHint" data-content="Select the type of data to be included 
-                   in this submission, you may select more than 1. If a 
-                   data type is missing please contact us on database@gigasciencejournal.com."></a>
-                <div class="controls">
-                    <?
-                    $datasetTypes = CHtml::listData(Type::model()->findAll(), 'id', 'name');
-                    foreach ($datasetTypes as $id => $datasetType) {
-                        $checkedHtml = in_array($id, $model->types) ? 'checked="checked"' : '';
-                        echo '<input type="checkbox" name="datasettypes[]" value="'.$id.'"' . $checkedHtml . '/> ' . $datasetType . '<br/>';
-                    }
-                    ?>
-                </div>
-            </div>
+      <div role="alert">
+        <?php if ($model->hasErrors()): ?>
+          <div class="alert alert-danger">
+            <?php echo $form->errorSummary($model); ?>
+          </div>
+        <?php endif; ?>
+      </div>
+    </div>
 
-            <div class="control-group">
-                <?php echo $form->labelEx($model, 'title', array('class' => 'control-label')); ?>
-                <a class="myHint" data-content="This should be a short descriptive title
-                   of the dataset to be submitted"></a>
-                <div class="controls">
-                    <?php echo $form->textField($model, 'title', array('size' => 60, 'maxlength' => 300)); ?>
-                    <?php echo $form->error($model, 'title'); ?>
-                </div>
-            </div>
-
-            <div class="control-group">
-
-                <?php echo CHtml::label('Estimated Dataset Size', '', array('class' => 'control-label'));
-                ?>
-                <a class="myHint" data-content="The approximate
-                   combined size of all the files that you intend to submit"></a>
-                   <?php //echo $form->labelEx($model, 'dataset_size', array('class' => 'control-label'));
-                   ?>
-                <div class="controls">
-                    <?php echo $form->textField($model, 'dataset_size', array('size' => 60, 'maxlength' => 200));
-                          echo CHtml::activeDropDownList($model,'union', array('B'=>'Bytes','M'=>'MB','G'=>'GB','T'=>'TB'));?>
-                    <?php echo $form->error($model, 'dataset_size'); ?>
-                </div>
-            </div>
+    <!-- row 1 col 1 -->
+    <div class="col-xs-5 form-block-1">
+      <div class="form-group">
+        <?php echo $form->labelEx($model, 'submitter_id', array('class' => 'control-label col-xs-4')); ?>
+        <div class="col-xs-8">
+          <?php
+          $email = Yii::app()->user->getEmail();
+          echo CHtml::textField(
+            "email",
+            $email,
+            array('size' => 60, 'maxlength' => 300, 'readonly' => "readonly", "class" => "form-control", 'required' => true, 'aria-required' => 'true', 'aria-describedby' => $model->hasErrors('submitter_id') ? 'submitter_id-error' : '')
+          );
+          ?>
+          <div id="submitter_id-error" role="alert" class="control-error help-block">
+            <?php echo $form->error($model, 'submitter_id'); ?>
+          </div>
         </div>
+      </div>
 
-        <?php echo $form->hiddenField($image, 'location', array('size' => 60, 'maxlength' => 200, 'readonly' => "readonly", 'class' => 'image')); ?>
+      <?php
+      $this->widget('application.components.controls.TextField', [
+        'form' => $form,
+        'model' => $model,
+        'attributeName' => 'title',
+        'labelOptions' => ['class' => 'col-xs-4'],
+        'inputWrapperOptions' => 'col-xs-8',
+        'description' => 'This should be a short descriptive title of the dataset to be submitted',
+        'inputOptions' => [
+          'size' => 60,
+          'maxlength' => 300,
+          'required' => true
+        ],
+      ]);
+      ?>
 
-        <div class="span6">
-            <div class="control-group">
-                <font class="control-label">No image</font>
-                <a class="myHint" data-content="check it if you don't want to upload an image"></a>
-                <div class="controls">
-                    <?php echo $form->checkBox($image,'is_no_image', array('id'=>'image-upload')); ?>
-                    <!--input id="image-upload" type="checkbox" name="Images[is_no_image]"
+
+      <fieldset class="form-group" aria-label="Dataset size and unit">
+        <?php echo CHtml::label('Estimated Dataset Size', '', array('class' => 'control-label col-xs-4', 'for' => 'Dataset_dataset_size'));
+        ?>
+        <div class="col-xs-8">
+          <div class="row sibling-controls">
+            <div class="col-xs-7 sibling-control">
+              <?php echo $form->textField($model, 'dataset_size', array('type' => 'number', 'size' => 60, 'maxlength' => 200, 'class' => 'form-control', 'aria-describedby' => $model->hasErrors('name') ? 'dataset_size-error dataset_size-desc' : 'dataset_size-desc'));
+              ?>
+            </div>
+            <div class="col-xs-5 sibling-control">
+              <?php
+              echo CHtml::activeDropDownList($model, 'union', array('B' => 'Bytes', 'M' => 'MB', 'G' => 'GB', 'T' => 'TB'), array('class' => 'form-control', 'aria-label' => 'Unit of dataset size'));
+              ?>
+            </div>
+          </div>
+          <p id="dataset_size-desc" class="control-description help-block">The approximate combined size of all
+            the files that
+            you intend to submit</p>
+          <div id="dataset_size-error" role="alert" class="control-error help-block">
+            <?php echo $form->error($model, 'dataset_size'); ?>
+          </div>
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend>Dataset Types</legend>
+        <!-- checkboxes -->
+        <div class="checkbox-group">
+          <?php
+          $datasetTypes = CHtml::listData(Type::model()->findAll(), 'id', 'name');
+          $checkedStatuses = array_map(function ($id) use ($model) {
+            return in_array($id, $model->types) ? 'checked="checked"' : '';
+          }, array_keys($datasetTypes));
+
+          foreach ($datasetTypes as $id => $datasetType): ?>
+            <div class="checkbox-horizontal">
+              <?php
+              $checkedHtml = $checkedStatuses[$id];
+              $checkboxId = "Dataset_$datasetType";
+              echo $form->labelEx($model, "$datasetType", array('class' => 'col-md-4 control-label'));
+
+              ?>
+
+              <div class="col-md-8 col-xs-1">
+                <input type="checkbox" id="<?php echo $checkboxId ?>" name="datasettypes[<?php echo $id ?>]"
+                  value="<?php echo $id; ?>" <?php echo $checkedHtml; ?> />
+              </div>
+            </div>
+          <?php endforeach; ?>
+        </div>
+      </fieldset>
+    </div>
+
+    <?php echo $form->hiddenField($image, 'location', array('size' => 60, 'maxlength' => 200, 'readonly' => "readonly", 'class' => 'image')); ?>
+
+    <!-- row 1 col 2 -->
+    <div class="col-xs-offset-1 col-xs-5 form-block-2">
+      <div class="control-group">
+        <font class="control-label">No image</font>
+        <a class="myHint" data-content="check it if you don't want to upload an image"></a>
+        <div class="controls">
+          <?php echo $form->checkBox($image, 'is_no_image', array('id' => 'image-upload')); ?>
+          <!--input id="image-upload" type="checkbox" name="Images[is_no_image]"
                            style="margin-right:5px"/-->
-                </div>
-            </div>
+        </div>
+      </div>
 
-            <div class="control-group">
-                <label class="control-label">Image Upload</label>
-                <a class="myHint" data-content="upload an image from your local computer/network"></a>
-                <div class="controls">
-                    <?php echo $form->fileField($image, 'image_upload', array('class'=>'image')); ?>
-                    <?php echo $form->error($image, 'image_upload'); ?>
-                </div>
-            </div>
+      <div class="control-group">
+        <label class="control-label">Image Upload</label>
+        <a class="myHint" data-content="upload an image from your local computer/network"></a>
+        <div class="controls">
+          <?php echo $form->fileField($image, 'image_upload', array('class' => 'image')); ?>
+          <?php echo $form->error($image, 'image_upload'); ?>
+        </div>
+      </div>
 
-            <div class="control-group">
-                <?php echo $form->labelEx($image, 'source', array('class' => 'control-label')); ?>
-                <a class="myHint" data-content= "from where did you get the image, e.g. wikipedia"></a>
-                <div class="controls">
-                    <?php echo $form->textField($image, 'source', array('size' => 60, 'maxlength' => 200, 'class' => 'image')); ?>
-                    <?php echo $form->error($image, 'source'); ?>
-                </div>
-            </div>
+      <div class="control-group">
+        <?php echo $form->labelEx($image, 'source', array('class' => 'control-label')); ?>
+        <a class="myHint" data-content="from where did you get the image, e.g. wikipedia"></a>
+        <div class="controls">
+          <?php echo $form->textField($image, 'source', array('size' => 60, 'maxlength' => 200, 'class' => 'image')); ?>
+          <?php echo $form->error($image, 'source'); ?>
+        </div>
+      </div>
 
-            <div class="control-group">
-                <?php echo $form->labelEx($image, 'tag', array('class' => 'control-label')); ?>
-                <a class="myHint" data-content="A brief descriptive title of the image, 
+      <div class="control-group">
+        <?php echo $form->labelEx($image, 'tag', array('class' => 'control-label')); ?>
+        <a class="myHint" data-content="A brief descriptive title of the image,
                    this will be shown to users if they hover over the image."></a>
-                <div class="controls">
-                    <?php echo $form->textField($image, 'tag', array('size' => 60, 'maxlength' => 200, 'class' => 'image')); ?>
-                    <?php echo $form->error($image, 'tag'); ?>
-                </div>
-            </div>
+        <div class="controls">
+          <?php echo $form->textField($image, 'tag', array('size' => 60, 'maxlength' => 200, 'class' => 'image')); ?>
+          <?php echo $form->error($image, 'tag'); ?>
+        </div>
+      </div>
 
-            <div class="control-group">
-                <?php echo $form->labelEx($image, 'license', array('class' => 'control-label')); ?>
-                <a class="myHint" data-content="GigaScience database will
+      <div class="control-group">
+        <?php echo $form->labelEx($image, 'license', array('class' => 'control-label')); ?>
+        <a class="myHint" data-content="GigaScience database will
                    only use images that are free for others to re-use,
                    primarily this is Creative Commons 0 license (CC0)
-                   please see <a target='_blank' href='http://creativecommons.org/about/cc0'>here</a> 
+                   please see <a target='_blank' href='http://creativecommons.org/about/cc0'>here</a>
                    for further reading on creative commons licenses."></a>
-                <div class="controls">
-                    <?php echo $form->textField($image, 'license', array('size' => 60, 'maxlength' => 200, 'class' => 'image')); ?>
-                    <?php echo $form->error($image, 'license'); ?>
-                </div>
-            </div>
-
-            <div class="control-group">
-                <?php echo $form->labelEx($image, 'photographer', array('class' => 'control-label')); ?>
-                <a class="myHint" data-content="The person(s) that should 
-                   be credited for the image"></a>
-                <div class="controls">
-                    <?php echo $form->textField($image, 'photographer', array('size' => 60, 'maxlength' => 200, 'class' => 'image')); ?>
-                    <?php echo $form->error($image, 'photographer'); ?>
-                </div>
-            </div>
+        <div class="controls">
+          <?php echo $form->textField($image, 'license', array('size' => 60, 'maxlength' => 200, 'class' => 'image')); ?>
+          <?php echo $form->error($image, 'license'); ?>
         </div>
+      </div>
+
+      <div class="control-group">
+        <?php echo $form->labelEx($image, 'photographer', array('class' => 'control-label')); ?>
+        <a class="myHint" data-content="The person(s) that should
+                   be credited for the image"></a>
+        <div class="controls">
+          <?php echo $form->textField($image, 'photographer', array('size' => 60, 'maxlength' => 200, 'class' => 'image')); ?>
+          <?php echo $form->error($image, 'photographer'); ?>
+        </div>
+      </div>
+    </div>
 
 
-        <div class="span10">
-            <div class="control-group">
-                <?php echo $form->labelEx($model, 'description', array('class' => 'control-label')); ?>
-                <a class="myHint" data-content="Please provide a full description of the datatset, this may 
-                   look like an article abstract giving a brief background of the research and a 
+    <!-- row 2 -->
+    <div class="">
+      <div class="control-group">
+        <?php echo $form->labelEx($model, 'description', array('class' => 'control-label')); ?>
+        <a class="myHint" data-content="Please provide a full description of the datatset, this may
+                   look like an article abstract giving a brief background of the research and a
                    description of the results to be found in the dataset
-                   (it should be between 100 and 500 word in length). 
+                   (it should be between 100 and 500 word in length).
                    Please note this text box accepts HTML code tags for formatting,
                    so you may use &quot;&lt; br &gt;&quot; for line breaks, &quot;&lt; em &gt;&QUOT; <em>for italics</em> &quot;
-                   &lt; em /&gt;&quot; 
+                   &lt; em /&gt;&quot;
                    and &quot;&lt; b &gt;&quot; <b>for bold</b> &quot;&lt; b/ &gt;&quot;"></a>
-                <div class="controls">
-                    <?php echo $form->textArea($model, 'description', array('rows' => 6, 'cols' => 100, 'style' => 'resize:vertical;width:610px')); ?>
-                    <?php echo $form->error($model, 'description'); ?>
-                </div>
-            </div>
+        <div class="controls">
+          <?php echo $form->textArea($model, 'description', array('rows' => 6, 'cols' => 100, 'style' => 'resize:vertical;width:610px')); ?>
+          <?php echo $form->error($model, 'description'); ?>
         </div>
-        <div class="span10">
-        <div class="control-group">
-                        <?php echo CHtml::label('Keywords','keywords', array('class'=>'control-label')); ?>
-                        <div class="controls">
-                            <?php echo CHtml::textField('keywords', '', array('class'=>'span10', 'size'=>60,'maxlength'=>300)); ?>
-                        </div>
-                    </div>
-               </div>
+      </div>
     </div>
+    <div class="">
+      <div class="control-group">
+        <?php echo CHtml::label('Keywords', 'keywords', array('class' => 'control-label')); ?>
+        <div class="controls">
+          <?php echo CHtml::textField('keywords', '', array('class' => '', 'size' => 60, 'maxlength' => 300)); ?>
+        </div>
+      </div>
+    </div>
+  </div>
 
-    <div class="span12" style="text-align:center">
-        <a href="<?= Yii::app()->createUrl('/user/view_profile') ?>" class="btn"/>Cancel</a>
-        <?php echo CHtml::submitButton('Next', array('class' => 'btn-green', 'id' => 'next-btn')); ?>
-    </div>
+  <div class="">
+    <a href="<?php echo Yii::app()->createUrl('/user/view_profile') ?>" class="btn">Cancel</a>
+    <?php echo CHtml::submitButton('Next', array('class' => 'btn-green', 'id' => 'next-btn')); ?>
+  </div>
 
 </div>
 
 <script>
-    $('.date').datepicker();
+  $('.date').datepicker();
 
 
-    $(".next1").click(function() {
-        $("#next-btn").click();
+  $(".next1").click(function () {
+    $("#next-btn").click();
+  });
+
+  $(".myHint").popover();
+
+  $(".myHintLink").popover({ trigger: 'manual' }).hover(function (e) {
+    $(this).popover('show');
+    e.preventDefault();
+  });
+
+
+  $('.myHintLink').on('mouseleave', function () {
+    var v = $(this);
+    setTimeout(
+      function () {
+        v.popover('hide');
+      }, 2000);
+  });
+
+  $(function () {
+    $('#image-upload').click(function () {
+      if ($(this).is(':checked')) {
+        $('.image').attr('disabled', true);
+      } else {
+        $('.image').attr('disabled', false);
+      }
     });
+  });
 
-    $(".myHint").popover();
-
-    $(".myHintLink").popover({trigger: 'manual'}).hover(function(e) {
-        $(this).popover('show');
-        e.preventDefault();
-    });
-
-
-    $('.myHintLink').on('mouseleave', function() {
-        var v = $(this);
-        setTimeout(
-                function() {
-                    v.popover('hide');
-                }, 2000);
-    });
-
-    $(function() {
-        $('#image-upload').click(function() {
-            if ($(this).is(':checked')) {
-                $('.image').attr('disabled', true);
-            } else {
-                $('.image').attr('disabled', false);
-            }
-        });
-    });
-    
-    function disableImage(){     
-//        alert('here');
-         if ($('#image-upload').is(':checked')) {
-                $('.image').attr('disabled', true);
-         }
+  function disableImage() {
+    //        alert('here');
+    if ($('#image-upload').is(':checked')) {
+      $('.image').attr('disabled', true);
     }
-        
-    window.onload = disableImage;
+  }
+
+  window.onload = disableImage;
 
 </script>
 <script>
-<?php
-$js_array = json_encode($model->getSemanticKeywords());
-echo "var existingTags = ". $js_array . ";\n";
-?>
-    $('#keywords').tagEditor({
+  <?php
+  $js_array = json_encode($model->getSemanticKeywords());
+  echo "var existingTags = " . $js_array . ";\n";
+  ?>
+  $('#keywords').tagEditor({
     initialTags:
-        existingTags,
+      existingTags,
     delimiter: ',', /* comma */
     placeholder: 'Enter keywords (separated by commas) ...'
-});
+  });
 </script>
-

--- a/protected/views/datasetSubmission/_nav.php
+++ b/protected/views/datasetSubmission/_nav.php
@@ -1,0 +1,33 @@
+<nav class="dataset-submission-nav" aria-label="create dataset">
+  <?php
+  // Current request URL without query string
+  $currentUrl = Yii::app()->request->getUrl();
+
+  // Define links with their respective labels
+  $links = [
+    "/datasetSubmission/create1" => Yii::t('app', 'Study'),
+    "/datasetSubmission/authorManagement/id/{$model->id}" => Yii::t('app', 'Author'),
+    "/datasetSubmission/projectManagement/id/{$model->id}" => Yii::t('app', 'Project'),
+    "/datasetSubmission/linkManagement/id/{$model->id}" => Yii::t('app', 'Link'),
+    "/datasetSubmission/exLinkManagement/id/{$model->id}" => Yii::t('app', 'External Link'),
+    "/datasetSubmission/relatedDoiManagement/id/{$model->id}" => Yii::t('app', 'Related Doi'),
+    "/datasetSubmission/sampleManagement/id/{$model->id}" => Yii::t('app', 'Sample'),
+  ];
+
+  foreach ($links as $url => $label) {
+    $isActive = $currentUrl == $url;
+    $class = $isActive ? 'class="active sw-selected-btn"' : 'class="js-submit"';
+
+    if ($isActive) {
+      echo CHtml::tag('span', [
+        'class' => 'active sw-selected-btn',
+      ], $label);
+    } else {
+      echo CHtml::tag('a', [
+        'href' => $url,
+        'class' => 'js-submit',
+      ], $label);
+    }
+  }
+  ?>
+</nav>

--- a/protected/views/datasetSubmission/authorManagement.php
+++ b/protected/views/datasetSubmission/authorManagement.php
@@ -11,7 +11,7 @@
   $this->renderPartial('_nav', array('model' => $model));
   ?>
 
-  <form class="form well">
+  <form class="form well js-author-amangement-form" novalidate dataset-id="<?= $model->id ?>">
     <div class="form-horizontal">
       <div id="author-grid" class="author-grid grid-view">
         <table class="table table-bordered">
@@ -32,7 +32,7 @@
               </th>
               <th id="author-grid_c3" class="author-orcid-col">
                 <div data-toggle="tooltip" data-html="true" tabindex="0"
-                  title="ORCID provides a persistent digital identifier that distinguishes you from every other researcher.  Please visit <a class='tooltip-link' href='http://orcid.org/'>http://orcid.org/</a> to learn more.">
+                  title="ORCID provides a persistent digital identifier that distinguishes you from every other researcher.  Please visit <a class='tooltip-link' tabindex='-1' href='http://orcid.org/'>http://orcid.org/</a> to learn more.">
                   <label for="js-author-orcid">ORCiD</label>
                   <i class="fa fa-question-circle" aria-hidden="true"></i>
                 </div>
@@ -73,9 +73,9 @@
                       appear in the dataset citation</span>
                   </td>
                   <td class="button-column">
-                    <a data-toggle="tooltip" title="Delete author <?php echo $authorFullName ?>"
-                      class="js-delete-author fa fa-trash fa-lg icon icon-delete" da-id="<?= $da->id ?>"
-                      aria-label="Delete author <?php echo $authorFullName ?>" href="/adminDataset/delete/id/5"></a>
+                    <button data-toggle="tooltip" title="Delete author <?php echo $authorFullName ?>"
+                      class="delete-author-btn js-delete-author fa fa-trash fa-lg icon icon-delete" da-id="<?= $da->id ?>"
+                      aria-label="Delete author <?php echo $authorFullName ?>"></button>
                   </td>
                 </tr>
               <? } ?>
@@ -112,27 +112,40 @@
         </table>
       </div>
       <div class="add-author-container btns-row btns-row-end">
-        <button dataset-id="<?= $model->id ?>" class="btn background-btn-o js-add-author">
+        <button dataset-id="<?= $model->id ?>" class="btn background-btn-o js-add-author" type="submit">
           Add Author
         </button>
       </div>
     </div>
 
-    <hr />
-
-    <div class="btns-row btns-row-end">
-      <a href="/datasetSubmission/datasetManagement/id/<?= $model->id ?>" class="btn background-btn">Previous</a>
-      <a href="/user/view_profile" title="Save your incomplete submission and leave the submission wizard."
-        class="btn background-btn delete-title">Save & Quit</a>
-      <a href="/datasetSubmission/projectManagement/id/<?= $model->id ?>" class="btn background-btn">Next</a>
-    </div>
-
   </form>
+  <div class="btns-row btns-row-end">
+    <a href="/datasetSubmission/datasetManagement/id/<?= $model->id ?>" class="btn background-btn">Previous</a>
+    <a href="/user/view_profile" title="Save your incomplete submission and leave the submission wizard."
+      class="btn background-btn delete-title">Save & Quit</a>
+    <a href="/datasetSubmission/projectManagement/id/<?= $model->id ?>" class="btn background-btn">Next</a>
+  </div>
 </div>
 
 <script>
   $(function () {
     $('[data-toggle="tooltip"]').tooltip()
+  })
+
+  $(document).ready(function () {
+    $('.js-author-amangement-form').on('submit', function (e) {
+      e.preventDefault()
+
+      const form = event.target
+
+      if (!form.checkValidity()) {
+        form.reportValidity()
+        return
+      }
+      addAuthor(this)
+
+
+    })
   })
 
   function ajaxIndicatorStart(text) {
@@ -220,9 +233,8 @@
     });
   });
 
-  $(".js-add-author").click(function (e) {
-    e.preventDefault();
-    var did = $(this).attr('dataset-id');
+  function addAuthor(el) {
+    var did = $(el).attr('dataset-id');
     var first_name = $('#js-author-first-name').val();
     var last_name = $('#js-author-last-name').val();
     var middle_name = $('#js-author-middle-name').val();
@@ -244,13 +256,12 @@
           window.location.reload();
         } else {
           alert(response.message);
-
         }
       },
       error: function () {
       }
     });
-  })
+  }
 
   $(".js-delete-author").click(function (e) {
     if (!confirm('Are you sure you want to delete this item?'))
@@ -281,8 +292,4 @@
     //hide ajax indicator
     ajaxIndicatorStop();
   });
-
-  // $(".myHint").tooltip({ 'placement': 'top' });
-  // $(".delete-title").tooltip({ 'placement': 'top' });
-
 </script>

--- a/protected/views/datasetSubmission/authorManagement.php
+++ b/protected/views/datasetSubmission/authorManagement.php
@@ -1,257 +1,246 @@
 <h2>Add Authors</h2>
 <div class="clear"></div>
 
-<a href="/datasetSubmission/datasetManagement/id/<?= $model->id ?>" class="btn nomargin"><?= Yii::t('app' , 'Study')?></a>
-<a href="#" class="btn sw-selected-btn"><?= Yii::t('app' , 'Author')?></a>
-<a href="/datasetSubmission/projectManagement/id/<?= $model->id ?>" class="btn nomargin"><?= Yii::t('app' , 'Project')?></a>
-<a href="/datasetSubmission/linkManagement/id/<?= $model->id ?>" class="btn nomargin"><?= Yii::t('app' , 'Link')?></a>
-<a href="/datasetSubmission/exLinkManagement/id/<?= $model->id ?>" class="btn nomargin"><?= Yii::t('app' , 'External Link')?></a>
-<a href="/datasetSubmission/relatedDoiManagement/id/<?= $model->id ?>" class="btn nomargin"><?= Yii::t('app' , 'Related Doi')?></a>
-<a href="/datasetSubmission/sampleManagement/id/<?= $model->id ?>" class="btn nomargin"><?= Yii::t('app' , 'Sample')?></a>
-<? if($model->isProteomic) { ?>
-<a href="/datasetSubmission/pxInfoManagement/id/<?= $model->id ?>" class="btn nomargin"><?= Yii::t('app' , 'PX Info')?></a>
-<? } ?>
-<? if($model->files && count($model->files) > 0) { ?>
-<a href="/adminFile/create1/id/<?= $model->id ?>" class="btn nomargin"><?= Yii::t('app' , 'File')?></a>
-<? } ?>
-
+<?
+$this->renderPartial('_nav', array('model' => $model));
+?>
 
 
 <div class="span12 form well">
-    <div class="form-horizontal">
-	<div id="author-grid" class="grid-view">
-		<table class="table table-bordered">
-			<thead>
-				<tr>
-					<th id="author-grid_c0" width="25%">First name</th>
-					<th id="author-grid_c1" width="25%">Middle name</th>
-					<th id="author-grid_c2" width="25%">Last name</th>
-					<th id="author-grid_c3" width="10%">
-                          <span>ORCiD</span>
-                          <a class="myHint" 
-                          title="ORCID provides a persistent digital identifier that distinguishes you from every other researcher.  Please visit <a href=&quot;http://orcid.org/&quot;>http://orcid.org/</a> to learn more."
-                          style="float:right"
-                          >
-                        </a>
-                        </th>
-					<th id="author-grid_c4" width="10%">
-                          <span>Order</span>
-                          <a class="myHint" title="This is the order in which authors will appear in the dataset citation." style="float:right"></a>
-                        </th>
-					<th id="author-grid_c5" class="button-column" width="5%"></th>
-				</tr>
-			</thead>
-			<tbody>
-				<?php if($das) { ?>
-				<?php foreach($das as $da) { ?>
-				<tr class="odd">
-					<td><?=$da->author->first_name?></td>
-					<td><?=$da->author->middle_name?></td>
-					<td><?=$da->author->surname?></td>
-					<td><?=$da->author->orcid?></td>
-					<td>
-						<input class='js-author-rank' 
-						id="js-author-rank-<?=$da->id?>"
-						da-id="<?=$da->id?>" 
-						value="<?=$da->rank?>"
-						type="text" 
-						style="width:25px">
-					</td>
-					<td class="button-column">
-						<a class="js-delete-author delete-title" da-id="<?=$da->id?>"  title="delete this row">
-							<img alt="delete this row" src="/images/delete.png">
-						</a>
-					</td>
-				</tr>
-				<? } ?>
-				<? } else { ?>
-				<tr>
-					<td colspan="4">
-						<span class="empty">No results found.</span>
-					</td>
-				</tr>
-				<tr>
-				<? } ?>
-					<td>
-					<input id="js-author-first-name" type="text" name="Author[first_name]" placeholder="First Name" style="width:180px">
-					</td>
-					<td>
-					<input id="js-author-middle-name" type="text" name="Author[middle_name]" placeholder="Middle Name (Option)" style="width:180px">
-					</td>
-					<td>
-					<input id="js-author-last-name" type="text" name="Author[last_name]" placeholder="Last Name" style="width:180px">
-					</td>
-					<td>
-                       <input id="js-author-orcid" type="text" name="Author[orcid]" placeholder="ORCiD(Option)" style="width:100px">
-                       </td>
-					<td></td>
-                          <td></td>
-				</tr>
-				</tbody>
-		</table>
-        </div>
-       <div class="add-author-container"><a href="#" dataset-id="<?=$model->id?>" class="btn js-add-author"/>Add Author</a></div>
+  <div class="form-horizontal">
+    <div id="author-grid" class="grid-view">
+      <table class="table table-bordered">
+        <thead>
+          <tr>
+            <th id="author-grid_c0" width="25%">First name</th>
+            <th id="author-grid_c1" width="25%">Middle name</th>
+            <th id="author-grid_c2" width="25%">Last name</th>
+            <th id="author-grid_c3" width="10%">
+              <span>ORCiD</span>
+              <a class="myHint"
+                title="ORCID provides a persistent digital identifier that distinguishes you from every other researcher.  Please visit <a href=&quot;http://orcid.org/&quot;>http://orcid.org/</a> to learn more."
+                style="float:right">
+              </a>
+            </th>
+            <th id="author-grid_c4" width="10%">
+              <span>Order</span>
+              <a class="myHint" title="This is the order in which authors will appear in the dataset citation."
+                style="float:right"></a>
+            </th>
+            <th id="author-grid_c5" class="button-column" width="5%"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <?php if ($das) { ?>
+            <?php foreach ($das as $da) { ?>
+              <tr class="odd">
+                <td><?= $da->author->first_name ?></td>
+                <td><?= $da->author->middle_name ?></td>
+                <td><?= $da->author->surname ?></td>
+                <td><?= $da->author->orcid ?></td>
+                <td>
+                  <input class='js-author-rank' id="js-author-rank-<?= $da->id ?>" da-id="<?= $da->id ?>" value="<?= $da->rank ?>"
+                    type="text" style="width:25px">
+                </td>
+                <td class="button-column">
+                  <a class="js-delete-author delete-title" da-id="<?= $da->id ?>" title="delete this row">
+                    <img alt="delete this row" src="/images/delete.png">
+                  </a>
+                </td>
+              </tr>
+            <? } ?>
+          <? } else { ?>
+            <tr>
+              <td colspan="4">
+                <span class="empty">No results found.</span>
+              </td>
+            </tr>
+            <tr>
+            <? } ?>
+            <td>
+              <input id="js-author-first-name" type="text" name="Author[first_name]" placeholder="First Name"
+                style="width:180px">
+            </td>
+            <td>
+              <input id="js-author-middle-name" type="text" name="Author[middle_name]"
+                placeholder="Middle Name (Option)" style="width:180px">
+            </td>
+            <td>
+              <input id="js-author-last-name" type="text" name="Author[last_name]" placeholder="Last Name"
+                style="width:180px">
+            </td>
+            <td>
+              <input id="js-author-orcid" type="text" name="Author[orcid]" placeholder="ORCiD(Option)"
+                style="width:100px">
+            </td>
+            <td></td>
+            <td></td>
+          </tr>
+        </tbody>
+      </table>
     </div>
+    <div class="add-author-container"><a href="#" dataset-id="<?= $model->id ?>" class="btn js-add-author" />Add
+      Author</a></div>
+  </div>
 
-     <div class="span12" style="text-align:center">
-        <a href="/datasetSubmission/datasetManagement/id/<?= $model->id ?>" class="btn-green">Previous</a>
-        <a href="/user/view_profile" title="Save your incomplete submission and leave the submission wizard." class="btn-green delete-title">Save & Quit</a>
-        <a href="/datasetSubmission/projectManagement/id/<?= $model->id ?>" class="btn-green">Next</a>
-    </div>
+  <div class="span12" style="text-align:center">
+    <a href="/datasetSubmission/datasetManagement/id/<?= $model->id ?>" class="btn-green">Previous</a>
+    <a href="/user/view_profile" title="Save your incomplete submission and leave the submission wizard."
+      class="btn-green delete-title">Save & Quit</a>
+    <a href="/datasetSubmission/projectManagement/id/<?= $model->id ?>" class="btn-green">Next</a>
+  </div>
 
 </div>
 
 <script>
-function ajaxIndicatorStart(text)
-{
-    if($('body').find('#resultLoading').attr('id') != 'resultLoading'){
-    $('body').append('<div id="resultLoading" style="display:none"><div><img width="30" src="/images/ajax-loader.gif"><div>'+text+'</div></div><div class="bg"></div></div>');
+  function ajaxIndicatorStart(text) {
+    if ($('body').find('#resultLoading').attr('id') != 'resultLoading') {
+      $('body').append('<div id="resultLoading" style="display:none"><div><img width="30" src="/images/ajax-loader.gif"><div>' + text + '</div></div><div class="bg"></div></div>');
     }
 
     $('#resultLoading').css({
-        'width':'100%',
-        'height':'100%',
-        'position':'fixed',
-        'z-index':'10000000',
-        'top':'0',
-        'left':'0',
-        'right':'0',
-        'bottom':'0',
-        'margin':'auto'
+      'width': '100%',
+      'height': '100%',
+      'position': 'fixed',
+      'z-index': '10000000',
+      'top': '0',
+      'left': '0',
+      'right': '0',
+      'bottom': '0',
+      'margin': 'auto'
     });
 
     $('#resultLoading .bg').css({
-        'background':'#000000',
-        'opacity':'0.7',
-        'width':'100%',
-        'height':'100%',
-        'position':'absolute',
-        'top':'0'
+      'background': '#000000',
+      'opacity': '0.7',
+      'width': '100%',
+      'height': '100%',
+      'position': 'absolute',
+      'top': '0'
     });
 
     $('#resultLoading>div:first').css({
-        'width': '250px',
-        'height':'75px',
-        'text-align': 'center',
-        'position': 'fixed',
-        'top':'0',
-        'left':'0',
-        'right':'0',
-        'bottom':'0',
-        'margin':'auto',
-        'font-size':'16px',
-        'z-index':'10',
-        'color':'#ffffff'
+      'width': '250px',
+      'height': '75px',
+      'text-align': 'center',
+      'position': 'fixed',
+      'top': '0',
+      'left': '0',
+      'right': '0',
+      'bottom': '0',
+      'margin': 'auto',
+      'font-size': '16px',
+      'z-index': '10',
+      'color': '#ffffff'
 
     });
 
     $('#resultLoading .bg').height('100%');
     $('#resultLoading').fadeIn(300);
     $('body').css('cursor', 'wait');
-}
+  }
 
-function ajaxIndicatorStop()
-{
+  function ajaxIndicatorStop() {
     $('#resultLoading .bg').height('100%');
     $('#resultLoading').fadeOut(300);
     $('body').css('cursor', 'default');
-}
+  }
 
-    $(".js-open-rank").click(function(e) {
-    	e.preventDefault();
-        	var  daid = $(this).attr('da-id');
-        	$('.js-author-rank').hide();
-        	$("#js-author-rank-"+daid).show();
-        	$('.js-open-rank').show();
-        	$(this).hide();
+  $(".js-open-rank").click(function (e) {
+    e.preventDefault();
+    var daid = $(this).attr('da-id');
+    $('.js-author-rank').hide();
+    $("#js-author-rank-" + daid).show();
+    $('.js-open-rank').show();
+    $(this).hide();
+  });
+
+  $(".js-author-rank").change(function (e) {
+    e.preventDefault();
+    var daid = $(this).attr('da-id');
+    var rank = $(this).val();
+    $.ajax({
+      type: 'POST',
+      url: '/adminDatasetAuthor/updateRank',
+      data: { 'da_id': daid, 'rank': rank },
+      beforeSend: function () {
+        ajaxIndicatorStart('loading data.. please wait..');
+      },
+      success: function (response) {
+        if (response.success == true) {
+          window.location.reload();
+        } else {
+          alert(response.message);
+        }
+      },
+      error: function () {
+      }
     });
+  });
 
-    $(".js-author-rank").change(function(e) {
-    	e.preventDefault();
-        	var  daid = $(this).attr('da-id');
-        	var rank = $(this).val();
-        	$.ajax({
-           type: 'POST',
-           url: '/adminDatasetAuthor/updateRank',
-	       data:{'da_id': daid,'rank':rank},
-            beforeSend:function(){
-               ajaxIndicatorStart('loading data.. please wait..');
-            },
-           success: function(response){
-           	if(response.success == true) {
-           		window.location.reload();
-           	} else {
-           		alert(response.message);
-           	}
-          },
-          error:function(){
-      	}   
-        });
+  $(".js-add-author").click(function (e) {
+    e.preventDefault();
+    var did = $(this).attr('dataset-id');
+    var first_name = $('#js-author-first-name').val();
+    var last_name = $('#js-author-last-name').val();
+    var middle_name = $('#js-author-middle-name').val();
+    var orcid = $('#js-author-orcid').val();
+
+    var author = {
+      'first_name': first_name,
+      'last_name': last_name,
+      'middle_name': middle_name,
+      'orcid': orcid,
+    }
+
+    $.ajax({
+      type: 'POST',
+      url: '/adminDatasetAuthor/addAuthor',
+      data: { 'dataset_id': did, 'Author': author },
+      success: function (response) {
+        if (response.success) {
+          window.location.reload();
+        } else {
+          alert(response.message);
+
+        }
+      },
+      error: function () {
+      }
     });
+  })
 
-    $(".js-add-author").click(function(e) {
-        e.preventDefault();
-        var  did = $(this).attr('dataset-id');
-        var first_name = $('#js-author-first-name').val();
-        var last_name = $('#js-author-last-name').val();
-        var middle_name = $('#js-author-middle-name').val();
-        var orcid = $('#js-author-orcid').val();
+  $(".js-delete-author").click(function (e) {
+    if (!confirm('Are you sure you want to delete this item?'))
+      return false;
+    e.preventDefault();
+    var daid = $(this).attr('da-id');
 
-        var author = {
-        	'first_name': first_name,
-        	'last_name': last_name,
-        	'middle_name': middle_name,
-         'orcid': orcid,
-    	    }
-
-        $.ajax({
-           type: 'POST',
-           url: '/adminDatasetAuthor/addAuthor',
-           data:{'dataset_id': did, 'Author':author},
-           success: function(response){
-           	if(response.success) {
-           		window.location.reload();
-           	} else {
-           		alert(response.message);
-
-           	}
-          },
-          error:function(){
-      	}   
-        });
-    })
-
-    $(".js-delete-author").click(function(e) {
-    	if (!confirm('Are you sure you want to delete this item?'))
-            return false; 
-        e.preventDefault();
-        var  daid = $(this).attr('da-id');
-
-        $.ajax({
-           type: 'POST',
-           url: '/adminDatasetAuthor/deleteAuthor',
-           data:{'da_id': daid},
-            beforeSend:function(){
-               ajaxIndicatorStart('loading data.. please wait..');
-            },
-           success: function(response){
-           	if(response.success) {
-           		window.location.reload();
-           	} else {
-           		alert(response.message);
-           	}
-          },
-          error:function(){
-      	}   
-        });
-    })
-
-    $(document).ajaxStop(function () {
-        //hide ajax indicator
-        ajaxIndicatorStop();
+    $.ajax({
+      type: 'POST',
+      url: '/adminDatasetAuthor/deleteAuthor',
+      data: { 'da_id': daid },
+      beforeSend: function () {
+        ajaxIndicatorStart('loading data.. please wait..');
+      },
+      success: function (response) {
+        if (response.success) {
+          window.location.reload();
+        } else {
+          alert(response.message);
+        }
+      },
+      error: function () {
+      }
     });
+  })
 
-    $(".myHint").tooltip({'placement':'top'});
-    $(".delete-title").tooltip({'placement':'top'});
+  $(document).ajaxStop(function () {
+    //hide ajax indicator
+    ajaxIndicatorStop();
+  });
+
+  $(".myHint").tooltip({ 'placement': 'top' });
+  $(".delete-title").tooltip({ 'placement': 'top' });
 
 </script>

--- a/protected/views/datasetSubmission/authorManagement.php
+++ b/protected/views/datasetSubmission/authorManagement.php
@@ -1,98 +1,140 @@
-<h2>Add Authors</h2>
-<div class="clear"></div>
+<div class="container dataset-submission-page">
+  <?php
+  $this->widget('TitleBreadcrumb', [
+    'pageTitle' => 'Add Authors',
+    'breadcrumbItems' => []
+  ]);
 
-<?
-$this->renderPartial('_nav', array('model' => $model));
-?>
+  ?>
 
+  <?
+  $this->renderPartial('_nav', array('model' => $model));
+  ?>
 
-<div class="span12 form well">
-  <div class="form-horizontal">
-    <div id="author-grid" class="grid-view">
-      <table class="table table-bordered">
-        <thead>
-          <tr>
-            <th id="author-grid_c0" width="25%">First name</th>
-            <th id="author-grid_c1" width="25%">Middle name</th>
-            <th id="author-grid_c2" width="25%">Last name</th>
-            <th id="author-grid_c3" width="10%">
-              <span>ORCiD</span>
-              <a class="myHint"
-                title="ORCID provides a persistent digital identifier that distinguishes you from every other researcher.  Please visit <a href=&quot;http://orcid.org/&quot;>http://orcid.org/</a> to learn more."
-                style="float:right">
-              </a>
-            </th>
-            <th id="author-grid_c4" width="10%">
-              <span>Order</span>
-              <a class="myHint" title="This is the order in which authors will appear in the dataset citation."
-                style="float:right"></a>
-            </th>
-            <th id="author-grid_c5" class="button-column" width="5%"></th>
-          </tr>
-        </thead>
-        <tbody>
-          <?php if ($das) { ?>
-            <?php foreach ($das as $da) { ?>
-              <tr class="odd">
-                <td><?= $da->author->first_name ?></td>
-                <td><?= $da->author->middle_name ?></td>
-                <td><?= $da->author->surname ?></td>
-                <td><?= $da->author->orcid ?></td>
-                <td>
-                  <input class='js-author-rank' id="js-author-rank-<?= $da->id ?>" da-id="<?= $da->id ?>" value="<?= $da->rank ?>"
-                    type="text" style="width:25px">
-                </td>
-                <td class="button-column">
-                  <a class="js-delete-author delete-title" da-id="<?= $da->id ?>" title="delete this row">
-                    <img alt="delete this row" src="/images/delete.png">
-                  </a>
+  <form class="form well">
+    <div class="form-horizontal">
+      <div id="author-grid" class="author-grid grid-view">
+        <table class="table table-bordered">
+          <thead>
+            <tr>
+              <th id="author-grid_c0" class="first-name-col">
+                <label for="js-author-first-name">First name<span> *</span></label>
+              </th>
+              <th id="author-grid_c1" class="middle-name-col">
+                <label for="js-author-middle-name">
+                  Middle name
+                </label>
+              </th>
+              <th id="author-grid_c2" class="last-name-col">
+                <label for="js-author-last-name">
+                  Last name<span> *</span>
+                </label>
+              </th>
+              <th id="author-grid_c3" class="author-orcid-col">
+                <div data-toggle="tooltip" data-html="true" tabindex="0"
+                  title="ORCID provides a persistent digital identifier that distinguishes you from every other researcher.  Please visit <a class='tooltip-link' href='http://orcid.org/'>http://orcid.org/</a> to learn more.">
+                  <label for="js-author-orcid">ORCiD</label>
+                  <i class="fa fa-question-circle" aria-hidden="true"></i>
+                </div>
+              </th>
+              <th id="author-grid_c4" class="order-col">
+                <div data-toggle="tooltip"
+                  title="This is the order in which authors will appear in the dataset citation." tabindex="0">
+                  <span>Order</span>
+                  <i class="fa fa-question-circle" aria-hidden="true"></i>
+                </div>
+              </th>
+              <th id="author-grid_c5" class="button-column">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php if ($das) { ?>
+              <?php foreach ($das as $da) {
+                $authorFullName = $da->author->first_name . ' ' . $da->author->middle_name . ' ' . $da->author->surname;
+                ?>
+                <tr class="odd">
+                  <td>
+                    <?= $da->author->first_name ?>
+                  </td>
+                  <td>
+                    <?= $da->author->middle_name ?>
+                  </td>
+                  <td>
+                    <?= $da->author->surname ?>
+                  </td>
+                  <td>
+                    <?= $da->author->orcid ?>
+                  </td>
+                  <td>
+                    <input type="number" class='js-author-rank form-control' id="js-author-rank-<?= $da->id ?>"
+                      da-id="<?= $da->id ?>" aria-label="Order for author <?= $authorFullName ?>"
+                      aria-describedby="js-author-rank-<?= $da->id ?>-desc" />
+                    <span class="sr-only" id="js-author-rank-<?= $da->id ?>-desc">This is the order in which authors will
+                      appear in the dataset citation</span>
+                  </td>
+                  <td class="button-column">
+                    <a data-toggle="tooltip" title="Delete author <?php echo $authorFullName ?>"
+                      class="js-delete-author fa fa-trash fa-lg icon icon-delete" da-id="<?= $da->id ?>"
+                      aria-label="Delete author <?php echo $authorFullName ?>" href="/adminDataset/delete/id/5"></a>
+                  </td>
+                </tr>
+              <? } ?>
+            <? } else { ?>
+              <tr>
+                <td colspan="4">
+                  <span class="empty">No results found.</span>
                 </td>
               </tr>
-            <? } ?>
-          <? } else { ?>
-            <tr>
-              <td colspan="4">
-                <span class="empty">No results found.</span>
+              <tr>
+              <? } ?>
+              <td>
+                <input id="js-author-first-name" class="form-control" type="text" name="Author[first_name]"
+                  placeholder="First Name" aria-required="true" required>
               </td>
+              <td>
+                <input id="js-author-middle-name" class="form-control" type="text" name="Author[middle_name]"
+                  placeholder="Middle Name">
+              </td>
+              <td>
+                <input id="js-author-last-name" class="form-control" type="text" name="Author[last_name]"
+                  placeholder="Last Name" aria-required="true" required>
+              </td>
+              <td>
+                <input id="js-author-orcid" class="form-control" type="text" name="Author[orcid]" placeholder="ORCiD"
+                  aria-describedby="author-orcid-desc">
+                <span class="sr-only" id="author-orcid-desc">ORCID provides a persistent digital identifier that
+                  distinguishes you from every other researcher. Please visit http://orcid.org/ to learn more.</span>
+              </td>
+              <td></td>
+              <td></td>
             </tr>
-            <tr>
-            <? } ?>
-            <td>
-              <input id="js-author-first-name" type="text" name="Author[first_name]" placeholder="First Name"
-                style="width:180px">
-            </td>
-            <td>
-              <input id="js-author-middle-name" type="text" name="Author[middle_name]"
-                placeholder="Middle Name (Option)" style="width:180px">
-            </td>
-            <td>
-              <input id="js-author-last-name" type="text" name="Author[last_name]" placeholder="Last Name"
-                style="width:180px">
-            </td>
-            <td>
-              <input id="js-author-orcid" type="text" name="Author[orcid]" placeholder="ORCiD(Option)"
-                style="width:100px">
-            </td>
-            <td></td>
-            <td></td>
-          </tr>
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </div>
+      <div class="add-author-container btns-row btns-row-end">
+        <button dataset-id="<?= $model->id ?>" class="btn background-btn-o js-add-author">
+          Add Author
+        </button>
+      </div>
     </div>
-    <div class="add-author-container"><a href="#" dataset-id="<?= $model->id ?>" class="btn js-add-author" />Add
-      Author</a></div>
-  </div>
 
-  <div class="span12" style="text-align:center">
-    <a href="/datasetSubmission/datasetManagement/id/<?= $model->id ?>" class="btn-green">Previous</a>
-    <a href="/user/view_profile" title="Save your incomplete submission and leave the submission wizard."
-      class="btn-green delete-title">Save & Quit</a>
-    <a href="/datasetSubmission/projectManagement/id/<?= $model->id ?>" class="btn-green">Next</a>
-  </div>
+    <hr />
 
+    <div class="btns-row btns-row-end">
+      <a href="/datasetSubmission/datasetManagement/id/<?= $model->id ?>" class="btn background-btn">Previous</a>
+      <a href="/user/view_profile" title="Save your incomplete submission and leave the submission wizard."
+        class="btn background-btn delete-title">Save & Quit</a>
+      <a href="/datasetSubmission/projectManagement/id/<?= $model->id ?>" class="btn background-btn">Next</a>
+    </div>
+
+  </form>
 </div>
 
 <script>
+  $(function () {
+    $('[data-toggle="tooltip"]').tooltip()
+  })
+
   function ajaxIndicatorStart(text) {
     if ($('body').find('#resultLoading').attr('id') != 'resultLoading') {
       $('body').append('<div id="resultLoading" style="display:none"><div><img width="30" src="/images/ajax-loader.gif"><div>' + text + '</div></div><div class="bg"></div></div>');
@@ -240,7 +282,7 @@ $this->renderPartial('_nav', array('model' => $model));
     ajaxIndicatorStop();
   });
 
-  $(".myHint").tooltip({ 'placement': 'top' });
-  $(".delete-title").tooltip({ 'placement': 'top' });
+  // $(".myHint").tooltip({ 'placement': 'top' });
+  // $(".delete-title").tooltip({ 'placement': 'top' });
 
 </script>

--- a/protected/views/datasetSubmission/create1.php
+++ b/protected/views/datasetSubmission/create1.php
@@ -22,29 +22,10 @@
     )
   );
   ?>
-  <nav class="dataset-submission-nav" aria-label="secondary">
-    <a href="#" class="sw-selected-btn">
-      <?= Yii::t('app', 'Study') ?>
-    </a>
-    <a href="/datasetSubmission/authorManagement/id/<?= $model->id ?>" class="js-submit">
-      <?= Yii::t('app', 'Author') ?>
-    </a>
-    <a href="/datasetSubmission/projectManagement/id/<?= $model->id ?>" class="js-submit">
-      <?= Yii::t('app', 'Project') ?>
-    </a>
-    <a href="/datasetSubmission/linkManagement/id/<?= $model->id ?>" class="js-submit">
-      <?= Yii::t('app', 'Link') ?>
-    </a>
-    <a href="/datasetSubmission/exLinkManagement/id/<?= $model->id ?>" class="js-submit">
-      <?= Yii::t('app', 'External Link') ?>
-    </a>
-    <a href="/datasetSubmission/relatedDoiManagement/id/<?= $model->id ?>" class="js-submit">
-      <?= Yii::t('app', 'Related Doi') ?>
-    </a>
-    <a href="/datasetSubmission/sampleManagement/id/<?= $model->id ?>" class="js-submit">
-      <?= Yii::t('app', 'Sample') ?>
-    </a>
-  </nav>
+
+  <?
+  $this->renderPartial('_nav', array('model' => $model));
+  ?>
 
   <?
   $this->renderPartial('_form1', array('model' => $model, 'form' => $form, 'image' => $image));

--- a/protected/views/datasetSubmission/create1.php
+++ b/protected/views/datasetSubmission/create1.php
@@ -1,37 +1,63 @@
-<h2>Create Dataset</h2>
-<div class="clear"></div>
+<div class="container dataset-submission-page">
 
-<?php
-$form = $this->beginWidget('CActiveForm', array(
-    'id' => 'dataset-form',
-    'enableAjaxValidation' => false,
-    'htmlOptions' => array(
+  <?php
+  $this->widget('TitleBreadcrumb', [
+    'pageTitle' => 'Create Dataset',
+    'breadcrumbItems' => []
+  ]);
+
+  ?>
+
+
+  <?php
+  $form = $this->beginWidget(
+    'CActiveForm',
+    array(
+      'id' => 'dataset-form',
+      'enableAjaxValidation' => false,
+      'htmlOptions' => array(
         'class' => 'form-horizontal',
-        'enctype' => 'multipart/form-data'),
-        ));
-?>
+        'enctype' => 'multipart/form-data'
+      ),
+    )
+  );
+  ?>
+  <nav class="dataset-submission-nav" aria-label="secondary">
+    <a href="#" class="sw-selected-btn">
+      <?= Yii::t('app', 'Study') ?>
+    </a>
+    <a href="/datasetSubmission/authorManagement/id/<?= $model->id ?>" class="js-submit">
+      <?= Yii::t('app', 'Author') ?>
+    </a>
+    <a href="/datasetSubmission/projectManagement/id/<?= $model->id ?>" class="js-submit">
+      <?= Yii::t('app', 'Project') ?>
+    </a>
+    <a href="/datasetSubmission/linkManagement/id/<?= $model->id ?>" class="js-submit">
+      <?= Yii::t('app', 'Link') ?>
+    </a>
+    <a href="/datasetSubmission/exLinkManagement/id/<?= $model->id ?>" class="js-submit">
+      <?= Yii::t('app', 'External Link') ?>
+    </a>
+    <a href="/datasetSubmission/relatedDoiManagement/id/<?= $model->id ?>" class="js-submit">
+      <?= Yii::t('app', 'Related Doi') ?>
+    </a>
+    <a href="/datasetSubmission/sampleManagement/id/<?= $model->id ?>" class="js-submit">
+      <?= Yii::t('app', 'Sample') ?>
+    </a>
+  </nav>
 
-<a href="#" class="btn sw-selected-btn"><?= Yii::t('app' , 'Study')?></a>
-<a href="/datasetSubmission/authorManagement/id/<?= $model->id ?>" class="btn nomargin js-submit"><?= Yii::t('app' , 'Author')?></a>
-<a href="/datasetSubmission/projectManagement/id/<?= $model->id ?>" class="btn nomargin js-submit"><?= Yii::t('app' , 'Project')?></a>
-<a href="/datasetSubmission/linkManagement/id/<?= $model->id ?>" class="btn nomargin js-submit"><?= Yii::t('app' , 'Link')?></a>
-<a href="/datasetSubmission/exLinkManagement/id/<?= $model->id ?>" class="btn nomargin js-submit"><?= Yii::t('app' , 'External Link')?></a>
-<a href="/datasetSubmission/relatedDoiManagement/id/<?= $model->id ?>" class="btn nomargin js-submit"><?= Yii::t('app' , 'Related Doi')?></a>
-<a href="/datasetSubmission/sampleManagement/id/<?= $model->id ?>" class="btn nomargin js-submit"><?= Yii::t('app' , 'Sample')?></a>
-
-<? 
-    $this->renderPartial('_form1', array('model'=>$model, 'form'=>$form,'image'=>$image));     
-?>
+  <?
+  $this->renderPartial('_form1', array('model' => $model, 'form' => $form, 'image' => $image));
+  ?>
 
 
+  <?php $this->endWidget(); ?>
 
-<?php $this->endWidget(); ?>
+</div>
 
 <script>
-	$('.js-submit').click(function(e) {
-		e.preventDefault();
-		$('#dataset-form').submit();
-	});
+  $('.js-submit').click(function (e) {
+    e.preventDefault();
+    $('#dataset-form').submit();
+  });
 </script>
-
-


### PR DESCRIPTION
# Pull request for issue: #1080

NOTE: this work in on hold until work on the submission wizard project is resumed

This is a pull request for the following functionalities:

* Upgrade beta submissin page to new layout
* Upgrade form styles for Study and Author pages

Study
![image](https://github.com/gigascience/gigadb-website/assets/143437854/a319d804-2f99-4776-af98-e143a45914e7)
![image](https://github.com/gigascience/gigadb-website/assets/143437854/cb8d613e-311f-40d3-aead-40b4d1a2bf27)

Error
![image](https://github.com/gigascience/gigadb-website/assets/143437854/89251028-5864-424f-903a-891ab693f91d)

Author
![image](https://github.com/gigascience/gigadb-website/assets/143437854/cf6167fc-eae9-4392-b608-3f618cb1b2ee)


## How to test?

* Navigate to http://gigadb.gigasciencejournal.com/datasetSubmission/create1
* Review page appearance
* fill in form and click next
* review page appearance of auhor page (left as work in progress, see comment thread in #1080 )

## How have functionalities been implemented?

* Upgrade Study and Author pages to use new layout
* Upgrade Study form in terms of layout and accessibility
  * Use readonly inputs or aria-disabled instead of `disabled`
  * Make input descriptions always visible and associated to inputs

## Any issues with implementation?

This multi-step form is relatively complex and it looks like work in progress so it seems better to put its restyling / a11y improvement on hold until new confirmation

## Any changes to automated tests?

--