### PR TITLE
fix: update projects url and name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1290: Update and save project url and name
 - Fix #2187: Make FAQ buttons responsive
 - Fix #2116: Make authors ordered as shown in the DOI page in the readme file
 

--- a/protected/models/Project.php
+++ b/protected/models/Project.php
@@ -15,7 +15,9 @@
  */
 class Project extends CActiveRecord
 {
-	/**
+    const SCENARIO_CREATE = 'create';
+
+    /**
 	 * Returns the static model of the specified AR class.
 	 * @param string $className active record class name.
 	 * @return Project the static model class
@@ -42,11 +44,12 @@ class Project extends CActiveRecord
 		// will receive user inputs.
 		return array(
 			array('url', 'required'),
-                        array('url', 'url','message'=>'Please check the URL format'),
+            array('url', 'url','message'=>'Please check the URL format'),
 			array('url', 'length', 'max'=>128),
 			array('name', 'length', 'max'=>255),
 			array('image_location', 'length', 'max'=>100),
-                        array('url','check_duplicate'),
+            array('url', 'unique', 'message' => 'This url already exists.'),
+            array('name', 'unique', 'message' => 'This name already exists.'),
 			// The following rule is used by search().
 			// Please remove those attributes that should not be searched.
 			array('id, url, name, image_location', 'safe', 'on'=>'search'),
@@ -107,21 +110,4 @@ class Project extends CActiveRecord
         }
         return $list;
     }
-    
-    function check_duplicate(){
-        
-        
-        $db_url= Project::model()->findBySql("select name from project where url='$this->url'");
-        
-        if($db_url !=null){
-        $this->addError('url','Duplicate URL');}
-        
-        $db_name= Project::model()->findBySql("select url from project where name='$this->name'");
-       
-        if($db_name !=null){
-        $this->addError('name','Duplicate Project Name');}
-        
-             
-    }
-
 }

--- a/tests/acceptance/AdminProject.feature
+++ b/tests/acceptance/AdminProject.feature
@@ -1,0 +1,15 @@
+@ok-can-offline
+Feature: form to manage project
+  As a curator
+  I want to be able to update a projects details without bugs
+  So that I can keep the project details upto date
+
+  Background:
+    Given I have signed in as admin
+
+  @ok
+  Scenario: Can update image location
+    Given I am on "/adminProject/update/id/2"
+    When I fill in the field of "name" "Project[image_location]" with "https://test/images/projects/genome_10k/G10Klogo.jpg"
+    And I press the button "Save"
+    Then I should see "View Project #2"

--- a/tests/functional/AdminProjectCest.php
+++ b/tests/functional/AdminProjectCest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+class AdminProjectCest
+{
+    /**
+     * @param FunctionalTester $I
+     *
+     * @return void
+     */
+    public function tryToUpdateNameAndUrlOfAProject(FunctionalTester $I)
+    {
+        $previousUrl = $I->grabFromDatabase('project', 'url', ['id' => 2]);
+        $previousName = $I->grabFromDatabase('project', 'name', ['id' => 2]);
+
+        //Login as admin
+        $I->amOnPage('/site/login');
+        $I->submitForm('form.form-horizontal', [
+                'LoginForm[username]' => 'admin@gigadb.org',
+                'LoginForm[password]' => 'gigadb'
+            ]
+        );
+        $I->canSee('Admin');
+        $I->click('Admin');
+        $I->click('Projects');
+        $I->canSee('Create New Project');
+        $I->seeElement('.table tr:first-child td:last-child a.icon-update');
+        $I->click('.table tr:first-child td:last-child a.icon-update');
+
+        $I->fillField("#Project_url", 'http://www.genome10kmodified.org/');
+        $I->fillField('#Project_name', 'modified name');
+        $I->click('Save');
+
+        $I->assertNotEquals($previousUrl, $I->grabFromDatabase('project', 'url', ['id' => 2]));
+        $I->assertNotEquals($previousName, $I->grabFromDatabase('project', 'name', ['id' => 2]));
+    }
+
+    /**
+     * @param FunctionalTester $I
+     *
+     * @return void
+     */
+    public function tryToUpdateOnlyImageLocation(FunctionalTester $I)
+    {
+        $previousImageLocation = $I->grabFromDatabase('project', 'image_location', ['id' => 2]);
+        $previousUrl = $I->grabFromDatabase('project', 'url', ['id' => 2]);
+        $previousName = $I->grabFromDatabase('project', 'name', ['id' => 2]);
+
+        //Login as admin
+        $I->amOnPage('/site/login');
+        $I->submitForm('form.form-horizontal', [
+                'LoginForm[username]' => 'admin@gigadb.org',
+                'LoginForm[password]' => 'gigadb'
+            ]
+        );
+
+        $I->amOnPage('/adminProject/update/id/2');
+        $I->fillField('#Project_image_location', 'http://www.modified.org/');
+        $I->click('Save');
+
+        $I->assertEquals($previousUrl, $I->grabFromDatabase('project', 'url', ['id' => 2]));
+        $I->assertEquals($previousName, $I->grabFromDatabase('project', 'name', ['id' => 2]));
+        $I->assertNotEquals($previousImageLocation, $I->grabFromDatabase('project', 'image_location', ['id' => 2]));
+    }
+
+    /**
+     * @param FunctionalTester $I
+     *
+     * @return void
+     */
+    public function testCantUpdateProjectWithDuplicatedUrlAndName(FunctionalTester $I)
+    {
+        //Login as admin
+        $I->amOnPage('/site/login');
+        $I->submitForm('form.form-horizontal', [
+                'LoginForm[username]' => 'admin@gigadb.org',
+                'LoginForm[password]' => 'gigadb'
+            ]
+        );
+
+        $I->seeInDatabase('project', [
+            'id'   => 2,
+            'url'  => 'http://www.genome10k.org/',
+            'name' => 'Genome 10K'
+        ]);
+
+        $I->seeInDatabase('project', [
+            'id'   => 3,
+            'url'  => 'http://avian.genomics.cn/en/index.html ',
+            'name' => 'The Avian Phylogenomic Project'
+        ]);
+
+        $I->amOnPage('/adminProject/update/id/2');
+
+        $I->fillField('#Project_url', 'http://avian.genomics.cn/en/index.html ');
+        $I->fillField('#Project_name', 'The Avian Phylogenomic Project');
+
+        $I->click('Save');
+
+        $I->canSee('This name already exists.');
+        $I->canSee('This url already exists.');
+    }
+}


### PR DESCRIPTION
# Pull request for issue: #1290  and #375 (duplicate?)

This is a pull request for the following functionalities:

update name and url without error

## How to test?

- log as admin
- click 'admin'
- click 'Projects'
- click update
- update name and/or url
- click save 

test added: AdminProjectCest

## How have functionalities been implemented?

Limit the constraint 'check duplicate' to juste the creation action

## Any changes to automated tests?

AdminProjectCest added

