### PR TITLE
Fix database updates to md5 checksum values and file sizes for dataset files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Fix #1845: Provide better md5 and sizes database updates to dataset files
+- Fix #1845: Use file path to update md5 values and file sizes in database
 - Fix #1812: Navigating tables on mockup pages does not generate errors
 - Fix #1801: Refresh materialized views daily using cron job and drop existing triggers
 - Feat #1143: Open external links in new browser tabs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1845: Provide better md5 and sizes database updates to dataset files
 - Fix #1812: Navigating tables on mockup pages does not generate errors
 - Fix #1801: Refresh materialized views daily using cron job and drop existing triggers
 - Feat #1143: Open external links in new browser tabs

--- a/data/dev/file.csv
+++ b/data/dev/file.csv
@@ -330,7 +330,7 @@ id,dataset_id,name,location,extension,size,description,date_stamp,format_id,type
 80844,144,GD_readme.pdf,https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100094/GD_readme.pdf,pdf,93218,Summary of uploaded files in the GD repository.,2014-06-06,3,1,"",,1,
 80845,144,CS-master.tar.gz,https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100094/CS-master.tar.gz,tar,117066,compressed archive of the Analysis scripts (CS) files,2014-06-06,17,113,"",,2,
 80846,144,GD-master.tar.gz,https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100094/GD-master.tar.gz,tar,171531316,compressed archive of the mock data and scripts GD files,2014-06-06,17,125,"",,4,
-87516,200,readme.txt,https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100142/readme.txt,txt,2351,"",2015-04-29,1,1,,,2,
+87516,200,readme_100142.txt,https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/dev/pub/10.5524/100001_101000/100142/readme_100142.txt,txt,1648,"",2015-04-29,1,1,,,2,
 87517,200,Diagram-ALL-FIELDS-Check-annotation.jpg,https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100142/Diagram-ALL-FIELDS-Check-annotation.jpg,jpg,55547,image usedin manuscript,2015-04-29,6,41,,,3,
 87540,200,SRAmetadb.zip,https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100142/SRAmetadb.zip,zip,383892184,Archival copy of SRA metadata at time of experiment,2015-04-29,6,7,,,2,
 87542,200,Diagram-SRA-Study-Experiment-Joined-probing.jpg,https://ftp.cngb.org/pub/gigadb/pub/10.5524/100001_101000/100142/Diagram-SRA-Study-Experiment-Joined-probing.jpg,jpg,81717,"",2015-04-30,6,41,"",,0,

--- a/gigadb/app/tools/excel-spreadsheet-uploader/README.md
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/README.md
@@ -41,6 +41,40 @@ You should see the dataset admin page for the new `Dataset 100679`. Also,
 checkout the `dataset`, ``file``, and ``sample`` tables (and their connecting 
 tables) in the PostgreSQL database.
 
+Running `execute.sh` will only ingest information relating to the study, samples
+and files that are contained in the Excel spreadsheet into the database. To add
+md5 checksum values and file size information, the `postUpload.sh` script has to
+be executed. It is possible to run the tools used in the post upload script on
+their own. For example, to update files with md5 checksum values:
+```
+$ pwd
+/path/to/gigadb-website
+$ docker-compose run --rm  test ./protected/yiic files updateMD5FileAttributes --doi=100006
+Saved md5 file attribute with id: 10674
+Saved md5 file attribute with id: 10672
+Saved md5 file attribute with id: 10673
+Saved md5 file attribute with id: 10671
+Saved md5 file attribute with id: 10670
+Saved md5 file attribute with id: 10669
+Saved md5 file attribute with id: 10675
+```
+
+Check md5 values have been updated for dataset 100006:
+```
+$ docker-compose run --rm test psql -h database -p 5432 -U gigadb gigadb -c "select file.name, file_attributes.value from file, file_attributes where file.dataset_id=8 and file_attributes.attribute_id=605 and file.id = file_attributes.file_id;"
+                  name                  |              value               
+----------------------------------------+----------------------------------
+ Pygoscelis_adeliae.RepeatMasker.out.gz | 5afc9d8348bf4b52ee6e9c2bae9fd542
+ Pygoscelis_adeliae.cds.gz              | bd9bed43475eaa22b6ab62b9fb7a3909
+ Pygoscelis_adeliae.fa.gz               | 43b35c4e828bed20dbb071d2c5a40f17
+ Pygoscelis_adeliae.gff.gz              | 47b8f47ca31cfd06d5ad62ceceb99860
+ Pygoscelis_adeliae.pep.gz              | 23c3241e6bc362d659a4b589c8d9e01c
+ readme.txt                             | 88888888888888888888888888888888
+ Pygoscelis_adeliae.scaf.fa.gz          | 55c764721558086197bfbd663e1567a6
+(7 rows)
+```
+
+To test update of file sizes, documentation is available in [files-metadata-console/README.md](../files-metadata-console/README.md).
 
 ## Remote execution
 
@@ -49,7 +83,7 @@ To load the spreadsheet in GigaDB instance deployed on the cloud, you need to:
 2. Change directory to ``gigadb-website-develop/gigadb/app/tools/excel-spreadsheet-uploader/``
 3. Ensure the spreadsheet you want to process is in the ``uploadDir`` directory 
    (see below)
-4. Run the ``execute.sh`` script as described above
+4. Run the ``datasetUpload.sh`` script as described above
 
 >Note: the setup script is already run when the bastion playbook was executed to provision that environment
 

--- a/gigadb/app/tools/files-metadata-console/components/DatasetFilesUpdater.php
+++ b/gigadb/app/tools/files-metadata-console/components/DatasetFilesUpdater.php
@@ -62,15 +62,15 @@ final class DatasetFilesUpdater extends Component
             }
             $tokens = explode("\t", $line);
             $size = (int)$tokens[0];
-            $filename = ltrim($tokens[1], './');
-            $filename = $this->doi . '/' . $filename;
+            $filepath = ltrim($tokens[1], './');
+            $filepath = $this->doi . '/' . $filepath;
             # Find file to be updated
             $file = File::find()
                 ->where(['dataset_id' => $d->id])
                 # Use % wildcard to ensure location ends with filename and
                 # another file with same filename in different directory is not
                 # accidentally updated
-                ->where("location LIKE :substr", array(':substr' => "%$filename"))
+                ->where("location LIKE :substr", array(':substr' => "%$filepath"))
                 ->one();
             if($file) {
                 # Update file size

--- a/gigadb/app/tools/files-metadata-console/components/DatasetFilesUpdater.php
+++ b/gigadb/app/tools/files-metadata-console/components/DatasetFilesUpdater.php
@@ -64,18 +64,18 @@ final class DatasetFilesUpdater extends Component
             $size = (int)$tokens[0];
             $filename = ltrim($tokens[1], './');
             $filename = $this->doi . '/' . $filename;
-            
-            # Find file id for file to be updated
-            $result = (new \yii\db\Query())
-                ->select('id')
-                ->from('file')
-                ->where(['like', 'location', $filename])
+            # Find file to be updated
+            $file = File::find()
+                ->where(['dataset_id' => $d->id])
+                # Use % wildcard to ensure location ends with filename and
+                # another file with same filename in different directory is not
+                # accidentally updated
+                ->where("location LIKE :substr", array(':substr' => "%$filename"))
                 ->one();
-            if($result) {
+            if($file) {
                 # Update file size
-                $f = File::find()->where(['id' => $result['id'], 'dataset_id' => $d->id])->one();
-                $f->size = $size;
-                if ($f->save()) {
+                $file->size = $size;
+                if ($file->save()) {
                     $success++;
                 }
             }

--- a/gigadb/app/tools/files-metadata-console/tests/functional/CheckValidURLsCest.php
+++ b/gigadb/app/tools/files-metadata-console/tests/functional/CheckValidURLsCest.php
@@ -16,6 +16,9 @@ class CheckValidURLsCest
         "https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/dev/pub/10.5524/100001_101000/100006/",
     ];
 
+    /**
+     * @skip Skip test due to CNGB FTP server not in use anymore
+     */
     public function tryReportIssues(\FunctionalTester $I): void {
         $expectedIssues = [
             "Resource cannot be downloaded, not found or forbidden (4xx)",
@@ -45,6 +48,9 @@ class CheckValidURLsCest
         }
     }
 
+    /**
+     * @skip Skip test due to CNGB FTP server not in use anymore
+     */
     public function tryNoIssueToReport(\FunctionalTester $I): void {
         $testWebClient = new Client([ 'allow_redirects' => false ]);
         $component = new FilesURLsFetcher(["doi" => "100142", "webClient" => $testWebClient]);

--- a/gigadb/app/tools/files-metadata-console/tests/functional/CheckValidURLsCest.php
+++ b/gigadb/app/tools/files-metadata-console/tests/functional/CheckValidURLsCest.php
@@ -16,9 +16,6 @@ class CheckValidURLsCest
         "https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/dev/pub/10.5524/100001_101000/100006/",
     ];
 
-    /**
-     * @skip Skip test due to CNGB FTP server not in use anymore
-     */
     public function tryReportIssues(\FunctionalTester $I): void {
         $expectedIssues = [
             "Resource cannot be downloaded, not found or forbidden (4xx)",
@@ -48,9 +45,6 @@ class CheckValidURLsCest
         }
     }
 
-    /**
-     * @skip Skip test due to CNGB FTP server not in use anymore
-     */
     public function tryNoIssueToReport(\FunctionalTester $I): void {
         $testWebClient = new Client([ 'allow_redirects' => false ]);
         $component = new FilesURLsFetcher(["doi" => "100142", "webClient" => $testWebClient]);

--- a/gigadb/app/tools/files-metadata-console/tests/functional/UpdateFileSizeCest.php
+++ b/gigadb/app/tools/files-metadata-console/tests/functional/UpdateFileSizeCest.php
@@ -17,7 +17,7 @@ class UpdateFileSizeCest
     public function tryFetchFileSizeFromFilesUrl(\FunctionalTester $I): void
     {
         $expectedLengthList = [
-            1641,
+            1648,
             0,
             0,
         ];

--- a/gigadb/app/tools/files-metadata-console/tests/functional/UpdateFileSizeCest.php
+++ b/gigadb/app/tools/files-metadata-console/tests/functional/UpdateFileSizeCest.php
@@ -14,9 +14,6 @@ class UpdateFileSizeCest
         "https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/dev/pub/10.5524/100001_101000/100142/",
     ];
 
-    /**
-     * @skip Skip test due to CNGB FTP server not in use anymore
-     */
     public function tryFetchFileSizeFromFilesUrl(\FunctionalTester $I): void
     {
         $expectedLengthList = [
@@ -46,9 +43,6 @@ class UpdateFileSizeCest
         }
     }
 
-    /**
-     * @skip Skip test due to CNGB FTP server not in use anymore
-     */
     public function tryUpdateFileSizeWhenContentLengthInBytes(\FunctionalTester $I): void
     {
         $webClient = new Client([ 'allow_redirects' => false ]);

--- a/gigadb/app/tools/files-metadata-console/tests/functional/UpdateFileSizeCest.php
+++ b/gigadb/app/tools/files-metadata-console/tests/functional/UpdateFileSizeCest.php
@@ -14,6 +14,9 @@ class UpdateFileSizeCest
         "https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/dev/pub/10.5524/100001_101000/100142/",
     ];
 
+    /**
+     * @skip Skip test due to CNGB FTP server not in use anymore
+     */
     public function tryFetchFileSizeFromFilesUrl(\FunctionalTester $I): void
     {
         $expectedLengthList = [
@@ -43,6 +46,9 @@ class UpdateFileSizeCest
         }
     }
 
+    /**
+     * @skip Skip test due to CNGB FTP server not in use anymore
+     */
     public function tryUpdateFileSizeWhenContentLengthInBytes(\FunctionalTester $I): void
     {
         $webClient = new Client([ 'allow_redirects' => false ]);

--- a/protected/commands/FilesCommand.php
+++ b/protected/commands/FilesCommand.php
@@ -62,15 +62,16 @@ class FilesCommand extends CConsoleCommand
                 // Only parse lines with content in md5 file
                 if($tokens[0] !== "") {
                     $md5_value = $tokens[0];
-                    $filename = basename($tokens[1]);
-                    if ($filename === "$doi.md5")  // Ignore $doi.md5 file
+                    # Make use of whole file path
+                    $filepath = ltrim($tokens[1], './');
+                    if ($filepath === "$doi.md5")  // Ignore $doi.md5 file
                         continue;
 
-                    # Update file_attributes table with md5 checksum value
-                    $file = File::model()->findByAttributes(array(
-                        'dataset_id' => $dataset->id,
-                        'name' => $filename,
-                    ));
+                    # Find file with unique URL location that ends with filepath
+                    $criteria = new CDbCriteria();
+                    $criteria->addColumnCondition(['dataset_id' => $dataset->id]);
+                    $criteria->addSearchCondition('location', "%$filepath", false);
+                    $file = File::model()->find($criteria);
                     $file->updateMd5Checksum($md5_value);
                 }
             }


### PR DESCRIPTION
# Pull request for issue: #1845

This is a pull request for the following functionalities:

* Enable file size information to be updated for files whose filenames are a substring of other files.
* Enable md5 checksum values to be updated for files whose filenames are identical to other files that reside in another directory in the same dataset.

## How to test?

### Dev environment using test data

Spin up a dev GigaDB environment:
```
$ ./up.sh
```

To test md5 checksum updates in `dev` environment:
```
$ docker-compose run --rm test ./protected/yiic files updateMD5FileAttributes --doi=100006

Saved md5 file attribute with id: 10674
Saved md5 file attribute with id: 10672
Saved md5 file attribute with id: 10673
Saved md5 file attribute with id: 10671
Saved md5 file attribute with id: 10670
Saved md5 file attribute with id: 10669
Saved md5 file attribute with id: 10675
```


Check md5 values have been updated for dataset 100006:
```
# Md5 checksum for readme.txt will be changed
$ docker-compose run --rm test psql -h database -p 5432 -U gigadb gigadb -c "select file.name, file_attributes.value from file, file_attributes where file.dataset_id=8 and file_attributes.attribute_id=605 and file.id = file_attributes.file_id;"
                  name                  |              value               
----------------------------------------+----------------------------------
 Pygoscelis_adeliae.RepeatMasker.out.gz | 5afc9d8348bf4b52ee6e9c2bae9fd542
 Pygoscelis_adeliae.cds.gz              | bd9bed43475eaa22b6ab62b9fb7a3909
 Pygoscelis_adeliae.fa.gz               | 43b35c4e828bed20dbb071d2c5a40f17
 Pygoscelis_adeliae.gff.gz              | 47b8f47ca31cfd06d5ad62ceceb99860
 Pygoscelis_adeliae.pep.gz              | 23c3241e6bc362d659a4b589c8d9e01c
 readme.txt                             | 88888888888888888888888888888888
 Pygoscelis_adeliae.scaf.fa.gz          | 55c764721558086197bfbd663e1567a6
(7 rows)
```

Take a look at the file sizes for dataset 100006:
```
$ pwd
/path/to/gigadb-website
$ docker-compose run --rm test psql -h database -p 5432 -U gigadb gigadb -c "select id, name, size from file where dataset_id=8;"
  id   |                  name                  |   size    
-------+----------------------------------------+-----------
   663 | readme.txt                             |       138
   664 | Pygoscelis_adeliae.scaf.fa.gz          | 367639441
 17677 | Pygoscelis_adeliae.fa.gz               | 367501431
 17678 | Pygoscelis_adeliae.gff.gz              |   1671666
 17679 | Pygoscelis_adeliae.RepeatMasker.out.gz |   7858032
 17680 | Pygoscelis_adeliae.cds.gz              |   6746663
 17681 | Pygoscelis_adeliae.pep.gz              |   4370788
(7 rows)

```

Test the file size update functionality in files metadata console tool:
```
$ cd gigadb/app/tools/files-metadata-console
$ docker-compose run --rm files-metadata-console ./yii update/file-sizes --doi=100006
Number of changes: 7
```

Check file sizes have been updated for dataset 100006:
```
$ cd ../../../..
$ docker-compose run --rm test psql -h database -p 5432 -U gigadb gigadb -c "select id, name, size from file where dataset_id=8;"
  id   |                  name                  |  size  
-------+----------------------------------------+--------
   663 | readme.txt                             |      8
 17680 | Pygoscelis_adeliae.cds.gz              |   1000
 17679 | Pygoscelis_adeliae.RepeatMasker.out.gz |  10000
 17677 | Pygoscelis_adeliae.fa.gz               | 100000
   664 | Pygoscelis_adeliae.scaf.fa.gz          |      1
 17678 | Pygoscelis_adeliae.gff.gz              |     10
 17681 | Pygoscelis_adeliae.pep.gz              |    100
(7 rows)
```

### Dev environment using production data

Next, try using the two tools with production data in your `dev` environment. Download the [live 20240612 database backup file](https://ap-east-1.console.aws.amazon.com/s3/object/gigadb-database-backups?region=ap-east-1&bucketType=general&prefix=gigadb_gigascience-upstream-gigadb-website_live_20240612.backup) from S3 gigadb-database-backups bucket. Place this in the `gigadb/app/tools/files-metadata-console/sql` directory.

There are  3 `REFRESH MATERIALIZED VIEW` commands which will can slow down the restoration of the database backup file. Therefore, comment out the 3 `REFRESH MATERIALIZED VIEW` commands at the bottom of the database backup file using a text editor so that it looks like this:
```
 --
 -- Name: dataset_finder; Type: MATERIALIZED VIEW DATA; Schema: public; Owner: gigadb
 --
 
 --REFRESH MATERIALIZED VIEW public.dataset_finder;
 
 --
 -- Name: file_finder; Type: MATERIALIZED VIEW DATA; Schema: public; Owner: gigadb
 --
 
 --REFRESH MATERIALIZED VIEW public.file_finder;
 
 --
 -- Name: sample_finder; Type: MATERIALIZED VIEW DATA; Schema: public; Owner: gigadb
 --
 
 --REFRESH MATERIALIZED VIEW public.sample_finder;
```

Load this production data into the dev database:
```
# Connect to dev database - use vagrant as password
docker-compose run --rm test psql -h database -p 5432 -U gigadb postgres
# Delete connections on a given database
postgres=# SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = 'gigadb';
postgres=# drop database gigadb;
postgres=# create database gigadb owner gigadb;
postgres=# \q

# Restore dev database using psql and backup file
$ docker-compose run --rm test psql -h database -U gigadb -d gigadb -f "/var/www/gigadb/app/tools/files-metadata-console/sql/gigadb_gigascience-upstream-gigadb-website_live_20240612.backup"
```

Drop database triggers as they will inhibit updates to tables, including the file table:
```
$ cd gigadb/app/tools/excel-spreadsheet-uploader
$ docker-compose run --rm pg_client -c 'drop trigger if exists file_finder_trigger on file RESTRICT'
DROP TRIGGER
$ docker-compose run --rm pg_client -c 'drop trigger if exists sample_finder_trigger on sample RESTRICT'
DROP TRIGGER
$ docker-compose run --rm pg_client -c 'drop trigger if exists dataset_finder_trigger on dataset RESTRICT'
DROP TRIGGER
```

Now, test the file size update functionality in files metadata console tool:
```
$ pwd
gigadb/app/tools/files-metadata-console
# Next command will take a couple of minutes
$ docker-compose run --rm files-metadata-console ./yii update/file-sizes --doi=102532
Number of changes: 125
```

### Staging environment

#### Preparation

Instantiate your staging environment:
```
$ cd /path/to/gigadb-website/ops/infrastructure/envs/staging

# Copy terraform files to staging environment
$ ../../../scripts/tf_init.sh --project gigascience/forks/fork-gigadb-website --env staging

# Provision with Terraform 
$ terraform plan
$ terraform apply
$ terraform refresh

# Copy ansible files
$ ../../../scripts/ansible_init.sh --env staging

# Provision webapp ec2 server with ansible
$ env TF_KEY_NAME=private_ip OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook -i ../../inventories webapp_playbook.yml -e "gigadb_env=staging"

# Provision bastion ec2 server and restore RDS with latest database backup
$ env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook -i ../../inventories bastion_playbook.yml -e "gigadb_env=staging"
```

Run Gitlab CI/CD pipeline to deploy the code from this PR into your staging environment. You should be able to see your staging GigaDB server displaying the GigaDB home page.

#### Test file size updates to files in database

Confirm files that have size = 0 for dataset 102532:
```
[centos@ip-10-99-0-173 ~]$ export PGPASSWORD='****'; psql -h rds-server-staging-peter.****.ap-northeast-1.rds.amazonaws.com -p 5432 -U gigadb gigadb -c "select name, size from file where dataset_id = 2800 and size = 0;"
              name              | size 
--------------------------------+------
 SHSY5Y_IVT_merged.fq           |    0
 Jurkat_IVT_merged.fq           |    0
 Jurkat_IVT_rep1.gencodev45.bam |    0
 SHSY5Y_IVT_rep1.hg38v10.bam    |    0
 HeLa_IVT_rep3.hg38v10.bam      |    0
 NTERA_IVT_rep2.gencodev45.bam  |    0
 NTERA_IVT_rep2.hg38v10.bam     |    0
(7 rows)
```

> [!NOTE]
> Five of these files failed to be updated with size information due to the bug this PR is fixing.

Use file size update tool to update files with real sizes:
```
# Drop triggers as they will inhibit file updates
[centos@ip-10-99-0-173 ~]$ docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c 'drop trigger if exists file_finder_trigger on file RESTRICT'
[centos@ip-10-99-0-173 ~]$ docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c 'drop trigger if exists sample_finder_trigger on sample RESTRICT'
[centos@ip-10-99-0-173 ~]$ docker run --rm  --env-file ./db-env registry.gitlab.com/$GITLAB_PROJECT/production_pgclient:$GIGADB_ENV -c 'drop trigger if exists dataset_finder_trigger on dataset RESTRICT'

# This command will take a few minutes to complete
[centos@ip-10-99-0-173 ~]$ docker run --rm "registry.gitlab.com/$GITLAB_PROJECT/production-files-metadata-console:$GIGADB_ENV" ./yii update/file-sizes --doi=102532
Number of changes: 125
```

Check how many files are now size = 0 for dataset 102532:
```
[centos@ip-10-99-0-173 ~]$ export PGPASSWORD='****'; psql -h rds-server-staging-peter.****.ap-northeast-1.rds.amazonaws.com -p 5432 -U gigadb gigadb -c "select name, size from file where dataset_id = 2800 and size = 0;"
         name         | size 
----------------------+------
 SHSY5Y_IVT_merged.fq |    0
 Jurkat_IVT_merged.fq |    0
(2 rows)
```

Now, only 2 files have size 0 which is correct according to `102532.filesizes` in S3 bucket.

#### Test md5 updates to files in database

Check how many files in dataset 102532 have md5 checksum values:
```
# Select file and their attributes
[centos@ip-10-99-0-173 ~]$ export PGPASSWORD='****'; psql -h rds-server-staging-peter.****.ap-northeast-1.rds.amazonaws.com -p 5432 -U gigadb gigadb -c "select file.name, file_attributes.value from file, file_attributes where file.dataset_id=2800 and file_attributes.attribute_id=605 and [file.id](http://file.id/) = file_attributes.file_id;"
                      name                       |              value               
-------------------------------------------------+----------------------------------
 SuppTable_S2.csv                                | 68be3e651fc2dbd6819388c224b53520
 HepG2_IVT_rep1.hg38v10.bam                      | f7f51b2c89863308cbe0c87894b86eb2
 A549_IVT_rep1.gencodev45.bam                    | c2258fce7506ea239fce9086c420ed9b
(85 rows)
```

The 102532 dataset has 125 files but only 85 of its files have been updated with md5 values.

Run the md5 update tool:
```
[centos@ip-10-99-0-173 ~]$ docker run -e YII_PATH=/var/www/vendor/yiisoft/yii "registry.gitlab.com/$GITLAB_PROJECT/production_app:$GIGADB_ENV" ./protected/yiic files updateMD5FileAttributes --doi=102532
...
Saved md5 file attribute with id: 681515
Saved md5 file attribute with id: 681516
Saved md5 file attribute with id: 681517
```

Now, check how many files in dataset 102532 have md5 checksum values:
```
# Select file and their attributes
[centos@ip-10-99-0-173 ~]$ export PGPASSWORD='****'; psql -h rds-server-staging-peter.****.ap-northeast-1.rds.amazonaws.com -p 5432 -U gigadb gigadb -c "select file.name, file_attributes.value from file, file_attributes where file.dataset_id=2800 and file_attributes.attribute_id=605 and [file.id](http://file.id/) = file_attributes.file_id;"
                      name                       |              value               
-------------------------------------------------+----------------------------------
 LogTransformed_HistogramReadlength.png          | f12961a3897d3ba81c2d87d31bc71926
 Yield_By_Length.png                             | 4895df95a14737a27542c495ed807567
 HistogramReadlength.png                         | 5d6ad69ea0a8fd5612a838b4afcdc101
(125 rows)
```

You will now see all 125 files in dataset 102532 have been updated with md5 checksum values.

## How have functionalities been implemented?

To identify which file to update with file size information, a wildcard is used to match the location URL that ends with the path of the file in the `updateFileSizes()` function in `DatasetFilesUpdater` class in the files metadata console tool.

A similar change in implementation was undertaken in the `actionUpdateMD5FileAttributes($doi)` function in `FileCommand` class for the MD5 update tool.

## Any changes to automated tests?

Had to skip known broken tests for CI pipeline to execute through to deployment.

## Any changes to documentation?

The `README.md` for the Excel spreadsheet upload tool has been updated with how to use MD% update tool.

The `README.md` for files metadata console tool has been updated with how it can be used to update file sizes.
