### PR TITLE
Replace Google Analytics script by Matomo script in all layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1759: Replace Google Analytics script by Matomo script in all layouts
 - Feat #1652: Update API doc for usage of retrieve known datasets by DOI endpoint
 
 ## v4.2.1 - 2024-03-18 - ac7d6168b

--- a/protected/views/layouts/datasetpage.php
+++ b/protected/views/layouts/datasetpage.php
@@ -29,7 +29,6 @@
         <link rel="stylesheet" type="text/css" href="/css/site.css"/>
     <? } ?>
 
-    <?= $this->renderPartial('//shared/_google_analytics')?>
 
     <title><?php echo CHtml::encode($this->pageTitle); ?></title>
 
@@ -50,7 +49,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.ba-bbq/1.2.1/jquery.ba-bbq.min.js" ></script>
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.0.4/css/bootstrap.min.css">
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" defer></script>
-
+    <?= $this->renderPartial('//shared/_matomo') ?>
 </head>
 
 <body>

--- a/protected/views/layouts/main.php
+++ b/protected/views/layouts/main.php
@@ -22,9 +22,9 @@
         <link rel="stylesheet" type="text/css" href="/css/site.css"/>
     <? } ?>
 
-    <?= $this->renderPartial('//shared/_google_analytics')?>
 
     <title><?php echo CHtml::encode($this->pageTitle); ?></title>
+    <?= $this->renderPartial('//shared/_matomo') ?>
 </head>
 
 <body>

--- a/protected/views/layouts/new_datasetpage.php
+++ b/protected/views/layouts/new_datasetpage.php
@@ -109,10 +109,10 @@ jQuery.sub = function() {
                 <script type="text/javascript" src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js" defer></script>
                 <script type="text/javascript" src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap.min.js" defer></script>
                 <? } ?>
-                    <?= $this->renderPartial('//shared/_google_analytics')?>
                         <title>
                             <?php echo CHtml::encode($this->pageTitle); ?>
                         </title>
+                        <?= $this->renderPartial('//shared/_matomo') ?>
 </head>
 
 <body>

--- a/protected/views/layouts/new_faq.php
+++ b/protected/views/layouts/new_faq.php
@@ -29,10 +29,10 @@
            Yii::app()->clientScript->scriptMap['jquery-ui.css'] = false;
            Yii::app()->clientScript->scriptMap['bootstrap.min.js'] = false;
            ?>
-                        <?= $this->renderPartial('//shared/_google_analytics') ?>
                             <title>
                                 <?php echo CHtml::encode($this->pageTitle); ?>
                             </title>
+                            <?= $this->renderPartial('//shared/_matomo') ?>
 </head>
 
 <body>

--- a/protected/views/layouts/new_main.php
+++ b/protected/views/layouts/new_main.php
@@ -103,6 +103,7 @@ jQuery.sub = function() {
                     <title>
                         <?php echo CHtml::encode($this->pageTitle); ?>
                     </title>
+  <?= $this->renderPartial('//shared/_matomo') ?>
 </head>
 
 <body>
@@ -316,7 +317,6 @@ jQuery.sub = function() {
     <script type="application/ld+json">
     { "@context": "http://schema.org", "@type": "DataCatalog", "name": "GigaDB.org", "description": "GigaDB primarily serves as a repository to host data and tools associated with articles in GigaScience; however, it also includes a subset of datasets that are not associated with GigaScience articles. GigaDB defines a dataset as a group of files (e.g., sequencing data, analyses, imaging files, software programs) that are related to and support an article or study. Through our association with DataCite, each dataset in GigaDB will be assigned a DOI that can be used as a standard citation for future use of these data in other articles by the authors and other researchers. Datasets in GigaDB all require a title that is specific to the dataset, an author list, and an abstract that provides information specific to the data included within the set. We encourage detailed information about the data we host to be submitted by their creators in ISA-Tab, a format used by the BioSharing and ISA Commons communities that we work with to maintain the highest data and metadata standards in our journal. To maximize its utility to the research community, all datasets in GigaDB are placed under a CC0 waiver (for more information on the issues surrounding CC0 and data see Hrynaszkiewicz and Cockerill, 2012).Datasets that are not affiliated with a GigaScience article are approved for inclusion by the Editors of GigaScience. The majority of such datasets are from internal projects at the BGI, given their sponsorship of GigaDB. Many of these datasets may not have another discipline-specific repository suitably able to host them or have been rapidly released prior to any publications for use by the research community, whilst enabling their producers to obtain credit through data citation. The GigaScience Editors may also consider the inclusion of particularly interesting, previously unpublished datasets in GigaDB, especially if they meet our criteria and inclusion as Data Note articles in the journal.", "alternateName": "GigaScience Journal Database", "license": "Public Domain", "citation": "Tam P. Sneddon, Xiao Si Zhe, Scott C. Edmunds, Peter Li, Laurie Goodman, Christopher I. Hunter; GigaDB: promoting data dissemination and reproducibility, Database, Volume 2014, 1 January 2014, bau018, https://doi.org/10.1093/database/bau018", "url": "https://GigaDB.org/", "keywords": ["registry", "life science", "GigaScience Journal"], "provider": [{ "@type": "Person", "name": "GigaDB.org support", "email": "database@gigasciencejournal.com" }] }
     </script>
-    <?= $this->renderPartial('//shared/_google_analytics') ?>
 </body>
 
 </html>

--- a/protected/views/layouts/uploader_layout.php
+++ b/protected/views/layouts/uploader_layout.php
@@ -33,6 +33,7 @@
                     <title>
                         <?php echo CHtml::encode($this->pageTitle); ?>
                     </title>
+                    <?= $this->renderPartial('//shared/_matomo') ?>
 </head>
 
 <body>
@@ -235,7 +236,6 @@
     <script type="application/ld+json">
     { "@context": "http://schema.org", "@type": "DataCatalog", "name": "GigaDB.org", "description": "GigaDB primarily serves as a repository to host data and tools associated with articles in GigaScience; however, it also includes a subset of datasets that are not associated with GigaScience articles. GigaDB defines a dataset as a group of files (e.g., sequencing data, analyses, imaging files, software programs) that are related to and support an article or study. Through our association with DataCite, each dataset in GigaDB will be assigned a DOI that can be used as a standard citation for future use of these data in other articles by the authors and other researchers. Datasets in GigaDB all require a title that is specific to the dataset, an author list, and an abstract that provides information specific to the data included within the set. We encourage detailed information about the data we host to be submitted by their creators in ISA-Tab, a format used by the BioSharing and ISA Commons communities that we work with to maintain the highest data and metadata standards in our journal. To maximize its utility to the research community, all datasets in GigaDB are placed under a CC0 waiver (for more information on the issues surrounding CC0 and data see Hrynaszkiewicz and Cockerill, 2012).Datasets that are not affiliated with a GigaScience article are approved for inclusion by the Editors of GigaScience. The majority of such datasets are from internal projects at the BGI, given their sponsorship of GigaDB. Many of these datasets may not have another discipline-specific repository suitably able to host them or have been rapidly released prior to any publications for use by the research community, whilst enabling their producers to obtain credit through data citation. The GigaScience Editors may also consider the inclusion of particularly interesting, previously unpublished datasets in GigaDB, especially if they meet our criteria and inclusion as Data Note articles in the journal.", "alternateName": "GigaScience Journal Database", "license": "Public Domain", "citation": "Tam P. Sneddon, Xiao Si Zhe, Scott C. Edmunds, Peter Li, Laurie Goodman, Christopher I. Hunter; GigaDB: promoting data dissemination and reproducibility, Database, Volume 2014, 1 January 2014, bau018, https://doi.org/10.1093/database/bau018", "url": "https://GigaDB.org/", "keywords": ["registry", "life science", "GigaScience Journal"], "provider": [{ "@type": "Person", "name": "GigaDB.org support", "email": "database@gigasciencejournal.com" }] }
     </script>
-    <?= $this->renderPartial('//shared/_google_analytics') ?>
 </body>
 
 </html>

--- a/protected/views/shared/_matomo.php
+++ b/protected/views/shared/_matomo.php
@@ -1,0 +1,15 @@
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(["setCookieDomain", "*.gigadb.org"]);
+  _paq.push(["setDoNotTrack", true]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function () {
+    var u = "https://gigadb.matomo.cloud/";
+    _paq.push(['setTrackerUrl', u + 'matomo.php']);
+    _paq.push(['setSiteId', '1']);
+    var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+    g.async = true; g.src = 'https://cdn.matomo.cloud/gigadb.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g, s);
+  })();
+</script>


### PR DESCRIPTION
# Pull request for issue: #1759

This is a pull request for the following functionalities:

* Remove google analytic script from all layouts
* Added a Matomo script and included it to all layouts (old and new) in the same way the ga script as included

## How to test?

- Go to any page and verify there is a "matomo" script, should look similar to this `<script async="" src="https://cdn.matomo.cloud/gigadb.matomo.cloud/matomo.js"></script>`
- Once it's deployed to production, it should be verified that it works and data is being added to matomo

## How have functionalities been implemented?

Describe how the new functionalities have been implemented by the
changed code at a high level

## Any issues with implementation?

Unable to test whether script works (see no reason why it shouldn't work) unless it's deployed to production and can see some analytics data in matomo dashboard

## Any changes to automated tests?

I see failures in tests:

./tests/unit_functional_runner

- tests/unit/FormattedDatasetConnectionsTest.php:testFormattedReturnsIsPreviousVersionOfRelationship
- tests/unit/StoredDatasetMainSectionTest.php:testStoredReturnsReleaseDetails
- tests/unit/StoredDatasetMainSectionTest.php:testStoredReturnsCitationsLinks

All related to apparent change in DOI values from 10.80027/100044 to 10.5072/100044 and most likely unrelated to this PR changes

I have fully deleted and recreated all docker containers in my system, could that be related?

Similarly, following acceptance tests fail:

✖ a user visit the dataset page: The google scholar link is working (5.71s)
✖ a user visit the dataset page: The Euro PubMed Central link is working (4.06s)
✖ a user visit the dataset page: The dimensions link is working (4.17s)

An obvious solution would be to change the expected value by the actual, but I don't know why this would be happening and it is unlreated to the PR changes