### PR TITLE
feat: Update bastion-users Ansible role to create AWS credentials file from Wasabi credentials CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Feat #1394: Update bastion-users Ansible role to create AWS credentials file from Wasabi credentials CSV
+- Fix #1833: Files metadata console containers built using gitlab-config-live-build.yml are tagged with "staging"
 
 ## v4.2.5 - 2024-04-25 - ca6d17e0f
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1394: Update bastion-users Ansible role to create AWS credentials file from Wasabi credentials CSV
+
 ## v4.2.5 - 2024-04-25 - ca6d17e0f
 
 - Feat #1770: Make AWS EFS can be mounted on the bastion server manually

--- a/docs/sop/PRODUCTION_TROUBLESHOOT.md
+++ b/docs/sop/PRODUCTION_TROUBLESHOOT.md
@@ -131,7 +131,7 @@ The bastion server can only be accessed from the authorized users, and each user
 ```
 $ cd ops/infrastructure/envs/live
 # try to create user lily in the bastion server
-$ ansible-playbook -i ../../inventories users_playbook.yml -e "newuser=lily"
+$ ansible-playbook -i ../../inventories users_playbook.yml -e "newuser=lily" --extra-vars="gigadb_env=live"
 # update the permission of the private key
 $ chmod 500 output/privkeys-$bastion-ip/lily
 $ ls -Al output/privkeys-$bastion-ip
@@ -142,6 +142,15 @@ $ ssh -i /path/to/envs/live/output/privkeys-$bastion-ip/lily lily@$bastion-ip
 [lily@ip-10-99-0-183 ~]$ ls
 uploadDir
 ```
+
+If the user will need to upload content to Wasabi, a new user should be created on Wasabi dashboard, and API keys should be created there.
+Wasabi will let the tech team operator download the credentials as a CSV file called `credentials.csv`.
+The command to run the `users_playbook.yml` should then be:
+```
+% ansible-playbook -i ../../inventories users_playbook.yml -e "newuser=lily" -e "credentials_csv_path=~/Downloads/credentials.csv" --extra-vars="gigadb_env=live"
+```
+
+
 ### What to do if we receive disk usage alerts or pipeline jobs fail due lack of space on device
 
 The disk usage is usually consumed by the docker containers, and it can be released by following the steps below:
@@ -299,6 +308,13 @@ The creation can be achieved as below:
 % chmod 500 output/privkeys-$bastion-ip/$user
 # connect to the bastion server
 % ssh -i output/privkeys-$bastion-ip/$user $user@$bastion-ip
+```
+
+If the user will need to upload content to Wasabi, a new user should be created on Wasabi dashboard, and API keys should be created there.
+Wasabi will let the tech team operator download the credentials as a CSV file called `credentials.csv`.
+The command to run the `users_playbook.yml` should then be:
+```
+% ansible-playbook -i ../../inventories users_playbook.yml -e "newuser=$user" -e "credentials_csv_path=~/Downloads/credentials.csv" --extra-vars="gigadb_env=live"
 ```
 
 ### What if a user has accidentally deleted (or corrupted) their .ssh/authorized_keys

--- a/gigadb/app/tools/files-metadata-console/gitlab-config-live-build.yml
+++ b/gigadb/app/tools/files-metadata-console/gitlab-config-live-build.yml
@@ -1,6 +1,6 @@
 FilesMetadataConsoleBuildLive:
   variables:
-    GIGADB_ENV: "staging"
+    GIGADB_ENV: "live"
     YII_DEBUG: "true"
   stage: live build
   tags:

--- a/ops/configuration/variables/wasabi-credentials-sample
+++ b/ops/configuration/variables/wasabi-credentials-sample
@@ -1,2 +1,0 @@
-User Name,Access Key Id,Secret Access Key
-Lily,xxxxxxxxxxxxxxxx,yyyyyyyyyyyyyyyyyy

--- a/ops/configuration/variables/wasabi-credentials-sample
+++ b/ops/configuration/variables/wasabi-credentials-sample
@@ -1,0 +1,2 @@
+User Name,Access Key Id,Secret Access Key
+Lily,xxxxxxxxxxxxxxxx,yyyyyyyyyyyyyyyyyy

--- a/ops/infrastructure/roles/bastion-users/tasks/credentials.j2
+++ b/ops/infrastructure/roles/bastion-users/tasks/credentials.j2
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id={{ credentials.list.0["Access Key Id"] }}
+aws_secret_access={{ credentials.list.0["Secret Access Key"] }}

--- a/ops/infrastructure/roles/bastion-users/tasks/main.yml
+++ b/ops/infrastructure/roles/bastion-users/tasks/main.yml
@@ -156,7 +156,24 @@
   delegate_to: localhost
 
 - ansible.builtin.debug:
-    msg: "{{credentials.list}}"
+    msg: "{{credentials.list.0}}"
+
+- name: Create a .aws directory fo the new user
+  ansible.builtin.file:
+    path: "/home/{{ newuser }}/.aws"
+    state: directory
+    mode: '0755'
+    owner: "{{ newuser }}"
+    group: "{{ newuser }}"
+
+
+- name: Create AWS credential file for access to Wasabi using rclone
+  template:
+    src: ./credentials.j2
+    dest: "/home/{{ newuser }}/.aws/credentials"
+    owner: "{{ newuser }}"
+    group: "{{ newuser }}"
+    mode: 0644
 
 
 - name: Restart systemd sshd service

--- a/ops/infrastructure/roles/bastion-users/tasks/main.yml
+++ b/ops/infrastructure/roles/bastion-users/tasks/main.yml
@@ -149,32 +149,34 @@
         mode: g-rw,o-rw
   when: (public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 200)
 
-- name: Read credentials from CSV file and return a dictionary
-  community.general.read_csv:
-    path: "{{ credentials_csv_path }}"
-  register: credentials
-  delegate_to: localhost
+- name: Create credentials file for user
+  block:
+  - name: Read credentials from CSV file and return a dictionary
+    community.general.read_csv:
+      path: "{{ credentials_csv_path }}"
+    register: credentials
+    delegate_to: localhost
 
-- ansible.builtin.debug:
-    msg: "{{credentials.list.0}}"
+  - ansible.builtin.debug:
+      msg: "{{credentials.list.0}}"
 
-- name: Create a .aws directory fo the new user
-  ansible.builtin.file:
-    path: "/home/{{ newuser }}/.aws"
-    state: directory
-    mode: '0755'
-    owner: "{{ newuser }}"
-    group: "{{ newuser }}"
+  - name: Create a .aws directory fo the new user
+    ansible.builtin.file:
+      path: "/home/{{ newuser }}/.aws"
+      state: directory
+      mode: '0755'
+      owner: "{{ newuser }}"
+      group: "{{ newuser }}"
 
 
-- name: Create AWS credential file for access to Wasabi using rclone
-  template:
-    src: ./credentials.j2
-    dest: "/home/{{ newuser }}/.aws/credentials"
-    owner: "{{ newuser }}"
-    group: "{{ newuser }}"
-    mode: 0644
-
+  - name: Create AWS credential file for access to Wasabi using rclone
+    template:
+      src: ./credentials.j2
+      dest: "/home/{{ newuser }}/.aws/credentials"
+      owner: "{{ newuser }}"
+      group: "{{ newuser }}"
+      mode: 0644
+  when: credentials_csv_path is defined
 
 - name: Restart systemd sshd service
   command: systemctl restart sshd.service

--- a/ops/infrastructure/roles/bastion-users/tasks/main.yml
+++ b/ops/infrastructure/roles/bastion-users/tasks/main.yml
@@ -149,5 +149,15 @@
         mode: g-rw,o-rw
   when: (public_key_in_bastion.stat.exists == false and public_key_in_gitlab.status == 200)
 
+- name: Read credentials from CSV file and return a dictionary
+  community.general.read_csv:
+    path: "{{ credentials_csv_path }}"
+  register: credentials
+  delegate_to: localhost
+
+- ansible.builtin.debug:
+    msg: "{{credentials.list}}"
+
+
 - name: Restart systemd sshd service
   command: systemctl restart sshd.service

--- a/ops/infrastructure/roles/bastion-users/tasks/main.yml
+++ b/ops/infrastructure/roles/bastion-users/tasks/main.yml
@@ -160,7 +160,7 @@
   - ansible.builtin.debug:
       msg: "{{credentials.list.0}}"
 
-  - name: Create a .aws directory fo the new user
+  - name: Create a .aws directory for the new user
     ansible.builtin.file:
       path: "/home/{{ newuser }}/.aws"
       state: directory


### PR DESCRIPTION
# Pull request for issue: #1394

This is a pull request for the following functionalities:

* Create a AWS credentials file for new bastion users to contain their Wasabi credentials

## How to test?

### Prepare your staging environment

Provision and configure your staging environment the usual way:

```
$ rm -rf ops/infrastructure/envs/staging
$ mkdir ops/infrastructure/envs/staging
$ cd ops/infrastructure/envs/staging/
$ ../../../scripts/tf_init.sh --project \<your gitlab project path\> --env staging --region \<your region\> --ssh-key \<path to your key\> --web-ec2-type t3.small --bastion-ec2-type t3.small
$ terraform plan
$ terraform apply
$ terraform refresh
```

Continue with Ansible provisioning, it should work as usual
 
```
$ ../../../scripts/ansible_init.sh --env staging
$ env TF_KEY_NAME=private_ip OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook  -i ../../inventories webapp_playbook.yml -e="gigadb_env=staging"
$ env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook -i ../../inventories bastion_playbook.yml -e "gigadb_env=staging" -e "backupDate=latest"
```

### Create a new user

On Wasabi dashboard create a new user for username for e.g:  `lily`.
In the first screen ensure "Programmatic (Create API key)" is checked.
In real situation you will want "Console" to be checked too.
Keep default in the remainder of the steps.
At the end, a the screen "Create Access Key",  there will be a button to download the credentials ("Download CSV").
Press that button.

Back to command line at `ops/infrastructure/envs/staging`, we are going to create the user Lily on bastion.
```
$ ansible-playbook -i ../../inventories users_playbook.yml -e "newuser=lily" -e "credentials_csv_path=~/Downloads/credentials.csv" --extra-vars="gigadb_env=staging"
```
Ensure that the credentials whose path you are passing to the variable `credentials_csv_path` is the one you have downloaded from Wasabi.

If you login to bastion you should see a new file in the new user home directory that contains the credentials that was obtained from Wasabi dashboard.


## How have functionalities been implemented?

Add new tasks in `bastion-users` role to parse the credentials CSV file, create `.aws` directory and create the AWS credentials files.

## Any changes to documentation?

Updated `PRODUCTION_TROUBLESHOOT.md` to document the change
