### PR TITLE
Fix: Samples table stuck to first page results when paginating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-- Feat #1741L: Add carets to sortable headers in dataset page
 
 ## Unreleased
 
 - Fix #1800: Read the correct sample page from cache on samples tables
+- Feat #1163: Add carets to sortable headers in dataset page
 - Feat #1664: Enable post upload script to work with non-published datasets
 
 ## v4.2.4 - 2024-04-16 - 576757f38

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1800: Read the correct sample page from cache on samples tables
 - Feat #1664: Enable post upload script to work with non-published datasets
 
 ## v4.2.4 - 2024-04-16 - 576757f38

--- a/protected/components/CachedDatasetSamples.php
+++ b/protected/components/CachedDatasetSamples.php
@@ -63,7 +63,7 @@ class CachedDatasetSamples extends DatasetComponents implements DatasetSamplesIn
      */
     public function getDatasetSamples(?string $limit = "ALL", ?int $offset = 0): array
     {
-        $samples =  $this->getCachedLocalData($this->getDatasetId());
+        $samples =  $this->getCachedLocalData($this->getDatasetId(), $limit."_".$offset);
         if (!$samples) {
             $samples = $this->_storedDatasetSamples->getDatasetSamples($limit, $offset);
             $this->saveLocalDataInCache($this->getDatasetId(), $samples);

--- a/tests/acceptance/DatasetView.feature
+++ b/tests/acceptance/DatasetView.feature
@@ -170,3 +170,12 @@ Feature: a user visit the dataset page
     And I should see "test generic image will be display for no image dataset"
     Then I should not see "Cite Dataset"
 
+  @ok
+  Scenario: Pagination in the sample tab
+    Given I have not signed in
+    And I am on "/dataset/100035"
+    And I follow "Sample"
+    And I should see "SRS173539"
+    When I follow "2"
+    Then I should see "SRS173549"
+    And I should not see "SRS173539"


### PR DESCRIPTION
# Pull request for issue: #1800 

This is a pull request for the following functionalities:

* Ensure sample tables show the correct page of sample result on all pages

## How to test?

Navigate to http://gigadb.gigasciencejournal.com/dataset/100035/

and check that you can paginate through all samples.

## How have functionalities been implemented?

The bug was that when loading the current page of result from cache we forgot to pass the limit and offset that consist part of the cache key, so it was retrieving the wrong data from cache

## Any issues with implementation?

N/a

## Any changes to automated tests?

Updated the unit test `tests/unit/CachedDatasetSamplesTest.php` with a new scenario that reveals the bug by testing various value of limit and offset . 

## Any changes to documentation?

N/a

## Any technical debt repayment?

N/a

## Any improvements to CI/CD pipeline?

N/a
