### PR TITLE
Feat: EFS filesystem for GigaDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1221: EFS filesystem for GigaDB
 - Feat #1717 #1715 #1716: remove Google Plus link, update X logo and add Mastodon link to social media links
 
 ## v4.2.3 - 2024-04-08 - f084f51dd 

--- a/docs/awsdocs/policy-efs.md
+++ b/docs/awsdocs/policy-efs.md
@@ -3,7 +3,33 @@
 	"Version": "2012-10-17",
 	"Statement": [
 		{
-			"Sid": "VisualEditor0",
+			"Sid": "EFSFullPermissions",
+			"Effect": "Allow",
+			"Action": [
+				"elasticfilesystem:DescribeBackupPolicy",
+				"elasticfilesystem:DeleteAccessPoint",
+				"elasticfilesystem:DescribeReplicationConfigurations",
+				"elasticfilesystem:UntagResource",
+				"elasticfilesystem:ListTagsForResource",
+				"elasticfilesystem:DeleteReplicationConfiguration",
+				"elasticfilesystem:ClientWrite",
+				"elasticfilesystem:CreateReplicationConfiguration",
+				"elasticfilesystem:DeleteTags",
+				"elasticfilesystem:DescribeLifecycleConfiguration",
+				"elasticfilesystem:ClientMount",
+				"elasticfilesystem:DescribeFileSystemPolicy",
+				"elasticfilesystem:PutLifecycleConfiguration",
+				"elasticfilesystem:DescribeFileSystems",
+				"elasticfilesystem:DeleteMountTarget",
+				"elasticfilesystem:CreateAccessPoint",
+				"elasticfilesystem:PutFileSystemPolicy",
+				"elasticfilesystem:DeleteFileSystemPolicy",
+				"elasticfilesystem:ModifyMountTargetSecurityGroups",
+				"elasticfilesystem:{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "EFSFullPermissions",
 			"Effect": "Allow",
 			"Action": [
 				"elasticfilesystem:DescribeBackupPolicy",
@@ -40,10 +66,44 @@
 				"elasticfilesystem:DescribeMountTargetSecurityGroups",
 				"elasticfilesystem:UpdateFileSystem"
 			],
-			"Resource": [
-				"arn:aws:elasticfilesystem:*:049839813732:file-system/*",
-				"arn:aws:elasticfilesystem:*:049839813732:access-point/*"
+			"Resource": "*"
+		},
+		{
+			"Sid": "EFSCreatePermission",
+			"Effect": "Allow",
+			"Action": [
+				"elasticfilesystem:PutAccountPreferences",
+				"elasticfilesystem:CreateFileSystem",
+				"elasticfilesystem:DescribeAccountPreferences"
 			],
+			"Resource": "*"
+		},
+		{
+			"Sid": "EFSRequiredForMountTarget",
+			"Effect": "Allow",
+			"Action": [
+				"ec2:DescribeNetworkInterfaceAttribute",
+				"kms:ListAliases"
+			],
+			"Resource": "*"
+		}
+	]
+}Targets",
+				"elasticfilesystem:Restore",
+				"elasticfilesystem:DescribeAccessPoints",
+				"elasticfilesystem:TagResource",
+				"elasticfilesystem:CreateTags",
+				"elasticfilesystem:UpdateFileSystemProtection",
+				"elasticfilesystem:DescribeTags",
+				"elasticfilesystem:CreateMountTarget",
+				"elasticfilesystem:Backup",
+				"elasticfilesystem:PutBackupPolicy",
+				"elasticfilesystem:ClientRootAccess",
+				"elasticfilesystem:DeleteFileSystem",
+				"elasticfilesystem:DescribeMountTargetSecurityGroups",
+				"elasticfilesystem:UpdateFileSystem"
+			],
+			"Resource": "*",
 			"Condition": {
 				"StringEquals": {
 					"aws:RequestedRegion": [
@@ -56,12 +116,30 @@
 			}
 		},
 		{
-			"Sid": "VisualEditor1",
+			"Sid": "EFSCreatePermission",
 			"Effect": "Allow",
 			"Action": [
 				"elasticfilesystem:PutAccountPreferences",
 				"elasticfilesystem:CreateFileSystem",
 				"elasticfilesystem:DescribeAccountPreferences"
+			],
+			"Resource": "*",
+			"Condition": {
+				"StringEquals": {
+					"aws:RequestedRegion": [
+						"ap-east-1",
+						"ap-northeast-1",
+						"ap-northeast-2",
+						"eu-west-3"
+					]
+				}
+			}
+		},
+		{
+			"Sid": "EFSRequiredForMountTarget",
+			"Effect": "Allow",
+			"Action": [
+				"ec2:DescribeNetworkInterfaceAttribute"
 			],
 			"Resource": "*",
 			"Condition": {

--- a/docs/awsdocs/policy-efs.md
+++ b/docs/awsdocs/policy-efs.md
@@ -1,0 +1,80 @@
+```
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "VisualEditor0",
+			"Effect": "Allow",
+			"Action": [
+				"elasticfilesystem:DescribeBackupPolicy",
+				"elasticfilesystem:DeleteAccessPoint",
+				"elasticfilesystem:DescribeReplicationConfigurations",
+				"elasticfilesystem:UntagResource",
+				"elasticfilesystem:ListTagsForResource",
+				"elasticfilesystem:DeleteReplicationConfiguration",
+				"elasticfilesystem:ClientWrite",
+				"elasticfilesystem:CreateReplicationConfiguration",
+				"elasticfilesystem:DeleteTags",
+				"elasticfilesystem:DescribeLifecycleConfiguration",
+				"elasticfilesystem:ClientMount",
+				"elasticfilesystem:DescribeFileSystemPolicy",
+				"elasticfilesystem:PutLifecycleConfiguration",
+				"elasticfilesystem:DescribeFileSystems",
+				"elasticfilesystem:DeleteMountTarget",
+				"elasticfilesystem:CreateAccessPoint",
+				"elasticfilesystem:PutFileSystemPolicy",
+				"elasticfilesystem:DeleteFileSystemPolicy",
+				"elasticfilesystem:ModifyMountTargetSecurityGroups",
+				"elasticfilesystem:DescribeMountTargets",
+				"elasticfilesystem:Restore",
+				"elasticfilesystem:DescribeAccessPoints",
+				"elasticfilesystem:TagResource",
+				"elasticfilesystem:CreateTags",
+				"elasticfilesystem:UpdateFileSystemProtection",
+				"elasticfilesystem:DescribeTags",
+				"elasticfilesystem:CreateMountTarget",
+				"elasticfilesystem:Backup",
+				"elasticfilesystem:PutBackupPolicy",
+				"elasticfilesystem:ClientRootAccess",
+				"elasticfilesystem:DeleteFileSystem",
+				"elasticfilesystem:DescribeMountTargetSecurityGroups",
+				"elasticfilesystem:UpdateFileSystem"
+			],
+			"Resource": [
+				"arn:aws:elasticfilesystem:*:049839813732:file-system/*",
+				"arn:aws:elasticfilesystem:*:049839813732:access-point/*"
+			],
+			"Condition": {
+				"StringEquals": {
+					"aws:RequestedRegion": [
+						"ap-east-1",
+						"ap-northeast-1",
+						"ap-northeast-2",
+						"eu-west-3"
+					]
+				}
+			}
+		},
+		{
+			"Sid": "VisualEditor1",
+			"Effect": "Allow",
+			"Action": [
+				"elasticfilesystem:PutAccountPreferences",
+				"elasticfilesystem:CreateFileSystem",
+				"elasticfilesystem:DescribeAccountPreferences"
+			],
+			"Resource": "*",
+			"Condition": {
+				"StringEquals": {
+					"aws:RequestedRegion": [
+						"ap-east-1",
+						"ap-northeast-1",
+						"ap-northeast-2",
+						"eu-west-3"
+					]
+				}
+			}
+		}
+	]
+}
+```

--- a/ops/infrastructure/modules/efs-filesystem/README.md
+++ b/ops/infrastructure/modules/efs-filesystem/README.md
@@ -63,13 +63,15 @@ the module is configured with the following settings
 
 | setting | value | description |
 | --- | --- | --- |
-| transition_to_ia | AFTER_30_DAYS | IA: Inactive data that is accessed only a few times each quarter | 
-| transition_to_primary_storage_class | AFTER_1_ACCESS | Primary: Active data requiring fast sub-millisecond latency performance | 
+| transition_to_ia | AFTER_7_DAYS | IA: Inactive data that is accessed only a few times each quarter. We transition in that state after 7 days | 
+| transition_to_primary_storage_class | AFTER_1_ACCESS | Primary: Active data requiring fast sub-millisecond latency performance. We transition to that state after 1 access | 
 
 
 We do not need to transition to archive (the third storage class) because dropbox are for transcient files (up to 3 months).
 
-(for more info see https://docs.aws.amazon.com/efs/latest/ug/availability-durability.html#storage-classes)
+For more info see:
+* https://docs.aws.amazon.com/efs/latest/ug/availability-durability.html#storage-classes
+* https://docs.amazonaws.cn/en_us/efs/latest/ug/API_LifecyclePolicy.html
 
 ## Other settings
 

--- a/ops/infrastructure/modules/efs-filesystem/README.md
+++ b/ops/infrastructure/modules/efs-filesystem/README.md
@@ -25,7 +25,7 @@ This module will provision an EFS resource in the selected region, as well as an
 | Type | filter | description |
 | --- | --- | --- |
 | aws_region | current | return the current region |
-| aws_availability_zones" | available | return list of all the availability zone in the current region |
+| aws_availability_zones | available | return list of all the availability zone in the current region |
 | aws_caller_identity | current | return details about the current IAM user |
 
 

--- a/ops/infrastructure/modules/efs-filesystem/README.md
+++ b/ops/infrastructure/modules/efs-filesystem/README.md
@@ -1,0 +1,50 @@
+# efs-filesystem
+
+```
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_efs_file_system" "dropbox_filesystem" {
+
+  creation_token = "gigadb-dropbox-efs-${var.owner}-${var.deployment_target}"
+  lifecycle_policy {
+    transition_to_ia                    = "AFTER_30_DAYS"
+    transition_to_primary_storage_class = "AFTER_1_ACCESS"
+  }
+
+}
+
+resource "aws_security_group" "dropbox_sg" {
+  name        = "dropbox-sg_${var.deployment_target}_${var.owner}"
+  description = "Security group for dropbox ${var.owner} on ${var.deployment_target}"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["10.99.0.0/18"]
+  }
+}
+
+resource "aws_efs_mount_target" "dropbox_mount_target" {
+  file_system_id  = aws_efs_file_system.dropbox_filesystem.id
+  security_groups = [aws_security_group.dropbox_sg.name]
+  subnet_id       = var.public_subnet_id
+}
+
+resource "aws_efs_access_point" "dropbox_accesspoint" {
+  file_system_id  = aws_efs_file_system.dropbox_filesystem.id
+  posix_user {
+    uid = 1000
+    gid = 1000
+  }
+
+  root_directory {
+    path = "/gigadb-dropbox"
+  }
+  
+}
+
+```

--- a/ops/infrastructure/modules/efs-filesystem/README.md
+++ b/ops/infrastructure/modules/efs-filesystem/README.md
@@ -6,8 +6,8 @@ This module will provision an EFS resource in the selected region, as well as an
 
 | name | description |
 | --- | --- |
-| vpc | vpc object instanciated by the vpc module, needed to access the provisioned private subnets |
-| deployment_target | target environment, used for taggging |
+| vpc | vpc object instantiated by the vpc module, needed to access the provisioned private subnets |
+| deployment_target | target environment, used for tagging |
 | owner | username of the developer, used for tagging | 
 
 ## Output used in main terraform files

--- a/ops/infrastructure/modules/efs-filesystem/README.md
+++ b/ops/infrastructure/modules/efs-filesystem/README.md
@@ -74,5 +74,5 @@ We do not need to transition to archive (the third storage class) because dropbo
 ## Other settings
 
 Currently, the encryption-at-rest is disabled (`enable_backup_policy = false`) and so are the inter-region replication (`create_replication_configuration = false`) and the backup policy (`enable_backup_policy = false`).
-They do not seem to be needed features for now but ew need to have discussion with the business to confirm and wether the need could surface over time. There performance and cost factors associated with enabling those features.
+They do not seem to be needed features for now but we need to have discussion with the business to confirm and wether the need could surface over time. There performance and cost factors associated with enabling those features.
 

--- a/ops/infrastructure/modules/efs-filesystem/README.md
+++ b/ops/infrastructure/modules/efs-filesystem/README.md
@@ -1,50 +1,78 @@
 # efs-filesystem
 
+This module will provision an EFS resource in the selected region, as well as ancilliary resources (mount targets and access points) and associate the tags `deployment_target` and `owner` to the created resource.
+
+## Input variables
+
+| name | description |
+| --- | --- |
+| vpc | vpc object instanciated by the vpc module, needed to access the provisioned private subnets |
+| deployment_target | target environment, used for taggging |
+| owner | username of the developer, used for tagging | 
+
+## Output used in main terraform files
+
+| name | description |
+| --- | --- |
+| efs_filesystem_id | file system id |
+| efs_filesystem_arn | arn of the filesystem |
+| efs_filesystem_size_in_bytes | last know size of the EFS storage |
+| efs_filesystem_access_points | maps of the available access points |
+
+
+## Data sources
+
+| Type | filter | description |
+| --- | --- | --- |
+| aws_region | current | return the current region |
+| aws_availability_zones" | available | return list of all the availability zone in the current region |
+| aws_caller_identity | current | return details about the current IAM user |
+
+
+## Policies
+
+policy for interaction with the EFS resources should be defined in IAM policy and documented in `docs/awsdocs/policy-efs.md`, like we do for everything else.
+
+Therefore resource attached policy is disabled (`attach_policy = false`).
+
+## File system type 
+
+We use a **regional** type of storage
+
+(for more info see https://docs.aws.amazon.com/efs/latest/ug/availability-durability.html#file-system-type)
+
+It means, that to enable regional durability, we need to create a mount target associated to a private subnet in each availability zones of the selected region.
 ```
-data "aws_availability_zones" "available" {
-  state = "available"
-}
-
-resource "aws_efs_file_system" "dropbox_filesystem" {
-
-  creation_token = "gigadb-dropbox-efs-${var.owner}-${var.deployment_target}"
-  lifecycle_policy {
-    transition_to_ia                    = "AFTER_30_DAYS"
-    transition_to_primary_storage_class = "AFTER_1_ACCESS"
-  }
-
-}
-
-resource "aws_security_group" "dropbox_sg" {
-  name        = "dropbox-sg_${var.deployment_target}_${var.owner}"
-  description = "Security group for dropbox ${var.owner} on ${var.deployment_target}"
-  vpc_id      = var.vpc_id
-
-  ingress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["10.99.0.0/18"]
-  }
-}
-
-resource "aws_efs_mount_target" "dropbox_mount_target" {
-  file_system_id  = aws_efs_file_system.dropbox_filesystem.id
-  security_groups = [aws_security_group.dropbox_sg.name]
-  subnet_id       = var.public_subnet_id
-}
-
-resource "aws_efs_access_point" "dropbox_accesspoint" {
-  file_system_id  = aws_efs_file_system.dropbox_filesystem.id
-  posix_user {
-    uid = 1000
-    gid = 1000
-  }
-
-  root_directory {
-    path = "/gigadb-dropbox"
-  }
-  
-}
-
+mount_targets              = { for k, v in zipmap(local.azs, var.vpc.private_subnets) : k => { subnet_id = v } }
 ```
+
+## Performance profile
+
+The settings `performance_mode` is set to `generalPurpose`
+
+(for more info see https://docs.aws.amazon.com/efs/latest/ug/performance.html#performancemodes)
+
+The settings `throughput_mode` is set to `elastic` (as recommended, but we need to keep an eye on that metric over time to see if that's stay the best mode for our usage)
+
+(for more info see https://docs.aws.amazon.com/efs/latest/ug/performance.html#throughput-modes)
+
+
+## Storage class
+
+the module is configured with the following settings
+
+| setting | value | description |
+| --- | --- | --- |
+| transition_to_ia | AFTER_30_DAYS | IA: Inactive data that is accessed only a few times each quarter | 
+| transition_to_primary_storage_class | AFTER_1_ACCESS | Primary: Active data requiring fast sub-millisecond latency performance | 
+
+
+We do not need to transition to archive (the third storage class) because dropbox are for transcient files (up to 3 months).
+
+(for more info see https://docs.aws.amazon.com/efs/latest/ug/availability-durability.html#storage-classes)
+
+## Other settings
+
+Currently, the encryption-at-rest is disabled (`enable_backup_policy = false`) and so are the inter-region replication (`create_replication_configuration = false`) and the backup policy (`enable_backup_policy = false`).
+They do not seem to be needed features for now but ew need to have discussion with the business to confirm and wether the need could surface over time. There performance and cost factors associated with enabling those features.
+

--- a/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
+++ b/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
@@ -1,0 +1,121 @@
+locals {
+
+  azs = slice(data.aws_availability_zones.available.names, 0, 3)
+  public_subnets   = ["10.99.0.0/24", "10.99.1.0/24", "10.99.2.0/24"]
+  private_subnets  = ["10.99.3.0/24", "10.99.4.0/24", "10.99.5.0/24"]
+
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_vpc" "selected" {
+  id = var.vpc_id
+}
+
+data "aws_region" "current" {}
+
+module "efs" {
+  source = "terraform-aws-modules/efs/aws"
+
+  # File system
+  name           = "gigadb-efs ${var.deployment_target}"
+  creation_token = "gigadb-efs-${data.aws_caller_identity.current.arn}-${var.deployment_target}"
+
+
+
+  lifecycle_policy = {
+    transition_to_ia                    = "AFTER_30_DAYS"
+    transition_to_primary_storage_class = "AFTER_1_ACCESS"
+  }
+
+  # File system policy (basic access only, better use IAM policies to add higher level access and/ore more granular)
+  attach_policy                      = true
+  bypass_policy_lockout_safety_check = false
+  policy_statements = [
+    {
+      sid     = "BasicReadonlyAccess"
+      actions = ["elasticfilesystem:ClientMount"]
+      principals = [
+        {
+          type        = "AWS"
+          identifiers = [data.aws_caller_identity.current.arn]
+        }
+      ]
+    }
+  ]
+
+  # Mount targets / security group
+  mount_targets              = { for k, v in zipmap(local.azs, local.private_subnets) : k => { subnet_id = v } }
+
+  security_group_description = "gigadb-efs EFS SG for ${data.aws_caller_identity.current.arn} on ${var.deployment_target}"
+  security_group_vpc_id      = data.aws_vpc.selected.id
+  security_group_rules = {
+    vpc = {
+      # relying on the defaults provdied for EFS/NFS (2049/TCP + ingress)
+      description = "NFS ingress from VPC private subnets"
+      cidr_blocks = local.private_subnets
+    }
+  }
+
+  # Access point(s)
+  access_points = {
+    dropbox_area = {
+
+      name = "dropbox-area"
+
+      posix_user = {
+        gid            = 1000
+        uid            = 1000
+      }
+
+      root_directory = {
+        path = "/share/dropbox"
+        creation_info = {
+          owner_gid   = 1000
+          owner_uid   = 1000
+          permissions = "755"
+        }
+      }
+
+    }
+
+    configuration_area = {
+
+      name = "configuration-area"
+
+      posix_user = {
+        gid            = 1000
+        uid            = 1000
+      }
+
+      root_directory = {
+        path = "/share/config"
+        creation_info = {
+          owner_gid   = 1000
+          owner_uid   = 1000
+          permissions = "700"
+        }
+      }
+
+    }
+
+  }
+
+  # Backup policy
+  enable_backup_policy = false
+
+  # Replication configuration
+  create_replication_configuration = true
+  replication_configuration_destination = {
+    region = data.aws_region.current.name
+  }
+
+  tags = {
+    Owner   = var.owner
+    Environment = var.deployment_target
+  }
+}

--- a/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
+++ b/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
@@ -1,8 +1,6 @@
 locals {
 
   azs = slice(data.aws_availability_zones.available.names, 0, 3)
-  public_subnets   = ["10.99.0.0/24", "10.99.1.0/24", "10.99.2.0/24"]
-  private_subnets  = ["10.99.3.0/24", "10.99.4.0/24", "10.99.5.0/24"]
 
 }
 
@@ -11,10 +9,6 @@ data "aws_availability_zones" "available" {
 }
 
 data "aws_caller_identity" "current" {}
-
-data "aws_vpc" "selected" {
-  id = var.vpc_id
-}
 
 data "aws_region" "current" {}
 
@@ -49,15 +43,15 @@ module "efs" {
   ]
 
   # Mount targets / security group
-  mount_targets              = { for k, v in zipmap(local.azs, local.private_subnets) : k => { subnet_id = v } }
+  mount_targets              = { for k, v in zipmap(local.azs, var.vpc.private_subnets) : k => { subnet_id = v } }
 
   security_group_description = "gigadb-efs EFS SG for ${data.aws_caller_identity.current.arn} on ${var.deployment_target}"
-  security_group_vpc_id      = data.aws_vpc.selected.id
+  security_group_vpc_id      = var.vpc.vpc_id
   security_group_rules = {
     vpc = {
       # relying on the defaults provided for EFS/NFS (2049/TCP + ingress)
       description = "NFS ingress from VPC private subnets"
-      cidr_blocks = local.private_subnets
+      cidr_blocks = var.vpc.private_subnets_cidr_blocks
     }
   }
 

--- a/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
+++ b/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
@@ -18,7 +18,7 @@ module "efs" {
   # File system
   name           = "gigadb-efs ${var.owner} ${var.deployment_target}"
   creation_token = "gigadb-efs-${var.owner}-${var.deployment_target}"
-
+  encrypted      = false
 
 
   lifecycle_policy = {

--- a/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
+++ b/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
@@ -22,8 +22,8 @@ module "efs" {
   source = "terraform-aws-modules/efs/aws"
 
   # File system
-  name           = "gigadb-efs ${var.deployment_target}"
-  creation_token = "gigadb-efs-${data.aws_caller_identity.current.arn}-${var.deployment_target}"
+  name           = "gigadb-efs ${var.owner} ${var.deployment_target}"
+  creation_token = "gigadb-efs-${var.owner}-${var.deployment_target}"
 
 
 
@@ -55,7 +55,7 @@ module "efs" {
   security_group_vpc_id      = data.aws_vpc.selected.id
   security_group_rules = {
     vpc = {
-      # relying on the defaults provdied for EFS/NFS (2049/TCP + ingress)
+      # relying on the defaults provided for EFS/NFS (2049/TCP + ingress)
       description = "NFS ingress from VPC private subnets"
       cidr_blocks = local.private_subnets
     }
@@ -65,7 +65,7 @@ module "efs" {
   access_points = {
     dropbox_area = {
 
-      name = "dropbox-area"
+      name = "dropbox-area-${data.aws_caller_identity.current.arn}-${var.deployment_target}"
 
       posix_user = {
         gid            = 1000
@@ -85,7 +85,7 @@ module "efs" {
 
     configuration_area = {
 
-      name = "configuration-area"
+      name = "config-area-${data.aws_caller_identity.current.arn}-${var.deployment_target}"
 
       posix_user = {
         gid            = 1000

--- a/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
+++ b/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
@@ -108,11 +108,11 @@ module "efs" {
   # Backup policy
   enable_backup_policy = false
 
-  # Replication configuration
-  create_replication_configuration = true
-  replication_configuration_destination = {
-    region = data.aws_region.current.name
-  }
+  # Replication (to another region) configuration (see https://docs.aws.amazon.com/efs/latest/ug/efs-replication.html)
+  create_replication_configuration = false
+  # replication_configuration_destination = {
+  #   region = data.aws_region.current.name
+  # }
 
   tags = {
     Owner   = var.owner

--- a/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
+++ b/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
@@ -22,7 +22,7 @@ module "efs" {
 
 
   lifecycle_policy = {
-    transition_to_ia                    = "AFTER_30_DAYS"
+    transition_to_ia                    = "AFTER_7_DAYS"
     transition_to_primary_storage_class = "AFTER_1_ACCESS"
   }
 

--- a/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
+++ b/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
@@ -26,22 +26,15 @@ module "efs" {
     transition_to_primary_storage_class = "AFTER_1_ACCESS"
   }
 
-  # File system policy (basic access only, better use IAM policies to add higher level access and/ore more granular)
-  attach_policy                      = true
+  # File system policy
+  attach_policy                      = false
   bypass_policy_lockout_safety_check = false
-  policy_statements = [
-    {
-      sid     = "BasicReadonlyAccess"
-      actions = ["elasticfilesystem:ClientMount"]
-      principals = [
-        {
-          type        = "AWS"
-          identifiers = [data.aws_caller_identity.current.arn]
-        }
-      ]
-    }
-  ]
+  
 
+  # Performance profile
+  performance_mode                = "generalPurpose"
+  throughput_mode                 = "elastic"
+  
   # Mount targets / security group
   mount_targets              = { for k, v in zipmap(local.azs, var.vpc.private_subnets) : k => { subnet_id = v } }
 

--- a/ops/infrastructure/modules/efs-filesystem/input.tf
+++ b/ops/infrastructure/modules/efs-filesystem/input.tf
@@ -1,3 +1,3 @@
-variable "vpc_id" {}
+variable "vpc" {}
 variable "deployment_target" {}
 variable "owner" {}

--- a/ops/infrastructure/modules/efs-filesystem/input.tf
+++ b/ops/infrastructure/modules/efs-filesystem/input.tf
@@ -1,0 +1,3 @@
+variable "vpc_id" {}
+variable "deployment_target" {}
+variable "owner" {}

--- a/ops/infrastructure/modules/efs-filesystem/output.tf
+++ b/ops/infrastructure/modules/efs-filesystem/output.tf
@@ -1,0 +1,55 @@
+################################################################################
+# File System
+################################################################################
+
+output "arn" {
+  description = "Amazon Resource Name of the file system"
+  value       = module.efs.arn
+}
+
+output "id" {
+  description = "The ID that identifies the file system (e.g., `fs-ccfc0d65`)"
+  value       = module.efs.id
+}
+
+output "dns_name" {
+  description = "The DNS name for the filesystem per [documented convention](http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html)"
+  value       = module.efs.dns_name
+}
+
+output "size_in_bytes" {
+  description = "The latest known metered size (in bytes) of data stored in the file system, the value is not the exact size that the file system was at any point in time"
+  value       = module.efs.size_in_bytes
+}
+
+################################################################################
+# Mount Target(s)
+################################################################################
+
+output "mount_targets" {
+  description = "Map of mount targets created and their attributes"
+  value       = module.efs.mount_targets
+}
+
+################################################################################
+# Security Group
+################################################################################
+
+output "security_group_arn" {
+  description = "ARN of the security group"
+  value       = module.efs.security_group_arn
+}
+
+output "security_group_id" {
+  description = "ID of the security group"
+  value       = module.efs.security_group_id
+}
+
+################################################################################
+# Access Point(s)
+################################################################################
+
+output "access_points" {
+  description = "Map of access points created and their attributes"
+  value       = module.efs.access_points
+}

--- a/ops/infrastructure/modules/rds-instance/rds-instance.tf
+++ b/ops/infrastructure/modules/rds-instance/rds-instance.tf
@@ -44,7 +44,7 @@ module "db" {
 
   parameter_group_name      = (var.deployment_target == "staging" ? aws_db_parameter_group.gigadb-db-param-group[0].name : null)
   engine                    = "postgres"
-  engine_version            = "14.8"
+  engine_version            = "14.10"
   family                    = "postgres14"  # DB parameter group
   major_engine_version      = "14"          # DB option group
   instance_class            = "db.${var.rds_ec2_type}"

--- a/ops/infrastructure/terraform.tf
+++ b/ops/infrastructure/terraform.tf
@@ -315,6 +315,6 @@ output "efs_filesystem_size_in_bytes" {
 }
 
 output "efs_filesystem_access_points" {
-  value = module.gigadb_efs.access_points
+  value = values(module.gigadb_efs.access_points)[*].id
 }
 

--- a/ops/infrastructure/terraform.tf
+++ b/ops/infrastructure/terraform.tf
@@ -107,24 +107,24 @@ terraform {
   backend "http" {
   }
 
-  required_providers {
-    random = {
-      source  = "hashicorp/random"
-      version = "3.5.1"
-    }
+  # required_providers {
+  #   random = {
+  #     source  = "hashicorp/random"
+  #     version = "3.5.1"
+  #   }
 
-    external = {
-      source  = "hashicorp/external"
-      version = "2.3.1"
-    }
+  #   external = {
+  #     source  = "hashicorp/external"
+  #     version = "2.3.1"
+  #   }
     
-    aws = {
-      source  = "hashicorp/aws"
-      version = "5.5.0"
-    }
-  }
+  #   aws = {
+  #     source  = "hashicorp/aws"
+  #     version = "5.5.0"
+  #   }
+  # }
 
-  required_version = ">= 1.1"
+  # required_version = ">= 1.1"
 }
 
 # A custom virtual private cloud network for RDS and EC2 instances
@@ -283,4 +283,15 @@ module "rds" {
 
 output "rds_instance_address" {
   value = module.rds.rds_instance_address
+}
+
+
+# Setup AWS EFS 
+module "gigadb_efs" {
+  source = "../../modules/efs-filesystem"
+
+  vpc_id = module.vpc.vpc_id
+  deployment_target = var.deployment_target
+  owner = data.external.callerUserName.result.userName
+  
 }

--- a/ops/infrastructure/terraform.tf
+++ b/ops/infrastructure/terraform.tf
@@ -290,7 +290,7 @@ output "rds_instance_address" {
 module "gigadb_efs" {
   source = "../../modules/efs-filesystem"
 
-  vpc_id = module.vpc.vpc_id
+  vpc = module.vpc
   deployment_target = var.deployment_target
   owner = data.external.callerUserName.result.userName
   

--- a/ops/infrastructure/terraform.tf
+++ b/ops/infrastructure/terraform.tf
@@ -286,7 +286,9 @@ output "rds_instance_address" {
 }
 
 
-# Setup AWS EFS 
+################################################################################
+# Provisioning of File System
+################################################################################ 
 module "gigadb_efs" {
   source = "../../modules/efs-filesystem"
 
@@ -295,3 +297,24 @@ module "gigadb_efs" {
   owner = data.external.callerUserName.result.userName
   
 }
+
+output "efs_filesystem_id" {
+  value = module.gigadb_efs.id
+}
+
+output "efs_filesystem_arn" {
+  value = module.gigadb_efs.arn
+}
+
+output "efs_filesystem_dns_name" {
+  value = module.gigadb_efs.dns_name
+}
+
+output "efs_filesystem_size_in_bytes" {
+  value = module.gigadb_efs.size_in_bytes
+}
+
+output "efs_filesystem_access_points" {
+  value = module.gigadb_efs.access_points
+}
+


### PR DESCRIPTION
# Pull request for issue: #1221

This is a pull request for the following functionalities:

* Provision an EFS filesystem in the selected region
* Attach Mount Targets on the private subnets in each availability zones of the selected region
* Add additional AWS IAM policies to control access to the filesystem

## How to test?

1. Checkout my branch and change directory  to it.
2. Create your staging environment on AWS  **from scratch**:

```
$ rm -rf ops/infrastructure/envs/staging
$ mkdir ops/infrastructure/envs/staging
$ cd ops/infrastructure/envs/staging/
$ ../../../scripts/tf_init.sh --project \<your gitlab project path\> --env staging --region \<your region\> --ssh-key \<path to your key\> --web-ec2-type t3.small --bastion-ec2-type t3.small
$ terraform plan
$ terraform apply
$ terraform refresh
```

3. Navigate to the AWS web console and verify that all the resources have been created in your region:
    * EFS fileystem  (by navigating to the EFS service for your region, and select the file system listed then click "View details")
    *  mount targets on the private subnets of each availability zones (click "Network" tab on the page above)
    * two access points for `/share/dropbox` and `/share/config` (click on "Access points" on the page above)

4. Continue with Ansible provisioning, it should work as usual
 
```
$ ../../../scripts/ansible_init.sh --env staging
$ env TF_KEY_NAME=private_ip OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook  -i ../../inventories webapp_playbook.yml -e="gigadb_env=staging"
$ env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook -i ../../inventories bastion_playbook.yml -e "gigadb_env=staging" -e "backupDate=latest"
```
   

## How have functionalities been implemented?

I have created a new module under `ops/infrastructure/modules` called `efs-filesystem` that looks like the other module with:

* a module terraform configuration file `efs-filesystem.tf`  
* an input file for input variables
* an output file for output variables
    
The `terraform.tf` file then instantiates the `efs-filesystem` module and pass on the parameters to populate its variables

## Any changes to documentation?

For more details on implementation , read the doc in `ops/infrastructure/modules/efs-filesystem/README.md`

The IAM policies used are documented in `docs/awsdocs/policy-efs.md`