### PR TITLE
Mockup links on non-public upload statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1817: generate mockup link button not appearing for all upload statuses
+
 ## v4.2.7 - 2024-05-07 - 902e5bfb5 - live since 2024-05-13
 
 - Feat #1834: Create rclone config for bastion users to allow managing files on Wasabi

--- a/protected/views/adminDataset/_form.php
+++ b/protected/views/adminDataset/_form.php
@@ -527,12 +527,14 @@ echo $form->hiddenField($model, "image_id");
         $model->isNewRecord ? 'Create' : 'Save',
         array('class' => 'btn background-btn submit-btn', 'id' => 'datasetFormSaveButton')
     ); ?>
-    <?php if ("hidden" === $datasetPageSettings->getPageType() || "draft" === $datasetPageSettings->getPageType()) { ?>
+    <?php if (in_array($datasetPageSettings->getPageType(), ["hidden", "draft", "mockup"])) { ?>
         <a href="<?= Yii::app()->createUrl('/adminDataset/private/identifier/' . $model->identifier) ?>" />Create/Reset Private URL</a>
         <?php if ($model->token) { ?>
             <a href="<?= Yii::app()->createUrl('/dataset/' . $model->identifier . '/token/' . $model->token) ?>">Open Private URL</a>
         <?php } ?>
-    <?php } elseif ("mockup" === $datasetPageSettings->getPageType()) {
+<?php } 
+        if (Yii::app()->featureFlag->isEnabled("fuw")
+            && "mockup" === $datasetPageSettings->getPageType()) {
         echo CHtml::link('Generate mockup for reviewers', '#', array(
             'class' => 'btn background-btn',
             'data-toggle' => "modal", 'data-target' => "#mockupCreation"

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -423,12 +423,12 @@ Feature: form to update dataset details
     And I wait "5" seconds
     And I should see "This DOI exists in datacite, but failed to update metadata because of: DOI 10.80027/100935: Missing child element(s). Expected is ( {http://datacite.org/schema/kernel-4}creator ). at line 4, column 0"
 
-  @broken @mint-doi
+  @ok @mint-doi
   Scenario: Try to create doi with invalid metadata format
     Given I am on "/adminDataset/update/id/700"
     When I follow "Mint DOI"
     Then I should see "minting under way, please wait"
-    And I wait "5" seconds
+    And I wait "10" seconds
     And I should see "This DOI cannot be created because of the metadata status: 422, and the doi status: 422 Details can be found at here"
     And I should see a link "here" to "https://support.datacite.org/reference/mds#api-response-codes"
 

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -423,7 +423,7 @@ Feature: form to update dataset details
     And I wait "5" seconds
     And I should see "This DOI exists in datacite, but failed to update metadata because of: DOI 10.80027/100935: Missing child element(s). Expected is ( {http://datacite.org/schema/kernel-4}creator ). at line 4, column 0"
 
-  @wip @mint-doi
+  @broken @mint-doi
   Scenario: Try to create doi with invalid metadata format
     Given I am on "/adminDataset/update/id/700"
     When I follow "Mint DOI"
@@ -431,3 +431,28 @@ Feature: form to update dataset details
     And I wait "5" seconds
     And I should see "This DOI cannot be created because of the metadata status: 422, and the doi status: 422 Details can be found at here"
     And I should see a link "here" to "https://support.datacite.org/reference/mds#api-response-codes"
+
+  @ok @dataset-status
+  Scenario Outline: Links to create mockup or to open mockup are always present for a non-published dataset
+    Given I am on "/adminDataset/update/id/668"
+    And I select <status> from the field "Dataset_upload_status"
+    And I press the button "Save"
+    And I am on "/adminDataset/update/id/668"
+    Then I should see a link "Create/Reset Private URL" to "/adminDataset/private/identifier/200070"
+    And I should see a link "Open Private URL" to "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
+    Examples:
+      | status                   |
+      | "ImportFromEM"           |
+      | "UserStartedIncomplete"  |
+      | "Rejected"               |
+      | "Not required"           |
+      | "Submitted"              |
+      | "Curation"               |
+      | "AuthorReview"           |
+      | "Private"                |
+      | "AssigningFTPbox"        |
+      | "UserUploadingData"      |
+      | "DataAvailableForReview" |
+      | "DataPending"            |
+
+

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -455,4 +455,13 @@ Feature: form to update dataset details
       | "DataAvailableForReview" |
       | "DataPending"            |
 
+  @ok @dataset-status
+  Scenario: Links to create mockup or to open mockup are not present for a published dataset
+    Given I am on "/adminDataset/update/id/5"
+    And I select "Published" from the field "Dataset_upload_status"
+    And I press the button "Save"
+    When I am on "/adminDataset/update/id/5"
+    Then I should not see "Create/Reset Private URL"
+    And I should not see "Open Private URL"
+
 


### PR DESCRIPTION
# Pull request for issue: #1816, #1817

This is a pull request for the following functionalities:

* Make the link for creating and opening mockup pages appears in the dataset form whatever status is selected

## How to test?

Locally and on CI, you can run the acceptance tests.

On an AWS environment, you can proceed as below:

1. Setup your AWS staging environment as described in the developer documentation:  
`docs/developers/SETUP_AWS_ENVIRONMENTS.md`

2. Push this branch to your Gitlab pipeline

3. Login to your staging environment as an admin and navigate to the /adminDataset/update/id/1835
4. You should be able to see the link [Create/Reset Private URL] for any upload status that's not "Published"
5. When you create the mockup, you should also see the link [Open Private URL] for any upload status that's not "Published"
6. When selecting "Published" as upload status, save the form and then fully reload the form, you should see neither of those links

## How have functionalities been implemented?

In the Yii view file `protected/views/adminDataset/_form.php`, we make sure all the non public type of pages will cause the code path to reach the block where we display the two links related to the classic mockup pages.
We also hide the button "Generate mockup for reviewers" behind feature flag as it is specific to File Upload Wizard and it was confusing the curators.



## Any issues with implementation?

Noticed issues that already exists on current live version, but because they are lower impact and need some attention to come up with the fix, I've created separate issues: 
* For a couple of upload status, saving the form redirect to the admin list of datasets #1854
* Selecting "Published" and saving the form doesn't immediately remove the links, needs to fully reload the page #1855

## Any changes to automated tests?

Two acceptance tests scenario were added in `tests/acceptance/AdminDatasetForm.feature` to surface the buggy behaviour and ensure it's fixed

## Any changes to documentation?

N/a
## Any technical debt repayment?

N/a

## Any improvements to CI/CD pipeline?

N/a
