### PR TITLE
Remove close button from new version popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-## v4.2.8 - 2024-05-28 - 771372fbb 
+- Fix #1825: Remove close button from view new version popup
+
+## v4.2.8 - 2024-05-28 - 771372fbb
 
 - Feat #1832: Make script for calculating the md5 values and file sizes available for bastion users
 - Fix #1817: generate mockup link button not appearing for all upload statuses

--- a/features/dataset-view.feature
+++ b/features/dataset-view.feature
@@ -451,3 +451,32 @@ Feature: a user visit the dataset page
 		| Ssol.cltw.I.67 	| |	Schistocephalus solidus |	Description:short PE reads | 70667 | |
 		| Ssol.cltw.I.98.1 	| |	Schistocephalus solidus |	Description:short PE reads | 70667 | |
 
+  @ok @javascript
+  Scenario: Popup Old version with link to new version closes when choosing old version
+    Given I am not logged in to Gigadb web site
+    And I am on "dataset/100044"
+    And I wait "3" seconds
+    And I should see "There is a new version of this dataset available at DOI 10.80027/100148"
+    And I should see a button "Continue to view old version" with link "#"
+    When I click on the "Continue to view old version" button
+    And I wait "3" seconds
+    Then I should not see "There is a new version of this dataset available at DOI 10.80027/100148"
+
+  @ok @javascript
+  Scenario: Popup Old version with link to new version doesn't have a close button
+    Given I am not logged in to Gigadb web site
+    When I am on "dataset/100044"
+    And I wait "3" seconds
+    And I should see "There is a new version of this dataset available at DOI 10.80027/100148"
+    And I should not see "Close"
+
+  @ok @javascript
+  Scenario: Popup Old version with link to new version go to new version when choosing new version
+    Given I am not logged in to Gigadb web site
+    And I am on "dataset/100044"
+    And I wait "3" seconds
+    And I should see "There is a new version of this dataset available at DOI 10.80027/100148"
+    And I should see a button "View new version" with link "/dataset/100148"
+    When I click on the "View new version" button
+    And I wait "3" seconds
+    Then I should be on "/dataset/100148"

--- a/features/dataset-view.feature
+++ b/features/dataset-view.feature
@@ -114,7 +114,6 @@ Feature: a user visit the dataset page
 		And I should see "There is a new version of this dataset available at DOI 10.80027/100148"
 		And I should see a button "View new version" with link "/dataset/100148"
 		And I should see a button "Continue to view old version" with link "/dataset/100044"
-		And I should see a button "Close"
 		# Then I take a screenshot named "Dataset view IsPreviousVersionOf"
 
 	@ok

--- a/protected/views/dataset/_connection_IsPreviousVersionOf.php
+++ b/protected/views/dataset/_connection_IsPreviousVersionOf.php
@@ -11,7 +11,6 @@
         <p>There is a new version of this dataset available at DOI <?=$relation['full_related_doi']?></p>
       </div>
       <div class="modal-footer">
-        <a href="#" class="btn btn-default" data-dismiss="modal">Close</a>
         <a href="/dataset/<?= $relation['related_doi'] ?>" class="btn btn-default">View new version</a>
         <a href="#" class="btn btn-default" data-dismiss="modal">Continue to view old version</a>
       </div>


### PR DESCRIPTION
# Pull request for issue: #1825

![image](https://github.com/gigascience/gigadb-website/assets/143437854/d998f2b0-dd9c-41ea-8305-7301e15d196f)

- Removed close button from popup when navigating to old version dataset as shown on image

## How to test?

You can see how there is no longer a close button in the `protected/views/dataset/_connection_IsPreviousVersionOf.php

## How have functionalities been implemented?

Removed line that renderd button

## Any issues with implementation?

--

## Any changes to automated tests?

- admin Dashboard: the currently deployed version of GigaDB is shown on the admin dashboard I see this test suddenly failing although it looks unrelated to the changes in this PR
- Deleted one line from `Scenario: IsPreviousVersionOf relation should show an alert warning of old version with link to new version` that expected a close button. Please confim this is correct