### PR TITLE
Mockup table pages bad request error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1812: Navigating tables on mockup pages does not generate errors
 - Fix #1801: Refresh materialized views daily using cron job and drop existing triggers
 - Feat #1143: Open external links in new browser tabs
 - Feat: updated upload spreadsheet template to version 19

--- a/ops/configuration/yii-conf/main.php.dist
+++ b/ops/configuration/yii-conf/main.php.dist
@@ -134,7 +134,7 @@ return CMap::mergeArray(array(
             'showScriptName'=>false,
             'rules'=>array(
                 '/dataset/<id:\d+>'=>'dataset/view/id/<id>',
-                '/dataset/<id:\d+>/<slug:.+>'=>'dataset/view/id/<id>',
+                '/dataset/<id:\d+>/<token:.+>'=>'dataset/view/id/<id>/<token>',
                 '.*'=>'site/index',
                 'site/forgot' => 'resetPasswordRequest/forgot',
                 'site/thanks' => 'resetPasswordRequest/thanks',

--- a/protected/components/DatasetPageSettings.php
+++ b/protected/components/DatasetPageSettings.php
@@ -33,7 +33,7 @@ class DatasetPageSettings extends yii\base\BaseObject
         parent::__construct();
         $this->_dao = $dao;
         $this->_model = $model;
-        if ($this->_model && !$this->_model->isNewRecord && in_array($this->_model->upload_status, ["UserUploadingData","DataAvailableForReview", "DataPending", "Curation", "AuthorReview"])) {
+        if ($this->_model && !$this->_model->isNewRecord && in_array($this->_model->upload_status, ["ImportFromEM","UserUploadingData","DataAvailableForReview", "DataPending", "Curation", "AuthorReview"])) {
             $this->_pageType = "draft";
         } elseif (
             $this->_model && !$this->_model->isNewRecord && "Published" !== $this->_model->upload_status

--- a/protected/controllers/DatasetController.php
+++ b/protected/controllers/DatasetController.php
@@ -154,9 +154,10 @@ class DatasetController extends Controller
             // Page private ? Disable robot to index
             $this->metaData['private'] = true;
 
-            if ("/dataset/$id/token/" . $assembly->getDataset()->token === $_SERVER['REQUEST_URI']) { //access using mockup page url
+            if (preg_match("/dataset\/$id\/token/",$_SERVER['REQUEST_URI']) || preg_match("/dataset\/view\/id\/$id\/token\/.+/",$_SERVER['REQUEST_URI']) ) { //access using mockup page url
                 $mainRenderer($assembly, $datasetPageSettings, $previousDataset, $nextDataset, $fileSettings, $sampleSettings, $flag);
             } else {
+                Yii::log('Request is invalid for URI: '.$_SERVER['REQUEST_URI'],'error');
                 $this->render('invalid', array('model' => new Dataset('search'), 'keyword' => $id));
             }
         } else { //page type is public

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -146,11 +146,11 @@ class AcceptanceTester extends \Codeception\Actor
     }
 
     /**
-     * @Then I should see a disabled file input for :file
+     * @Then I should see a file input for :file
      */
-    public function iShouldSeeADisbledFileInputFor($file)
+    public function iShouldSeeAFileInputFor($file)
     {
-        $this->seeElement('input', ['type' => 'file', 'name' => $file, 'aria-disabled' => 'true']);
+        $this->seeElement('input', ['type' => 'file', 'name' => $file]);
     }
 
     /**

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -465,3 +465,12 @@ Feature: form to update dataset details
     And I should not see "Open Private URL"
 
 
+  @wip @issue-1812 @mockup
+  Scenario: Navigating mockup tables does not generate errors
+    Given I am on "/adminDataset/update/id/5"
+    When I press the button "Create/Reset Private URL"
+    And I wait "1" seconds
+    And I press the button "Files"
+    And I press the button "Next >"
+    And I wait "1" seconds
+    Then I should see "Parrot.k31.NetworkTest.txt"

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -465,8 +465,8 @@ Feature: form to update dataset details
     And I should not see "Open Private URL"
 
 
-  @wip @issue-1812 @mockup
-  Scenario: Navigating mockup tables does not generate errors
+  @ok @issue-1812 @mockup
+  Scenario: Navigating mockup page tables does not generate errors
     Given I am on "/adminDataset/update/id/5"
     When I press the button "Create/Reset Private URL"
     And I wait "1" seconds

--- a/tests/acceptance/DatasetUpload.feature
+++ b/tests/acceptance/DatasetUpload.feature
@@ -10,10 +10,9 @@ Scenario: Display all the fields for uploading dataset spreadsheet
   When I am on "/datasetSubmission/upload"
   Then I should see "Dataset Upload"
   And I should see a check-box field "agree-checkbox"
-  And I should see "You must agree to the terms and conditions before continuing"
   And I should see "Excel File"
-  And I should see a disabled file input for "xls"
-  And I should see a disabled submit button "Upload New Dataset"
+  And I should see a file input for "xls"
+  And I should see a submit button "Upload New Dataset"
 
 @ok
 Scenario: Upload dataset metadata with an Excel spreadsheet


### PR DESCRIPTION
# Pull request for issue: #1812 

This is a pull request for the following functionalities:

* Navigating tables  on mockup pages does not generate errors

## How to test?

### Locally

Checkout this branch on your local environment. Then:

* Execute `./up.sh`
* Navigate to: http://gigadb.gigasciencejournal.com/adminDataset/update/id/5
* Click on "Create/Reset Private URL"
* On the mockup page, switch to the Files tab
* Observe that you can navigate through the multiple pages

### On your staging environment on AWS


First build your AWS environment from this branch by following:
docs/developers/SETUP_AWS_ENVIRONMENTS.md

Then:

* Navigate to: /adminDataset/update/id/2420
* Click on "Create/Reset Private URL"
* On the mockup page, switch to the Samples tab
* Observe that you can navigate through the multiple pages


## How have functionalities been implemented?

The error occurs because the URL used in the links in the table navigation pager have incorrectly specified parts,
So that when the user click on then, you get the 400 bad request HTTP error.

The problem comes from a compounding of several issues:
* The path to token based URLs was not properly configure in UrlManager
* SiteLinkPager used to create pagination links was therefore generating erroneous URLS
* DatasetController view action was not parsing the multiple formats a token based URL can have

The full fix consists in:

* Change the URLs/controller mapping rules to properly represent a paginated mockup page URL in `ops/configuration/yii-conf/main.php.dist`
* Update the View action in `protected/controllers/DatasetController.php` so that the regex that detect that the request is for a mockup page still works when pagination parts are added to the URL 

## Any issues with implementation?

N/a

## Any changes to automated tests?

Added a test scenario to reproduce the issue in `tests/acceptance/AdminDatasetForm.feature`

## Any changes to documentation?

N/a

## Any technical debt repayment?

* Upload status "ImportFromEM" (which was the status of the local example and remote example) was not in the list of status considered as "draft" type  in `protected/components/DatasetPageSettings.php` which will cause problem with creating mockup
* Fixed the `DatasetUpload.feature`'s failing scenario due to PR #1744 having been pushed, approved and merged without running its automated tests
 
## Any improvements to CI/CD pipeline?

N/a


