### PR TITLE
feat: make aws efs can be mounted to bastion server maunally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1770: Make AWS EFS can be mounted on the bastion server manually
 - Feat #1757: Add pagination to samples table in dataset view
 - Fix #1800: Read the correct sample page from cache on samples tables
 - Feat #1163: Add carets to sortable headers in dataset page

--- a/docs/sop/EFS_DATA_MIGRATION.md
+++ b/docs/sop/EFS_DATA_MIGRATION.md
@@ -76,7 +76,7 @@ rclone v1.66.0
 - go/tags: none
 # copy the $bastion-user-pem in local computer and paste it to the ftp server
 [ken@cngb-gigadb-ftp ~]$ vi $bastion-user-pem 
-# create rclone.conf file with following contents
+# create rclone.conf file with following contents and replace the variable with actual values
 [ken@cngb-gigadb-ftp ~]$ vi rclone.conf
 [aws-efs]
 type = sftp
@@ -137,16 +137,7 @@ Checks:                 4 / 4, 100%
 Elapsed time:         2.1s
 [ken@cngb-gigadb-ftp ~]$ 
 # use rclone to delete file in the aws efs dropbox in dry-run mode
-[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf delete -v aws-efs:/share/dropbox/rclone-current-linux-amd64.zip
-2024/04/25 12:15:55 INFO  : rclone-current-linux-amd64.zip: Deleted
-[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf delete -v aws-efs:/share/dropbox/rclone-current-linux-amd64.zip
-2024/04/25 12:16:00 ERROR : : error listing: directory not found
-2024/04/25 12:16:00 ERROR : Attempt 1/3 failed with 2 errors and: directory not found
-2024/04/25 12:16:00 ERROR : : error listing: directory not found
-2024/04/25 12:16:00 ERROR : Attempt 2/3 failed with 2 errors and: directory not found
-2024/04/25 12:16:00 ERROR : : error listing: directory not found
-2024/04/25 12:16:00 ERROR : Attempt 3/3 failed with 2 errors and: directory not found
-2024/04/25 12:16:00 Failed to delete with 2 errors: last error was: directory not found
+[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf delete -v aws-efs:/share/dropbox/user103 --dry-run
 # use rclone to delete file in the aws efs dropbox 
 [ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf delete -v aws-efs:/share/dropbox/user103
 2024/04/25 12:34:02 INFO  : NO25.txt: Deleted
@@ -154,7 +145,17 @@ Elapsed time:         2.1s
 2024/04/25 12:34:04 INFO  : AD25.txt: Deleted
 2024/04/25 12:34:04 INFO  : user103.md5: Deleted
 [ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf ls aws-efs:/share/dropbox
-[ken@cngb-gigadb-ftp ~]$ 
+[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf lsd aws-efs:/share/dropbox                        
+          -1 2024-04-25 12:34:04        -1 user103
+# remove the path and all ot its contents in dry-run mode
+[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf purge -v aws-efs:/share/dropbox/user103 --dry-run
+2024/04/25 14:06:15 NOTICE: sftp://mary@3.36.204.163:22//share/dropbox/user103: Skipped remove directory as --dry-run is set
+# remove the path and all ot its contents
+[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf purge -v aws-efs:/share/dropbox/user103
+2024/04/25 14:06:15 NOTICE: sftp://mary@3.36.204.163:22//share/dropbox/user103: Removing directory
+[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf lsd aws-efs:/share/dropbox 
+[ken@cngb-gigadb-ftp ~]$
+# confirm the files still exist in the source dir 
 [ken@cngb-gigadb-ftp ~]$ ls -al /data/data_upload/user103/
 total 17
 drwxrwxr-x   2 gigadb_user gigadb_user 4096 Mar 14 01:55 .

--- a/docs/sop/EFS_DATA_MIGRATION.md
+++ b/docs/sop/EFS_DATA_MIGRATION.md
@@ -1,0 +1,167 @@
+# SOP: Instructions for migrating data in CNGB server to AWS EFS
+
+### Pre-requisite
+1. BGI VPN is connected
+2. A bastion user is created and the private key is reachable
+3. Valid credentials for accessing the CNGB server
+4. AWS EFS has been instantiated
+
+### How to manually migrate user dropboxs in cngb ftp server to aws efs
+0. Access to this [spreadsheet](https://docs.google.com/spreadsheets/d/1qvfqRhfkoMCyubfL7z42hQmFLOozVbD2BYBSPBPPbwU/edit#gid=0) and identify which user dropbox is labelled with `COPY TO NEW SERVER` 
+1. Log in the BGI server admin page at [here](https://uomc.genomics.cn/shterm/login)
+2. Download the AccessClient from the page and install it if not yet installed
+3. Click the ssh icon next to the server IP, a command line terminal will be popped up 
+4. Log in the server, eg. cngb ftp server, with the valid credentials, and perform the migration steps:
+```
+login: ken
+ken@192.168.28.205's password: 
+Last login: Tue Apr 23 22:05:50 2024 from 10.17.24.13
+
+Welcome to Alibaba Cloud Elastic Compute Service !
+
+-bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
+[ken@cngb-gigadb-ftp ~]$ 
+[ken@cngb-gigadb-ftp ~]$ df -hT
+Filesystem                                                 Type      Size  Used Avail Use% Mounted on
+/dev/vda1                                                  ext4       50G   17G   31G  36% /
+devtmpfs                                                   devtmpfs   16G     0   16G   0% /dev
+tmpfs                                                      tmpfs      16G     0   16G   0% /dev/shm
+tmpfs                                                      tmpfs      16G  580K   16G   1% /run
+tmpfs                                                      tmpfs      16G     0   16G   0% /sys/fs/cgroup
+240704b1c5-eey91.cn-shenzhen.nas.aliyuncs.com:/data_upload nfs        10P  6.9T   10P   1% /data
+192.168.56.61:/data/gigadb                                 nfs4      191T  166T   15T  92% /var/ftp/gigadb
+tmpfs                                                      tmpfs     3.1G     0  3.1G   0% /run/user/5057
+[ken@cngb-gigadb-ftp ~]$ ls /data/data_upload/
+user1    user111  user16  user29  user41  user54  user67  user8   user92
+user10   user112  user17  user3   user42  user55  user68  user80  user93
+user100  user113  user18  user30  user43  user56  user69  user81  user94
+user101  user114  user19  user31  user44  user57  user7   user82  user95
+user102  user115  user2   user32  user45  user58  user70  user83  user96
+user103  user116  user20  user33  user46  user59  user71  user84  user97
+user104  user117  user21  user34  user47  user6   user72  user85  user98
+user105  user118  user22  user35  user48  user60  user73  user86  user99
+user106  user119  user23  user36  user49  user61  user74  user87  user_gaofei
+user107  user12   user24  user37  user5   user62  user75  user88
+user108  user120  user25  user38  user50  user63  user76  user89
+user109  user13   user26  user39  user51  user64  user77  user9
+user11   user14   user27  user4   user52  user65  user78  user90
+user110  user15   user28  user40  user53  user66  user79  user91
+# install go by following https://go.dev/doc/install#requirements if not yet installed
+[ken@cngb-gigadb-ftp ~]$ sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.22.2.linux-amd64.tar.gz
+[ken@cngb-gigadb-ftp ~]$ export PATH=$PATH:/usr/local/go/bin
+[ken@cngb-gigadb-ftp ~]$ go version
+go version go1.22.2 linux/amd64
+# install rclone by following https://rclone.org/install/#linux
+[ken@cngb-gigadb-ftp ~]$ curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100 20.1M  100 20.1M    0     0  2116k      0  0:00:09  0:00:09 --:--:-- 4154k
+[ken@cngb-gigadb-ftp ~]$ unzip rclone-current-linux-amd64.zip
+[ken@cngb-gigadb-ftp ~]$ cd rclone-*-linux-amd64
+[ken@cngb-gigadb-ftp rclone-v1.66.0-linux-amd64]$ sudo cp rclone /usr/bin/
+[ken@cngb-gigadb-ftp rclone-v1.66.0-linux-amd64]$ sudo chown root:root /usr/bin/rclone
+[ken@cngb-gigadb-ftp rclone-v1.66.0-linux-amd64]$ sudo chmod 755 /usr/bin/rclone
+[ken@cngb-gigadb-ftp rclone-v1.66.0-linux-amd64]$ sudo mkdir -p /usr/local/share/man/man1
+[ken@cngb-gigadb-ftp rclone-v1.66.0-linux-amd64]$ sudo cp rclone.1 /usr/local/share/man/man1/
+[ken@cngb-gigadb-ftp rclone-v1.66.0-linux-amd64]$ sudo mandb
+[ken@cngb-gigadb-ftp rclone-v1.66.0-linux-amd64]$ cd ..
+[ken@cngb-gigadb-ftp ~]$ rclone version
+rclone v1.66.0
+- os/version: centos 7.5.1804 (64 bit)
+- os/kernel: 3.10.0-862.14.4.el7.x86_64 (x86_64)
+- os/type: linux
+- os/arch: amd64
+- go/version: go1.22.1
+- go/linking: static
+- go/tags: none
+# copy the $bastion-user-pem in local computer and paste it to the ftp server
+[ken@cngb-gigadb-ftp ~]$ vi $bastion-user-pem 
+# create rclone.conf file with following contents
+[ken@cngb-gigadb-ftp ~]$ vi rclone.conf
+[aws-efs]
+type = sftp
+host = $bastion-ip
+user = $bastion-user
+key_file = /path/to/$bastion-user-pem 
+shell_type = unix
+md5sum_command = md5sum
+sha1sum_command = sha1sum
+# use rclone to list the mounted accesspoint in the bastion server
+[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf lsd aws-efs:/share
+          -1 2024-04-25 10:37:57        -1 config
+          -1 2024-04-25 10:37:24        -1 dropbox
+[ken@cngb-gigadb-ftp ~]$ 
+[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf ls aws-efs:/share/dropbox
+[ken@cngb-gigadb-ftp ~]$ 
+# use rclone to copy file to the aws efs dropbox in dry-run mode
+# user103 is labelled as `COPY TO NEW SERVER`
+[ken@cngb-gigadb-ftp ~]$ ls -al /data/data_upload/user103
+total 17
+drwxrwxr-x   2 gigadb_user gigadb_user 4096 Mar 14 01:55 .
+drwxr-xr-x 123 chris              5052 4096 Apr  9 17:14 ..
+-rw-r--r--   1 gigadb_user gigadb_user  425 Mar 14 01:47 AD25.txt
+-rw-r--r--   1 gigadb_user gigadb_user  425 Mar 14 01:46 NO25.txt
+-rw-r--r--   1 gigadb_user gigadb_user  255 Mar 14 01:46 readme.txt
+-rw-r--r--   1 root        root         185 Mar 14 01:55 user103.md5
+[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf copy -v /data/data_upload/user103 aws-efs:/share/dropbox/user103 --dry-run
+2024/04/25 12:30:26 NOTICE: AD25.txt: Skipped copy as --dry-run is set (size 425)
+2024/04/25 12:30:26 NOTICE: readme.txt: Skipped copy as --dry-run is set (size 255)
+2024/04/25 12:30:26 NOTICE: NO25.txt: Skipped copy as --dry-run is set (size 425)
+2024/04/25 12:30:26 NOTICE: user103.md5: Skipped copy as --dry-run is set (size 185)
+2024/04/25 12:30:26 NOTICE: 
+Transferred:   	    1.260 KiB / 1.260 KiB, 100%, 0 B/s, ETA -
+Transferred:            4 / 4, 100%
+Elapsed time:         1.4s
+[ken@cngb-gigadb-ftp ~]$
+# use rclone to copy file to the aws efs dropbox 
+[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf copy -v /data/data_upload/user103 aws-efs:/share/dropbox/user103
+2024/04/25 12:30:46 INFO  : readme.txt: Copied (new)
+2024/04/25 12:30:47 INFO  : AD25.txt: Copied (new)
+2024/04/25 12:30:48 INFO  : user103.md5: Copied (new)
+2024/04/25 12:30:48 INFO  : NO25.txt: Copied (new)
+2024/04/25 12:30:48 INFO  : 
+Transferred:   	    1.260 KiB / 1.260 KiB, 100%, 322 B/s, ETA 0s
+Transferred:            4 / 4, 100%
+Elapsed time:         6.1s
+
+[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf ls aws-efs:/share/dropbox
+      425 user103/AD25.txt
+      425 user103/NO25.txt
+      255 user103/readme.txt
+      185 user103/user103.md5
+[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf copy -v /data/data_upload/user103 aws-efs:/share/dropbox/user103
+2024/04/25 12:32:19 INFO  : There was nothing to transfer
+2024/04/25 12:32:19 INFO  : 
+Transferred:   	          0 B / 0 B, -, 0 B/s, ETA -
+Checks:                 4 / 4, 100%
+Elapsed time:         2.1s
+[ken@cngb-gigadb-ftp ~]$ 
+# use rclone to delete file in the aws efs dropbox in dry-run mode
+[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf delete -v aws-efs:/share/dropbox/rclone-current-linux-amd64.zip
+2024/04/25 12:15:55 INFO  : rclone-current-linux-amd64.zip: Deleted
+[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf delete -v aws-efs:/share/dropbox/rclone-current-linux-amd64.zip
+2024/04/25 12:16:00 ERROR : : error listing: directory not found
+2024/04/25 12:16:00 ERROR : Attempt 1/3 failed with 2 errors and: directory not found
+2024/04/25 12:16:00 ERROR : : error listing: directory not found
+2024/04/25 12:16:00 ERROR : Attempt 2/3 failed with 2 errors and: directory not found
+2024/04/25 12:16:00 ERROR : : error listing: directory not found
+2024/04/25 12:16:00 ERROR : Attempt 3/3 failed with 2 errors and: directory not found
+2024/04/25 12:16:00 Failed to delete with 2 errors: last error was: directory not found
+# use rclone to delete file in the aws efs dropbox 
+[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf delete -v aws-efs:/share/dropbox/user103
+2024/04/25 12:34:02 INFO  : NO25.txt: Deleted
+2024/04/25 12:34:04 INFO  : readme.txt: Deleted
+2024/04/25 12:34:04 INFO  : AD25.txt: Deleted
+2024/04/25 12:34:04 INFO  : user103.md5: Deleted
+[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf ls aws-efs:/share/dropbox
+[ken@cngb-gigadb-ftp ~]$ 
+[ken@cngb-gigadb-ftp ~]$ ls -al /data/data_upload/user103/
+total 17
+drwxrwxr-x   2 gigadb_user gigadb_user 4096 Mar 14 01:55 .
+drwxr-xr-x 123 chris              5052 4096 Apr  9 17:14 ..
+-rw-r--r--   1 gigadb_user gigadb_user  425 Mar 14 01:47 AD25.txt
+-rw-r--r--   1 gigadb_user gigadb_user  425 Mar 14 01:46 NO25.txt
+-rw-r--r--   1 gigadb_user gigadb_user  255 Mar 14 01:46 readme.txt
+-rw-r--r--   1 root        root         185 Mar 14 01:55 user103.md5
+[ken@cngb-gigadb-ftp ~]$ 
+```

--- a/docs/sop/PRODUCTION_TROUBLESHOOT.md
+++ b/docs/sop/PRODUCTION_TROUBLESHOOT.md
@@ -367,3 +367,123 @@ Then user can connect to the bastion server with the given private key as below:
 5. Locate the $user.ppk private key and click "Open".
 6. Finally, click "Open" again to log into the remote server with key pair authentication.
 ```
+
+### How to manually listing and mounting the AWS EFS access-points
+
+Assuming AWS EFS has been created after `terraform apply`, which can be further confirmed in the regional AWS EFS dashboard, eg. [here](https://ap-northeast-2.console.aws.amazon.com/efs/home?region=ap-northeast-2#/get-started)
+While the `FileSystem Id`, `access point Id` can be obtained from the `terraform output` as well, for example :
+
+```
+% cd ops/infrastructure/envs/staging
+% terraform output
+...
+Outputs:
+.
+.
+.
+efs_filesystem_access_points = {
+  "configuration_area" = "fsap-02000d2d873a159be"
+  "dropbox_area" = "fsap-03cba147d08a9405c"
+}
+efs_filesystem_arn = "arn:aws:elasticfilesystem:ap-northeast-2:049839813732:file-system/fs-00073d99cb4083b87"
+efs_filesystem_dns_name = "fs-00073d99cb4083b87.efs.ap-northeast-2.amazonaws.com"
+efs_filesystem_id = "fs-00073d99cb4083b87"
+...
+
+```
+
+Below are the details for mounting and listing the access points:
+```
+# mounting can only be done by a sudoer
+# login bastion server as a sudoer, eg. centos
+% ssh -i output/privkeys-$bastion-ip/centos centos@$bastion-ip
+Activate the web console with: systemctl enable --now cockpit.socket
+
+Last login: Tue Apr 23 13:40:56 2024 from 14.199.148.232
+[centos@ip-10-99-0-157 ~]$ ls -al
+total 16
+drwx------.  6 centos centos  124 Apr 25 02:29 .
+drwxr-xr-x.  4 root   root     32 Apr 25 02:12 ..
+drwx------.  3 centos centos   17 Apr 25 02:12 .ansible
+-rw-r--r--.  1 centos centos   18 Feb 10 08:05 .bash_logout
+-rw-r--r--.  1 centos centos  141 Feb 10 08:05 .bash_profile
+-rw-r--r--.  1 centos centos  376 Feb 10 08:05 .bashrc
+drwx------.  2 centos centos   
+[centos@ip-10-99-0-157 ~]$ 
+# confirm the dir for mounting exists
+[centos@ip-10-99-0-157 ~]$ ls -al /share
+total 0
+drwxr-xr-x.  4 centos centos  35 Apr 25 02:00 .
+dr-xr-xr-x. 18 root   root   237 Apr 25 02:00 ..
+drwxr-xr-x.  2 centos centos   6 Apr 25 02:00 config
+drwxr-xr-x.  2 centos centos   6 Apr 25 02:00 dropbox
+[centos@ip-10-99-0-157 ~]$ ls -al /share/dropbox/
+total 0
+drwxr-xr-x. 2 centos centos  6 Apr 25 02:00 .
+drwxr-xr-x. 4 centos centos 35 Apr 25 02:00 ..
+[[macentosry@ip-10-99-0-157 ~]$ df -hT
+Filesystem     Type      Size  Used Avail Use% Mounted on
+devtmpfs       devtmpfs  838M     0  838M   0% /dev
+tmpfs          tmpfs     871M     0  871M   0% /dev/shm
+tmpfs          tmpfs     871M  8.5M  862M   1% /run
+tmpfs          tmpfs     871M     0  871M   0% /sys/fs/cgroup
+/dev/nvme0n1p1 xfs        30G  1.6G   29G   6% /
+tmpfs          tmpfs     175M     0  175M   0% /run/user/1001
+[centos@ip-10-99-0-157 ~]$ sudo mount -t efs -o tls,accesspoint=fsap-03cba147d08a9405c fs-00073d99cb4083b87 /share/dropbox
+[centos@ip-10-99-0-157 ~]$ sudo mount -t efs -o tls,accesspoint=fsap-02000d2d873a159be fs-00073d99cb4083b87 /share/config
+[centos@ip-10-99-0-157 ~]$ df -hT
+Filesystem     Type      Size  Used Avail Use% Mounted on
+devtmpfs       devtmpfs  838M     0  838M   0% /dev
+tmpfs          tmpfs     871M     0  871M   0% /dev/shm
+tmpfs          tmpfs     871M  8.6M  862M   1% /run
+tmpfs          tmpfs     871M     0  871M   0% /sys/fs/cgroup
+/dev/nvme0n1p1 xfs        30G  3.9G   27G  13% /
+tmpfs          tmpfs     175M     0  175M   0% /run/user/1001
+tmpfs          tmpfs     175M     0  175M   0% /run/user/1000
+127.0.0.1:/    nfs4      8.0E     0  8.0E   0% /share/dropbox
+127.0.0.1:/    nfs4      8.0E     0  8.0E   0% /share/config
+[centos@ip-10-99-0-157 ~]$ mount | grep /share
+127.0.0.1:/ on /share/dropbox type nfs4 (rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,hard,noresvport,proto=tcp,port=20450,timeo=600,retrans=2,sec=sys,clientaddr=127.0.0.1,local_lock=none,addr=127.0.0.1)
+127.0.0.1:/ on /share/config type nfs4 (rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,hard,noresvport,proto=tcp,port=20162,timeo=600,retrans=2,sec=sys,clientaddr=127.0.0.1,local_lock=none,addr=127.0.0.1)
+[centos@ip-10-99-0-157 ~]$ 
+```
+
+Below are the details for listing the access points as a user:
+```
+# login bastion server as a sudoer, eg. mary
+% ssh -i output/privkeys-$bastion-ip/mary mary@$bastion-ip
+[mary@ip-10-99-0-157 ~]$ ls -al
+total 12
+drwx------. 4 mary mary  91 Apr 25 02:12 .
+drwxr-xr-x. 4 root root  32 Apr 25 02:12 ..
+-rw-r--r--. 1 mary mary  18 Feb 10 08:05 .bash_logout
+-rw-r--r--. 1 mary mary 141 Feb 10 08:05 .bash_profile
+-rw-r--r--. 1 mary mary 376 Feb 10 08:05 .bashrc
+drwx------. 2 mary mary  29 Apr 25 02:13 .ssh
+drwx------. 2 mary mary   6 Apr 25 02:12 uploadDir
+[mary@ip-10-99-0-157 ~]$ ls -al /share/dropbox
+total 4
+drwxr-xr-x. 2 centos centos 6144 Apr 25 02:37 .
+drwxr-xr-x. 4 centos centos   35 Apr 25 02:00 ..
+[mary@ip-10-99-0-157 ~]$ ls -al /share/config/
+total 4
+drwx------. 2 centos centos 6144 Apr 25 02:37 .
+drwxr-xr-x. 4 centos centos   35 Apr 25 02:00 ..
+[mary@ip-10-99-0-157 ~]$
+[mary@ip-10-99-0-157 ~]$ df -hT
+Filesystem     Type      Size  Used Avail Use% Mounted on
+devtmpfs       devtmpfs  838M     0  838M   0% /dev
+tmpfs          tmpfs     871M     0  871M   0% /dev/shm
+tmpfs          tmpfs     871M  8.6M  862M   1% /run
+tmpfs          tmpfs     871M     0  871M   0% /sys/fs/cgroup
+/dev/nvme0n1p1 xfs        30G  3.9G   27G  13% /
+tmpfs          tmpfs     175M     0  175M   0% /run/user/1001
+tmpfs          tmpfs     175M     0  175M   0% /run/user/1000
+127.0.0.1:/    nfs4      8.0E     0  8.0E   0% /share/dropbox
+127.0.0.1:/    nfs4      8.0E     0  8.0E   0% /share/config
+[mary@ip-10-99-0-157 ~]$ 
+[mary@ip-10-99-0-157 ~]$ mount | grep /share
+127.0.0.1:/ on /share/dropbox type nfs4 (rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,hard,noresvport,proto=tcp,port=20450,timeo=600,retrans=2,sec=sys,clientaddr=127.0.0.1,local_lock=none,addr=127.0.0.1)
+127.0.0.1:/ on /share/config type nfs4 (rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,hard,noresvport,proto=tcp,port=20162,timeo=600,retrans=2,sec=sys,clientaddr=127.0.0.1,local_lock=none,addr=127.0.0.1)
+[mary@ip-10-99-0-157 ~]$ 
+```

--- a/docs/sop/PRODUCTION_TROUBLESHOOT.md
+++ b/docs/sop/PRODUCTION_TROUBLESHOOT.md
@@ -374,7 +374,7 @@ Assuming AWS EFS has been created after `terraform apply`, which can be further 
 While the `FileSystem Id`, `access point Id` can be obtained from the `terraform output` as well, for example :
 
 ```
-% cd ops/infrastructure/envs/staging
+% cd ops/infrastructure/envs/live
 % terraform output
 ...
 Outputs:

--- a/ops/infrastructure/modules/bastion-aws-instance/bastion-aws-instance.tf
+++ b/ops/infrastructure/modules/bastion-aws-instance/bastion-aws-instance.tf
@@ -62,6 +62,7 @@ resource "aws_instance" "bastion" {
   vpc_security_group_ids = [aws_security_group.bastion_sg.id]
   key_name = var.key_name
   subnet_id = var.public_subnet_id
+  user_data     = file("../../mount-efs.sh")
 
   tags = {
     Name = "bastion_server_${var.deployment_target}_${var.owner}",

--- a/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
+++ b/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
@@ -43,8 +43,11 @@ module "efs" {
   security_group_rules = {
     vpc = {
       # relying on the defaults provided for EFS/NFS (2049/TCP + ingress)
-      description = "NFS ingress from VPC bastion public subnets"
-      cidr_blocks = var.vpc.public_subnets_cidr_blocks
+      description = "NFS ingress from VPC subnets"
+      cidr_blocks = concat(
+        var.vpc.public_subnets_cidr_blocks,
+        var.vpc.private_subnets_cidr_blocks
+      )
     }
   }
 

--- a/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
+++ b/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
@@ -27,7 +27,7 @@ module "efs" {
   }
 
   # File system policy
-  attach_policy                      = true
+  attach_policy                      = false
   bypass_policy_lockout_safety_check = false
   
 
@@ -43,8 +43,8 @@ module "efs" {
   security_group_rules = {
     vpc = {
       # relying on the defaults provided for EFS/NFS (2049/TCP + ingress)
-      description = "NFS ingress from VPC private subnets"
-      cidr_blocks = ["0.0.0.0/0"]
+      description = "NFS ingress from VPC bastion public subnets"
+      cidr_blocks = var.vpc.public_subnets_cidr_blocks
     }
   }
 

--- a/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
+++ b/ops/infrastructure/modules/efs-filesystem/efs-filesystem.tf
@@ -27,7 +27,7 @@ module "efs" {
   }
 
   # File system policy
-  attach_policy                      = false
+  attach_policy                      = true
   bypass_policy_lockout_safety_check = false
   
 
@@ -44,7 +44,7 @@ module "efs" {
     vpc = {
       # relying on the defaults provided for EFS/NFS (2049/TCP + ingress)
       description = "NFS ingress from VPC private subnets"
-      cidr_blocks = var.vpc.private_subnets_cidr_blocks
+      cidr_blocks = ["0.0.0.0/0"]
     }
   }
 

--- a/ops/infrastructure/mount-efs.sh
+++ b/ops/infrastructure/mount-efs.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # Define the base mount path
-baseMountPath="/home/centos/efs-mountpoint"
+baseMountPath="/efs-mountpoint"
 
 # Create the mount directory if it doesn't exist
 if [ ! -d "$baseMountPath" ]; then
@@ -20,7 +20,7 @@ fi
 # by following https://github.com/aws/efs-utils?tab=readme-ov-file#on-other-linux-distributions
 #sudo yum update -y
 #sudo yum -y install git rpm-build make rust cargo openssl-devel
-#git clone https://github.com/aws/efs-utils.git
+#git clone https://github.com/aws/efs-utils
 #cd efs-utils
 #sudo make rpm
 #sudo yum -y install build/amazon-efs-utils*rpm

--- a/ops/infrastructure/mount-efs.sh
+++ b/ops/infrastructure/mount-efs.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -ex
+
+# Define the base mount path
+baseMountPath="/home/centos/efs-mountpoint"
+
+# Create the mount directory if it doesn't exist
+if [ ! -d "$baseMountPath" ]; then
+  sudo mkdir -p "$baseMountPath" "$baseMountPath/dropbox" "$baseMountPath/config"
+  sudo chown -R  centos:centos "$baseMountPath"
+fi
+
+# TODO: install aws efs utils
+# by following this doc: https://github.com/aws/efs-utils?tab=readme-ov-file#on-other-linux-distributions
+# Wait for cloud-init to complete
+#while [ ! -f /var/lib/cloud/instance/boot-finished ]; do
+#    echo "Waiting for cloud-init to complete..."
+#    sleep 5
+#done
+# by following https://github.com/aws/efs-utils?tab=readme-ov-file#on-other-linux-distributions
+#sudo yum update -y
+#sudo yum -y install git rpm-build make rust cargo openssl-devel
+#git clone https://github.com/aws/efs-utils.git
+#cd efs-utils
+#sudo make rpm
+#sudo yum -y install build/amazon-efs-utils*rpm
+
+# TODO: mount accesspoint
+#sudo mount -t efs -o tls,accesspoint=access-point-id-dropbox file-system-id efs-mountpoint/dropbox
+#sudo mount -t efs -o tls,accesspoint=access-point-id-config file-system-id efs-mountpoint/config
+
+# TODO: make a permanent mount
+#echo "file-system-id efs-mountpoint/dropbox _netdev,tls,accesspoint=access-point-id-dropbox 0 0" > /etc/fstab
+#echo "file-system-id efs-mountpoint/config _netdev,tls,accesspoint=access-point-id-config 0 0" > /etc/fstab
+
+

--- a/ops/infrastructure/mount-efs.sh
+++ b/ops/infrastructure/mount-efs.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # Define the base mount path
-baseMountPath="/efs-mountpoint"
+baseMountPath="/share"
 
 # Create the mount directory if it doesn't exist
 if [ ! -d "$baseMountPath" ]; then

--- a/ops/infrastructure/terraform.tf
+++ b/ops/infrastructure/terraform.tf
@@ -315,6 +315,9 @@ output "efs_filesystem_size_in_bytes" {
 }
 
 output "efs_filesystem_access_points" {
-  value = values(module.gigadb_efs.access_points)[*].id
+  value = {
+    dropbox_area       = module.gigadb_efs.access_points["dropbox_area"].id
+    configuration_area = module.gigadb_efs.access_points["configuration_area"].id
+  }
 }
 


### PR DESCRIPTION
# Pull request for issue: #1770

This is a pull request for the following functionalities:

* Make aws efs can be accessed from the bastion server by allowing the efs accepts ingress from the public subnets
* Can mount the aws efs to the bastion server
* The mounted aws efs can be managed as a SFTP through rclone
 
## How to test?

Describe how the new functionalities can be tested by PR reviewers

### Pre-requisite 
1. install rclone in local and also in the cngb ftp server
2. create `rclone.conf` as below:
```
[aws-efs]
type = sftp
host = $bastion-ip
user = $bastion-user
key_file = /path/to/$bastion-user-pem (will know after executing ansible user script)
shell_type = unix
md5sum_command = md5sum
sha1sum_command = sha1sum
```

### Spin up the staging instances and efs
 ```
% rm -rf ops/infrastructure/envs/staging
% mkdir ops/infrastructure/envs/staging
% cd ops/infrastructure/envs/staging/
% ../../../scripts/tf_init.sh --project \<your gitlab project path\>  --env staging --web-ec2-type t3.small --bastion-ec2-type t3.small
% terraform plan
% terraform apply
% terraform refresh
% ssh -i $bastion-centos-pem centos@$bastion-ip
[centos@ip-10-99-0-28 ~]$ df -hT
Filesystem     Type      Size  Used Avail Use% Mounted on
devtmpfs       devtmpfs  838M     0  838M   0% /dev
tmpfs          tmpfs     871M     0  871M   0% /dev/shm
tmpfs          tmpfs     871M  8.5M  862M   1% /run
tmpfs          tmpfs     871M     0  871M   0% /sys/fs/cgroup
/dev/nvme0n1p1 xfs        30G  1.6G   29G   6% /
tmpfs          tmpfs     175M     0  175M   0% /run/user/1000
# install aws efs utils for mounting the accesspoints
[centos@ip-10-99-0-140 ~]$ sudo yum update -y
[centos@ip-10-99-0-140 ~]$ sudo yum -y install git rpm-build make rust cargo openssl-devel
[centos@ip-10-99-0-140 ~]$ git clone https://github.com/aws/efs-utils
[centos@ip-10-99-0-140 ~]$ cd efs-utils
[centos@ip-10-99-0-140 ~]$ sudo make rpm
[centos@ip-10-99-0-140 ~]$ sudo yum -y install build/amazon-efs-utils*rpm
[centos@ip-10-99-0-164 ~]$ ls -al
total 16
drwx------.  5 centos centos  113 Apr 23 03:26 .
drwxr-xr-x.  3 root   root     20 Apr 23 03:16 ..
-rw-r--r--.  1 centos centos   18 Feb 10 08:05 .bash_logout
-rw-r--r--.  1 centos centos  141 Feb 10 08:05 .bash_profile
-rw-r--r--.  1 centos centos  376 Feb 10 08:05 .bashrc
drwx------.  2 centos centos   29 Apr 23 03:16 .ssh
drwxrwxr-x. 11 centos centos 4096 Apr 23 03:27 efs-utils
[centos@ip-10-99-0-164 ~]$ ls -al /efs-mountpoint/
total 0
drwxr-xr-x. 4 centos centos  35 Apr 23 03:16 .
drwx------. 5 centos centos 113 Apr 23 03:26 ..
drwxr-xr-x. 2 centos centos   6 Apr 23 03:16 config
drwxr-xr-x. 2 centos centos   6 Apr 23 03:16 dropbox
[centos@ip-10-99-0-164 ~]$ 
# get the file system id from terraform output or from aws efs dashboard
[centos@ip-10-99-0-164 ~]$ sudo mount -t efs -o tls,accesspoint=fsap-dropbox-id fs-id /efs-mountpoint/dropbox
[centos@ip-10-99-0-164 ~]$ sudo mount -t efs -o tls,accesspoint=fsap-confix-id fs-id /efs-mountpoint/config
[centos@ip-10-99-0-164 ~]$ df -hT
Filesystem     Type      Size  Used Avail Use% Mounted on
devtmpfs       devtmpfs  838M     0  838M   0% /dev
tmpfs          tmpfs     871M     0  871M   0% /dev/shm
tmpfs          tmpfs     871M  8.6M  862M   1% /run
tmpfs          tmpfs     871M     0  871M   0% /sys/fs/cgroup
/dev/nvme0n1p1 xfs        30G  2.7G   28G   9% /
tmpfs          tmpfs     175M     0  175M   0% /run/user/1000
127.0.0.1:/    nfs4      8.0E     0  8.0E   0% /efs-mountpoint/dropbox
127.0.0.1:/    nfs4      8.0E     0  8.0E   0% /efs-mountpoint/config
[centos@ip-10-99-0-164 ~]$  mount | grep efs-mountpoint
127.0.0.1:/ on /efs-mountpoint/dropbox type nfs4 (rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,hard,noresvport,proto=tcp,port=20612,timeo=600,retrans=2,sec=sys,clientaddr=127.0.0.1,local_lock=none,addr=127.0.0.1)
127.0.0.1:/ on /efs-mountpoint/config type nfs4 (rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,hard,noresvport,proto=tcp,port=20291,timeo=600,retrans=2,sec=sys,clientaddr=127.0.0.1,local_lock=none,addr=127.0.0.1)
[centos@ip-10-99-0-164 ~]$ 
[centos@ip-10-99-0-164 ~]$ sudo umount /efs-mountpoint/config
[centos@ip-10-99-0-164 ~]$ mount | grep efs-mountpoint/config
[centos@ip-10-99-0-164 ~]$ df -hT
Filesystem     Type      Size  Used Avail Use% Mounted on
devtmpfs       devtmpfs  838M     0  838M   0% /dev
tmpfs          tmpfs     871M     0  871M   0% /dev/shm
tmpfs          tmpfs     871M  8.6M  862M   1% /run
tmpfs          tmpfs     871M     0  871M   0% /sys/fs/cgroup
/dev/nvme0n1p1 xfs        30G  2.7G   28G   9% /
tmpfs          tmpfs     175M     0  175M   0% /run/user/1000
127.0.0.1:/    nfs4      8.0E     0  8.0E   0% /efs-mountpoint/dropbox
[centos@ip-10-99-0-164 ~]$ 
[centos@ip-10-99-0-164 ~]$ cd /efs-mountpoint/dropbox
[centos@ip-10-99-0-164 dropbox]$ curl http://212.183.159.230/100MB.zip --output 100MB.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  100M  100  100M    0     0  2228k      0  0:00:45  0:00:45 --:--:-- 6478k
[centos@ip-10-99-0-164 dropbox]$ 
[centos@ip-10-99-0-164 dropbox]$ ls -al
total 102404
drwxr-xr-x. 2 centos centos      6144 Apr 23 03:43 .
drwxr-xr-x. 4 centos centos        35 Apr 23 03:16 ..
-rw-rw-r--. 1 centos centos 104857600 Apr 23 03:43 100MB.zip
[centos@ip-10-99-0-164 dropbox]$ 
# use aws cli to check the size
% aws efs describe-file-systems --file-system-id fs-id
# or go to aws efs dashboard to confirm the size is 100MiB in `Size in Standard`.
```

### Create a bastion user for copy/delete files using rclone
```
% cd ops/infrastructure/envs/staging
% ../../../scripts/ansible_init.sh --env staging
% ansible-playbook -i ../../inventories users_playbook.yml -e "newuser=mary" --extra-vars="gigadb_env=staging"
% chmod 500 output/privkeys-$bastion-ip/mary
% ssh -i output/privkeys-$bastion-ip/mary mary@$bastion-ip
Activate the web console with: systemctl enable --now cockpit.socket

Last login: Tue Apr 23 13:40:56 2024 from 14.199.148.232
[mary@ip-10-99-0-129 ~]$ ls -al
total 16
drwx------. 4 mary mary 112 Apr 23 09:13 .
drwxr-xr-x. 4 root root  32 Apr 23 09:11 ..
-rw-------. 1 mary mary 158 Apr 23 14:18 .bash_history
-rw-r--r--. 1 mary mary  18 Feb 10 08:05 .bash_logout
-rw-r--r--. 1 mary mary 141 Feb 10 08:05 .bash_profile
-rw-r--r--. 1 mary mary 376 Feb 10 08:05 .bashrc
drwx------. 2 mary mary  29 Apr 23 09:12 .ssh
drwx------. 2 mary mary   6 Apr 23 09:11 uploadDir
[mary@ip-10-99-0-129 ~]$ ls -al /efs-mountpoint/
total 4
drwxr-xr-x.  4 centos centos   35 Apr 23 09:07 .
dr-xr-xr-x. 18 root   root    246 Apr 23 09:07 ..
drwxr-xr-x.  2 centos centos    6 Apr 23 09:07 config
drwxr-xr-x.  2 centos centos 6144 Apr 23 14:10 dropbox
[mary@ip-10-99-0-129 ~]$ ls -al /efs-mountpoint/dropbox/
total 102404
drwxr-xr-x. 2 centos centos      6144 Apr 23 14:10 .
drwxr-xr-x. 4 centos centos        35 Apr 23 09:07 ..
-rw-rw-r--. 1 centos centos 104857600 Apr 23 13:43 100MB.zip
[mary@ip-10-99-0-129 ~]$ df -hT
Filesystem     Type      Size  Used Avail Use% Mounted on
devtmpfs       devtmpfs  838M     0  838M   0% /dev
tmpfs          tmpfs     871M     0  871M   0% /dev/shm
tmpfs          tmpfs     871M  8.6M  862M   1% /run
tmpfs          tmpfs     871M     0  871M   0% /sys/fs/cgroup
/dev/nvme0n1p1 xfs        30G  2.7G   28G   9% /
tmpfs          tmpfs     175M     0  175M   0% /run/user/1000
127.0.0.1:/    nfs4      8.0E  100M  8.0E   1% /efs-mountpoint/dropbox
tmpfs          tmpfs     175M     0  175M   0% /run/user/1001
[mary@ip-10-99-0-129 ~]$ mount | grep efs-mountpoint
127.0.0.1:/ on /efs-mountpoint/dropbox type nfs4 (rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,hard,noresvport,proto=tcp,port=20559,timeo=600,retrans=2,sec=sys,clientaddr=127.0.0.1,local_lock=none,addr=127.0.0.1)
[mary@ip-10-99-0-129 ~]$ 
```

### Test the rclone config in local computer, make sure the rclone.conf mentioned in pre-requiste is reachable
```
% cd gigadb-website
% rclone --version
% rclone --config /path/to/rclone.conf lsd aws-efs:/efs-mountpoint
          -1 2024-04-23 17:07:10        -1 config
          -1 2024-04-23 22:10:44        -1 dropbox
% rclone --config rclone.conf ls aws-efs:/efs-mountpoint/dropbox
104857600 100MB.zip
% rclone --config /path/to/rclone.conf copy -v gigadb/app/tools/excel-spreadsheet-uploader/xls/100679newversion.xls  aws-efs:/efs-mountpoint/dropbox
2024/04/24 10:41:59 INFO  : 100679newversion.xls: Copied (new)
2024/04/24 10:41:59 INFO  : 
Transferred:           72 KiB / 72 KiB, 100%, 71.921 KiB/s, ETA 0s
Transferred:            1 / 1, 100%
Elapsed time:         3.0s
 % rclone --config /path/to/rclone.conf -v gigadb/app/tools/excel-spreadsheet-uploader/xls/100679newversion.xls  aws-efs:/efs-mountpoint/dropbox
2024/04/24 10:42:04 INFO  : 
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Elapsed time:         1.5s
% rclone --config /path/to/rclone.confls aws-efs:/efs-mountpoint/dropbox
    73728 100679newversion.xls
104857600 100MB.zip
% rclone --config /path/to/rclone.conf -v delete aws-efs:/efs-mountpoint/dropbox/100679newversion.xls 
2024/04/24 10:43:21 INFO  : 100679newversion.xls: Deleted
 % rclone --config rclone.conf -v delete aws-efs:/efs-mountpoint/dropbox/100679newversion.xls 
2024/04/24 10:43:27 ERROR : : error listing: directory not found
2024/04/24 10:43:27 ERROR : Attempt 1/3 failed with 2 errors and: directory not found
2024/04/24 10:43:27 ERROR : : error listing: directory not found
2024/04/24 10:43:27 ERROR : Attempt 2/3 failed with 2 errors and: directory not found
2024/04/24 10:43:27 ERROR : : error listing: directory not found
2024/04/24 10:43:27 ERROR : Attempt 3/3 failed with 2 errors and: directory not found
2024/04/24 10:43:28 Failed to delete with 2 errors: last error was: directory not found
% rclone --config r/path/to/rclone.conf ls aws-efs:/efs-mountpoint/dropbox                            
104857600 100MB.zip
```
### Login to cngb ftp server via https://uomc.genomics.cn/ after bgi vpn connected 
```
login: ken
ken@192.168.28.205's password: 
Last login: Tue Apr 23 11:59:22 2024 from 10.17.24.13

Welcome to Alibaba Cloud Elastic Compute Service !

-bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
[ken@cngb-gigadb-ftp ~]$ uname -a
Linux cngb-gigadb-ftp 3.10.0-862.14.4.el7.x86_64 #1 SMP Wed Sep 26 15:12:11 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
[ken@cngb-gigadb-ftp ~]$ lsb_release -a
LSB Version:	:core-4.1-amd64:core-4.1-noarch
Distributor ID:	CentOS
Description:	CentOS Linux release 7.5.1804 (Core) 
Release:	7.5.1804
Codename:	Core
[ken@cngb-gigadb-ftp ~]$ df -hT
Filesystem                                                 Type      Size  Used Avail Use% Mounted on
/dev/vda1                                                  ext4       50G   17G   31G  36% /
devtmpfs                                                   devtmpfs   16G     0   16G   0% /dev
tmpfs                                                      tmpfs      16G     0   16G   0% /dev/shm
tmpfs                                                      tmpfs      16G  580K   16G   1% /run
tmpfs                                                      tmpfs      16G     0   16G   0% /sys/fs/cgroup
240704b1c5-eey91.cn-shenzhen.nas.aliyuncs.com:/data_upload nfs        10P  6.9T   10P   1% /data
192.168.56.61:/data/gigadb                                 nfs4      191T  166T   15T  92% /var/ftp/gigadb
tmpfs                                                      tmpfs     3.1G     0  3.1G   0% /run/user/5057
[ken@cngb-gigadb-ftp ~]$ 
[ken@cngb-gigadb-ftp ~]$ ls
logs
[ken@cngb-gigadb-ftp ~]$ ls /data/
JBrowse  data_upload  https_log
[ken@cngb-gigadb-ftp ~]$ ls /data/data_upload/
user1    user111  user16  user29  user41  user54  user67  user8   user92
user10   user112  user17  user3   user42  user55  user68  user80  user93
user100  user113  user18  user30  user43  user56  user69  user81  user94
user101  user114  user19  user31  user44  user57  user7   user82  user95
user102  user115  user2   user32  user45  user58  user70  user83  user96
user103  user116  user20  user33  user46  user59  user71  user84  user97
user104  user117  user21  user34  user47  user6   user72  user85  user98
user105  user118  user22  user35  user48  user60  user73  user86  user99
user106  user119  user23  user36  user49  user61  user74  user87  user_gaofei
user107  user12   user24  user37  user5   user62  user75  user88
user108  user120  user25  user38  user50  user63  user76  user89
user109  user13   user26  user39  user51  user64  user77  user9
user11   user14   user27  user4   user52  user65  user78  user90
user110  user15   user28  user40  user53  user66  user79  user91
[ken@cngb-gigadb-ftp ~]$ 
# install go and rclone by following https://go.dev/doc/install#requirements if not
[ken@cngb-gigadb-ftp ~]$ sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.22.2.linux-amd64.tar.gz
[ken@cngb-gigadb-ftp ~]$ export PATH=$PATH:/usr/local/go/bin
[ken@cngb-gigadb-ftp ~]$ go version
go version go1.22.2 linux/amd64
[ken@cngb-gigadb-ftp ~]$ curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 20.1M  100 20.1M    0     0  2116k      0  0:00:09  0:00:09 --:--:-- 4154k
[ken@cngb-gigadb-ftp ~]$ unzip rclone-current-linux-amd64.zip
[ken@cngb-gigadb-ftp ~]$ cd rclone-*-linux-amd64
[ken@cngb-gigadb-ftp rclone-v1.66.0-linux-amd64]$ sudo cp rclone /usr/bin/
[ken@cngb-gigadb-ftp rclone-v1.66.0-linux-amd64]$ sudo chown root:root /usr/bin/rclone
[ken@cngb-gigadb-ftp rclone-v1.66.0-linux-amd64]$ sudo chmod 755 /usr/bin/rclone
[ken@cngb-gigadb-ftp rclone-v1.66.0-linux-amd64]$ sudo mkdir -p /usr/local/share/man/man1
[ken@cngb-gigadb-ftp rclone-v1.66.0-linux-amd64]$ sudo cp rclone.1 /usr/local/share/man/man1/
[ken@cngb-gigadb-ftp rclone-v1.66.0-linux-amd64]$ sudo mandb
[ken@cngb-gigadb-ftp rclone-v1.66.0-linux-amd64]$ cd ..
[ken@cngb-gigadb-ftp ~]$ rclone version
rclone v1.66.0
- os/version: centos 7.5.1804 (64 bit)
- os/kernel: 3.10.0-862.14.4.el7.x86_64 (x86_64)
- os/type: linux
- os/arch: amd64
- go/version: go1.22.1
- go/linking: static
- go/tags: none
[ken@cngb-gigadb-ftp ~]$ 
# copy the rclone.conf and the $bastion-user-pem in local to the cngb ftp server manually
[ken@cngb-gigadb-ftp ~]$ vi rclone.config
[ken@cngb-gigadb-ftp ~]$ vi $bastion-user-pem
[ken@cngb-gigadb-ftp ~]$ ls
efs-utils  go1.22.2.linux-amd64.tar.gz  logs  rclone-current-linux-amd64.zip  rclone-v1.66.0-linux-amd64  $bastion-user-pem rclone.config
[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf lsd aws-efs:/efs-mountpoint
          -1 2024-04-23 17:07:10        -1 config
          -1 2024-04-23 22:03:44        -1 dropbox
 [ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf ls aws-efs:/efs-mountpoint/dropbox 
104857600 100MB.zip
[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf copy -v rclone-current-linux-amd64.zip aws-efs:/efs-mountpoint/dropbox
2024/04/23 22:09:40 INFO  : rclone-current-linux-amd64.zip: Copied (new)
2024/04/23 22:09:40 INFO  : 
Transferred:   	   20.158 MiB / 20.158 MiB, 100%, 6.719 MiB/s, ETA 0s
Transferred:            1 / 1, 100%
Elapsed time:         4.6s

[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf ls aws-efs:/efs-mountpoint/dropbox
104857600 100MB.zip
 21137057 rclone-current-linux-amd64.zip
[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf copy -v rclone-current-linux-amd64.zip aws-efs:/efs-mountpoint/dropbox
2024/04/23 22:10:31 INFO  : 
Transferred:   	          0 B / 0 B, -, 0 B/s, ETA -
Elapsed time:         1.4s

[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf delete -v aws-efs:/efs-mountpoint/dropbox/rclone-current-linux-amd64.zip
2024/04/23 22:10:44 INFO  : rclone-current-linux-amd64.zip: Deleted
[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf delete -v aws-efs:/efs-mountpoint/dropbox/rclone-current-linux-amd64.zip
2024/04/23 22:10:50 ERROR : : error listing: directory not found
2024/04/23 22:10:50 ERROR : Attempt 1/3 failed with 2 errors and: directory not found
2024/04/23 22:10:50 ERROR : : error listing: directory not found
2024/04/23 22:10:50 ERROR : Attempt 2/3 failed with 2 errors and: directory not found
2024/04/23 22:10:50 ERROR : : error listing: directory not found
2024/04/23 22:10:50 ERROR : Attempt 3/3 failed with 2 errors and: directory not found
2024/04/23 22:10:51 Failed to delete with 2 errors: last error was: directory not found
[ken@cngb-gigadb-ftp ~]$ rclone --config rclone.conf ls aws-efs:/efs-mountpoint/dropbox
104857600 100MB.zip

```

## How have functionalities been implemented?

Firstly, udpate the aws efs module to accept ingress from the public subnets of the VPC where the bastion server located. And also create the directory `/efs-mountpoint` with two sub directories `dropbox` and `config` during `terraform apply`, so when it is done, the `/efs-mountpoint/dropbox` and `/efs-mountpoint/config` would be already existed.

Then, in order to mount the accesspoint of the aws efs, [Amazon EFS client](https://docs.aws.amazon.com/efs/latest/ug/installing-amazon-efs-utils.html) needs to be installed in the bastion server. After it, the [accesspoint can be mounted](https://docs.aws.amazon.com/efs/latest/ug/mounting-access-points.html) using:
```
$ sudo mount -t efs -o tls,accesspoint=access-point-id file-system-id efs-mount-point
```

The aws efs can also be manged by using rclone after it is configured to have a sftp endpoint pointing to the bastion server. Details for setting up a sftp endpoint can refer to [here](https://rclone.org/sftp/).

For the basic steps of mounting, automounting and unmounting of the aws efs can refer to [here](https://repost.aws/knowledge-center/efs-mount-automount-unmount-steps)


## Any issues with implementation?

The `mount-efs.sh` is created for the `user_data` in the terraform script which aims to create mount directories and mount them to the aws efs automatically, further work is required in #1771 .

## Any changes to automated tests?
None

## Any changes to documentation?

None

## Any technical debt repayment?

None

## Any improvements to CI/CD pipeline?

None
