### PR TITLE
Increase rate limits to allow curators workflow on admin forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix: Enable curators to save Gigadb forms from many browser tabs at once
 - Feat #1840: Make create readme tool available as part of postUpload script
 
 ## v4.3.0 - 2024-06-25 - 9cf91f224

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Fix: Enable curators to save Gigadb forms from many browser tabs at once
+- Fix #1912: Enable curators to save Gigadb forms from many browser tabs at once
 - Feat #1840: Make create readme tool available as part of postUpload script
 
 ## v4.3.0 - 2024-06-25 - 9cf91f224

--- a/ops/configuration/nginx-conf/nginx.conf
+++ b/ops/configuration/nginx-conf/nginx.conf
@@ -41,7 +41,7 @@ http {
   charset UTF-8;
 
   limit_req_zone $binary_remote_addr zone=gigadbsearch:1m rate=5r/s;
-  limit_req_zone $binary_remote_addr zone=gigadb_php_burstrate:10m rate=5r/s;
+  #limit_req_zone $binary_remote_addr zone=gigadb_php_burstrate:10m rate=5r/s;
   limit_conn_zone $binary_remote_addr zone=gigadb_php_periplimit:10m;
   # see http://kbeezie.com/securing-nginx-php/2/
 

--- a/ops/configuration/nginx-conf/nginx.conf
+++ b/ops/configuration/nginx-conf/nginx.conf
@@ -41,7 +41,8 @@ http {
   charset UTF-8;
 
   limit_req_zone $binary_remote_addr zone=gigadbsearch:1m rate=5r/s;
-  limit_conn_zone $binary_remote_addr zone=phplimit:1m;
+  limit_req_zone $binary_remote_addr zone=gigadb_php_burstrate:10m rate=5r/s;
+  limit_conn_zone $binary_remote_addr zone=gigadb_php_periplimit:10m;
   # see http://kbeezie.com/securing-nginx-php/2/
 
   map $http_upgrade $connection_upgrade {

--- a/ops/configuration/nginx-conf/nginx.conf
+++ b/ops/configuration/nginx-conf/nginx.conf
@@ -41,7 +41,6 @@ http {
   charset UTF-8;
 
   limit_req_zone $binary_remote_addr zone=gigadbsearch:1m rate=5r/s;
-  #limit_req_zone $binary_remote_addr zone=gigadb_php_burstrate:10m rate=5r/s;
   limit_conn_zone $binary_remote_addr zone=gigadb_php_periplimit:10m;
   # see http://kbeezie.com/securing-nginx-php/2/
 

--- a/ops/configuration/nginx-conf/phplimit.conf.enabled
+++ b/ops/configuration/nginx-conf/phplimit.conf.enabled
@@ -1,1 +1,2 @@
-limit_conn phplimit 5;
+limit_conn gigadb_php_periplimit 100;
+limit_req zone=gigadb_php_burstrate burst=50;

--- a/ops/configuration/nginx-conf/phplimit.conf.enabled
+++ b/ops/configuration/nginx-conf/phplimit.conf.enabled
@@ -1,2 +1,2 @@
 limit_conn gigadb_php_periplimit 100;
-limit_req zone=gigadb_php_burstrate burst=50;
+#limit_req zone=gigadb_php_burstrate burst=50;

--- a/ops/configuration/nginx-conf/phplimit.conf.enabled
+++ b/ops/configuration/nginx-conf/phplimit.conf.enabled
@@ -1,2 +1,1 @@
 limit_conn gigadb_php_periplimit 100;
-#limit_req zone=gigadb_php_burstrate burst=50;


### PR DESCRIPTION
# Pull request for issue: #1912 

This is a pull request for the following functionalities:

* Increase the PHP connection limit per ip from 5 to 100

## How to test?

Build your AWS environment from this branch by following:  
`docs/developers/SETUP_AWS_ENVIRONMENTS.md`

Navigate to the dataset in your AWS deployment URL for GigaDB to preload the cache, so caching state has no influence during load testing:
```
$ curl <your aws deployment url for GigaDB>/dataset/102535
```

Then run two sessions of load testing against your AWS staging deployment

First, well above the original 5 limit, but below the new limit
```
$  ab -n 300 -c 50 <your aws deployment url for GigaDB>/dataset/102535
```

Second, load test above the new limit:

```
$ ab -n 300 -c 150 <your aws deployment url for GigaDB>/dataset/102535 
```

In the first case, all requests should be successful.
In the second case, you should see request failures.




## How have functionalities been implemented?

Increase the rate limit for the `gigadb_php_periplimit` zone within the PHP scripts location in Nginx.

## Any issues with implementation?

N/a

## Any changes to automated tests?

~Commented an acceptance test scenario for `tests/acceptance/DatasetUpload.feature` which is failing on Upstream pipeline for the develop branch.
The fix to that test is coming with PR #1907~

## Any changes to documentation?

N/a

## Any technical debt repayment?

N/a

## Any improvements to CI/CD pipeline?

N/a
