### PR TITLE
Web pages used in new user onboarding workflow still use the old design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1892: Update uder confirm and user welcome pages to new styles
 - Feat #1825: "Continue to view old version" closes New Version Alert pop up
 - Feat #514: Add canonical URL to dataset pages
 

--- a/protected/controllers/UserController.php
+++ b/protected/controllers/UserController.php
@@ -261,6 +261,7 @@ class UserController extends Controller {
 	}
 
     public function actionWelcome() {
+        $this->layout = 'new_main';
         $this->render('welcome', array('user'=>$this->loadUser())) ;
     }
 

--- a/protected/controllers/UserController.php
+++ b/protected/controllers/UserController.php
@@ -256,6 +256,7 @@ class UserController extends Controller {
             $this->sendNotificationEmail($user);
         }
 
+    $this->layout = 'new_main';
 		$this->render('confirm', array('user'=>$user));
 	}
 

--- a/protected/views/user/confirm.php
+++ b/protected/views/user/confirm.php
@@ -6,7 +6,7 @@
     <? } else { ?>
     <h1 class="h2">Account Pending</h1>
 
-    You are now registered. We will contact you shortly. Feel free to <?= CHtml::link("contact us", "mailto:database@gigasciencejournal.com" . Yii::app()->params['support_email']) ?> if you prefer.</p>
+    <p>You are now registered. We will contact you shortly. Feel free to <?= CHtml::link("contact us", "mailto:database@gigasciencejournal.com" . Yii::app()->params['support_email']) ?> if you prefer.</p>
     <? } ?>
 </div>
 

--- a/protected/views/user/confirm.php
+++ b/protected/views/user/confirm.php
@@ -1,10 +1,10 @@
 <div class="container">
   <? if ($user->is_activated) { ?>
-    <h3>Your account has been activated</h3>
+    <h1 class="h2">Your account has been activated</h1>
 
     <p><?= CHtml::link("Log in", array('site/login')) ?> to configure your account.</p>
     <? } else { ?>
-    <h3>Account Pending</h3>
+    <h1 class="h2">Account Pending</h1>
 
     You are now registered. We will contact you shortly. Feel free to <?= CHtml::link("contact us", "mailto:database@gigasciencejournal.com" . Yii::app()->params['support_email']) ?> if you prefer.</p>
     <? } ?>

--- a/protected/views/user/confirm.php
+++ b/protected/views/user/confirm.php
@@ -1,12 +1,12 @@
-<? if ($user->is_activated) { ?>
-<h3>Your account has been activated</h3>
+<div class="container">
+  <? if ($user->is_activated) { ?>
+    <h3>Your account has been activated</h3>
 
-<p><?= CHtml::link("Log in", array('site/login')) ?> to configure your account.</p>
-<? } else { ?>
-<h3>Account Pending</h3>
+    <p><?= CHtml::link("Log in", array('site/login')) ?> to configure your account.</p>
+    <? } else { ?>
+    <h3>Account Pending</h3>
 
-You are now registered. We will contact you shortly. Feel free to
-or <?= CHtml::link("contact us", "mailto:" . Yii::app()->params['support_email']) ?>&nbsp;
-if you prefer.</p>
-<? } ?>
+    You are now registered. We will contact you shortly. Feel free to <?= CHtml::link("contact us", "mailto:database@gigasciencejournal.com" . Yii::app()->params['support_email']) ?> if you prefer.</p>
+    <? } ?>
+</div>
 

--- a/protected/views/user/welcome.php
+++ b/protected/views/user/welcome.php
@@ -2,7 +2,7 @@
 
 <? $this->pageTitle = Yii::app()->name . ' - Welcome' ?>
 
-<h2><?=Yii::t('app' , 'Welcome!')?></h2>
+<h1 class="h2"><?=Yii::t('app' , 'Welcome!')?></h1>
 <div class="clear"></div>
 <p><?=Yii::t('app' , 'Thank you for registering with GigaDB. An account activation email will be sent to your email address shortly. To complete your account\'s activation, please click on the activation link in the account activation email.')?><br/>
 <?= Yii::t('app' , 'If you don\'t receive the email within a few minutes, please check your spam filters, or')?> <?= CHtml::link(Yii::t('app' ,"resend the email"), array("user/sendActivationEmail", 'id'=>$user->id)) ?>.</p>

--- a/protected/views/user/welcome.php
+++ b/protected/views/user/welcome.php
@@ -1,3 +1,5 @@
+<div class="container">
+
 <? $this->pageTitle = Yii::app()->name . ' - Welcome' ?>
 
 <h2><?=Yii::t('app' , 'Welcome!')?></h2>
@@ -5,3 +7,4 @@
 <p><?=Yii::t('app' , 'Thank you for registering with GigaDB. An account activation email will be sent to your email address shortly. To complete your account\'s activation, please click on the activation link in the account activation email.')?><br/>
 <?= Yii::t('app' , 'If you don\'t receive the email within a few minutes, please check your spam filters, or')?> <?= CHtml::link(Yii::t('app' ,"resend the email"), array("user/sendActivationEmail", 'id'=>$user->id)) ?>.</p>
 
+</div>


### PR DESCRIPTION
# Pull request for issue: #1892

This is a pull request for the following functionalities:

* Update styles of user/confirm and user/welcome pages

* http://gigadb.gigasciencejournal.com/user/confirm/401
* http://gigadb.gigasciencejournal.com/user/welcome/id/401

## How to test?

- Navigate to above pages
- Verify that they use new style
- Run a11y audit (e.g. with WAVE chrome extension) and verify that there are no errors

## How have functionalities been implemented?

- Use new layouts in these pages by adding `$this->layout = 'new_main';` right before the render call
- Wrap page content in a div with a `container` class to add margins
- Wrap one of the paragraphs in a html `p` tag which missed it
- Tweak the text on the `confirm` page to be grammatically correct (it looked like one part of a sentence was missing)
- Add missing mailto destination to the `contact us` in the `confirm` page

## Any issues with implementation?

- /user/confirm I updated the message as it was previously missing something. Not sure if it needs more changes. In my opinion the last "if you prefer" is a bit unclear (if you prefer what? Speed up the process...?)

![Screenshot from 2024-05-25 14-05-43](https://github.com/gigascience/gigadb-website/assets/143437854/3e96b280-1905-409f-a4a1-87de882b36f0)

- The original pages did not have breadcrumbs so I didn't add them here. I think since these pages are accessed through means other than direct website navigation, breacrumbs are not needed here.

## Any changes to automated tests?

--