### PR TITLE
Fix 1854 stay on form after updating a dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1854: Stay on form after updating a dataset
+
 ## v4.4.16 - 2025-08-15 - 6e04c0b9e -
 
 - Fix #2428: AdminUserController should target AdminUserController when validating or rejecting a claim

--- a/features/dataset-admin.feature
+++ b/features/dataset-admin.feature
@@ -7,53 +7,53 @@ Background:
 	Given Gigadb web site is loaded with "gigadb_testdata.pgdmp" data
 	And default admin user exists
 
-@ok
-Scenario: Keywords
-	Given I sign in as an admin
-	And I am on "/adminDataset/update/id/210"
-	When I fill in the "keywords" field with "abcd, a four part keyword, my_keyword, my-keyword, my dodgy tag<script>alert('xss!');</script>"
-	And I follow "Save"
-	Then I should see links to "Keyword search"
-	| Keyword search |
-	| abcd |
-	| a four part keyword |
-	| my_keyword |
-	| my-keyword |
-	And I should not see links to "Keyword search"
-	| Keyword search |
-	| my dodgy tag<script>alert('xss!');</script> |
-	| my dodgy tag |
+	@ok
+	Scenario: Keywords
+		Given I sign in as an admin
+		And I am on "/adminDataset/update/id/210"
+		When I fill in the "keywords" field with "abcd, a four part keyword, my_keyword, my-keyword, my dodgy tag<script>alert('xss!');</script>"
+		Then I should see "Updated successfully!"
+		And I go to "/dataset/view/id/100002"
+		Then I should see links to "Keyword search"
+		| Keyword search |
+		| abcd |
+		| a four part keyword |
+		| my_keyword |
+		| my-keyword |
+		And I should not see links to "Keyword search"
+		| Keyword search |
+		| my dodgy tag<script>alert('xss!');</script> |
+		| my dodgy tag |
 
-
-@ok @javascript @ci-js
-Scenario: redirect
-	Given I sign in as an admin
-	And I am on "/adminDataset/update/id/210"
-	When I fill in "urltoredirect" with "http://gigadb.test/dataset/100002/token/banasdfsaf74hsfds"
-	And I press "Save"
-	And I go to "/dataset/100002/token/banasdfsaf74hsfds"
-	Then the url should be "/dataset/100002/token/banasdfsaf74hsfds"
+	@ok @javascript @ci-js
+	Scenario: redirect
+		Given I sign in as an admin
+		And I am on "/adminDataset/update/id/210"
+		When I fill in "urltoredirect" with "http://gigadb.test/dataset/100002/token/banasdfsaf74hsfds"
+		And I press "Save"
+		And I go to "/dataset/100002/token/banasdfsaf74hsfds"
+		Then the url should be "/dataset/100002/token/banasdfsaf74hsfds"
 	# And I take a screenshot named "redirect notice page (before)"
-	And I should see "Redirect notice"
-	And I wait "10" seconds
+		And I should see "Redirect notice"
+		And I wait "10" seconds
 	# And I take a screenshot named "redirect notice page (after)"
-	And I should not see "Redirect notice"
+		And I should not see "Redirect notice"
 
-@ok
-Scenario: new dataset with mandatory fields filled in
-	Given I sign in as an admin
-	And I am on "/adminDataset/admin"
-	When I follow "Create Dataset"
-	And I select "user@gigadb.org" from "Submitter"
-	And I fill in "Title" with "My dataset"
-	And I fill in "Dataset Size" with "345345324235"
-	And I fill in "Source" with "Wikimedia"
-	And I fill in "License" with "CC0"
-	And I fill in "Photographer" with "Anonymous"
-	And I fill in "DOI" with "100900"
-	And I fill in "Ftp Site" with "ftp.genomics.cn"
-	And I press "Create"
-	Then the response should contain "My Dataset"
-	And the response should contain "10.5524/100900"
-	And I should see a button "Your dataset?"
-	And the url should match the pattern "/\/dataset\/100900\/token\//"
+	@ok
+	Scenario: new dataset with mandatory fields filled in
+		Given I sign in as an admin
+		And I am on "/adminDataset/admin"
+		When I follow "Create Dataset"
+		And I select "user@gigadb.org" from "Submitter"
+		And I fill in "Title" with "My dataset"
+		And I fill in "Dataset Size" with "345345324235"
+		And I fill in "Source" with "Wikimedia"
+		And I fill in "License" with "CC0"
+		And I fill in "Photographer" with "Anonymous"
+		And I fill in "DOI" with "100900"
+		And I fill in "Ftp Site" with "ftp.genomics.cn"
+		And I press "Create"
+		Then the response should contain "My Dataset"
+		And the response should contain "10.5524/100900"
+		And I should see a button "Your dataset?"
+		And the url should match the pattern "/\/dataset\/100900\/token\//"

--- a/protected/components/AttributeService.php
+++ b/protected/components/AttributeService.php
@@ -46,26 +46,15 @@ class AttributeService extends CApplicationComponent
     public function replaceKeywordsForDatasetIdWithString($dataset_id, $keyword_string)
     {
         $sanitized_keywords = trim(filter_var($keyword_string, FILTER_SANITIZE_FULL_SPECIAL_CHARS));
-        $transaction = Yii::app()->db->getCurrentTransaction();
-        if ($transaction !== null) {
-            // Transaction already started outside
-            $transaction = null;
-        } else {
-            // There is no outer transaction, creating a local one
-            $transaction = Yii::app()->db->beginTransaction();
-        }
-
+        $transaction = Yii::app()->db->beginTransaction();
 
         try {
             $this->dataset_dao->removeKeywordsFromDatabaseForDatasetId($dataset_id);
             $this->dataset_dao->addKeywordsToDatabaseForDatasetIdAndString($dataset_id, $sanitized_keywords);
-            if ($transaction !== null) {
-                $transaction->commit();
-            }
+
+            $transaction->commit();
         } catch (Exception $e) {
-            if ($transaction !== null) {
-                $transaction->rollback();
-            }
+            $transaction->rollback();
         }
     }
 }

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -281,23 +281,11 @@ class AdminDatasetController extends Controller
                 $urlToRedirectDatasetAttribute->save();
             }
 
-            if ($hasPartialError) {
-                 $this->redirect(array('/adminDataset/update/id/' . $model->id));
+            if (!$hasPartialError) {
+                Yii::app()->user->setFlash('updateSuccess', 'Updated successfully!');
             }
 
-            Yii::app()->user->setFlash('updateSuccess', 'Updated successfully!');
-            switch ($datasetPageSettings->getPageType()) {
-                case "draft":
-                    $this->redirect('/adminDataset/admin/');
-                    break;
-                case "public":
-                    $this->redirect('/dataset/' . $model->identifier);
-                    break;
-                case "hidden":
-                    $this->redirect(array('/adminDataset/update/id/' . $model->id));
-                    break;
-            }
-
+            $this->redirect(array('/adminDataset/update/id/' . $model->id));
         } else {
             Yii::app()->user->setFlash('updateError', 'Fail to update!');
             Yii::log(print_r($model->getErrors(), true), 'error');

--- a/protected/models/Attributes.php
+++ b/protected/models/Attributes.php
@@ -67,7 +67,8 @@ class Attributes extends CActiveRecord
 		return array(
 			'exp_attributes' => array(self::HAS_MANY, 'ExpAttributes', 'attribute_id'),
 			'sample_attributes' => array(self::HAS_MANY, 'SampleAttribute', 'attribute_id'),
-			'dataset_attributes' => array(self::HAS_MANY, 'DatasetAttributes', 'attribute_id'),
+            'datasets' => array(self::MANY_MANY, 'Dataset', 'dataset_attributes(attribute_id, dataset_id)'),
+            'dataset_attributes' => array(self::HAS_MANY, 'DatasetAttributes', 'attribute_id'),
 			'file_attributes' => array(self::HAS_MANY, 'FileAttributes', 'attribute_id'),
 		);
 	}

--- a/protected/models/Dataset.php
+++ b/protected/models/Dataset.php
@@ -126,8 +126,8 @@ class Dataset extends CActiveRecord
             'datasetFunders'=>array(self::HAS_MANY, 'DatasetFunder', 'dataset_id'),
             'funders' =>array(self::HAS_MANY, 'Funder', 'dataset_funder(dataset_id, funder_id)'),
             'datasetLogs'=>array(self::HAS_MANY, 'DatasetLog', 'dataset_id'),
-            'datasetAttributes' => array(self::HAS_MANY, 'DatasetAttributes', 'dataset_id'),
             'attributes' => array(self::MANY_MANY, 'Attributes', 'dataset_attributes(dataset_id, attribute_id)'),
+            'datasetAttributes' => array(self::HAS_MANY, 'DatasetAttributes', 'dataset_id'),
         );
     }
 

--- a/protected/models/DatasetAttributesFactory.php
+++ b/protected/models/DatasetAttributesFactory.php
@@ -2,7 +2,7 @@
 
 class DatasetAttributesFactory
 {
-	protected $da;
+	protected DatasetAttributes $da;
 
 	public function create()
 	{

--- a/protected/tests/functional/AdminDatasetUpdateActionTest.php
+++ b/protected/tests/functional/AdminDatasetUpdateActionTest.php
@@ -82,7 +82,6 @@ class AdminDatasetUpdateActionTest extends FunctionalTesting
         $this->session->visit($this->url);
         $this->session->getPage()->selectFieldOption("Dataset_upload_status", "Rejected");
         $this->session->getPage()->pressButton("Save");
-        $this->session->visit($this->url);
         $this->assertTrue($this->session->getPage()->hasContent($curationEntry));
         
 
@@ -105,7 +104,6 @@ class AdminDatasetUpdateActionTest extends FunctionalTesting
         $this->session->visit($this->url);
         $this->session->getPage()->selectFieldOption("Dataset_upload_status", "Submitted");
         $this->session->getPage()->pressButton("Save");
-        $this->session->visit($this->url);
         $this->assertTrue($this->session->getPage()->hasContent($curationEntry));
         
 

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -642,3 +642,10 @@ Feature: form to update dataset details
     And I am on "/adminDataset/update/id/5"
     Then I can see the option "Published" selected for "Dataset_upload_status"
     And I should see "Status changed to Published"
+
+  @ok
+  Scenario: We stay on udate page after updating a published dataset
+    Given I am on "/adminDataset/update/id/5"
+    When I select "Published" from the field "Dataset_upload_status"
+    And I press the button "Save"
+    Then I should see "Updated Successfully"

--- a/tests/functional/AdminDatasetCest.php
+++ b/tests/functional/AdminDatasetCest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+class AdminDatasetCest
+{
+    /**
+     * @param FunctionalTester     $I
+     * @param \Codeception\Example $status
+     *
+     * @return void
+     * @dataProvider statusDataProvider
+     *
+     */
+    public function tryToStayOnUpdatePageWhenUpdateStatus(FunctionalTester $I, \Codeception\Example $status)
+    {
+        //Login as admin
+        $I->amOnPage('/site/login');
+        $I->submitForm('form.form-horizontal', [
+                'LoginForm[username]' => 'admin@gigadb.org',
+                'LoginForm[password]' => 'gigadb'
+            ]
+        );
+        $I->canSee('Admin');
+        $I->amOnPage('adminDataset/update/id/8');
+        $I->selectOption('#Dataset_upload_status', $status[0]);
+        $I->click('Save');
+        $I->seeCurrentUrlEquals('/adminDataset/update/id/8');
+    }
+
+    protected function statusDataProvider()
+    {
+        return [
+            ['AssigningFTPbox'],
+            ['Private'],
+            ['Published'],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull request for issue: #1854 #2050 

This is a pull request for the following functionalities:

* after updating a dataset, you will stay on the form

## How to test?

- connect as admin
- click on dataset
- pick one and click update
- update something and save
- stay on the form

## Any changes to automated tests?

AdminDatasetCest added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where users were redirected away from the dataset update form after saving changes; users now remain on the update page and see a success message after updating a dataset.

* **Tests**
  * Added new acceptance and functional tests to verify that users stay on the dataset update page after saving changes and receive appropriate success feedback.
  * Improved test formatting and removed redundant steps for better reliability and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->