### PR TITLE
Update the pureftpd passwd path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1865: Change configuration location of the FTP server
 - Fix #1812: Navigating tables on mockup pages does not generate errors
 - Fix #1801: Refresh materialized views daily using cron job and drop existing triggers
 - Feat #1143: Open external links in new browser tabs

--- a/ops/configuration/file-server/docker-compose.yml.j2
+++ b/ops/configuration/file-server/docker-compose.yml.j2
@@ -5,7 +5,7 @@ services:
     volumes:
       - /share/dropbox:/home
       - /home/centos/app_data/pure-ftpd:/etc/pure-ftpd
-      - /home/centos/app_data/pure-ftpd/passwd:/etc/pure-ftpd/passwd
+      - /share/config/pure-ftpd/passwd:/etc/pure-ftpd/passwd
     environment:
       PUBLICHOST: "{{ remote_fileserver_hostname.json.value }}"
     command: -l puredb:/etc/pure-ftpd/pureftpd.pdb -E -j -R -P {{ remote_fileserver_hostname.json.value }}


### PR DESCRIPTION
# Pull request for issue: #1865

This is a pull request for the following functionalities:

* Updated the volume mapping in the docker-compose file for the ftpd service as below:
```
    - /share/config/pure-ftpd/passwd:/etc/pure-ftpd/passwd
```


## How to test?

Describe how the new functionalities can be tested by PR reviewers

1. Follow the `docs/developers/SETUP_AWS_ENVIRONMENTS.md` to spin up servers, `webapp`, `bastion` and `files`.
2. Follow the `docs/sop/DEPLOY_AND_CONFIGURE_PUBLIC_FTP_SERVER.md` to configure the FTP server and the testing.


## How have functionalities been implemented?

By updating the volume mapping of `/etc/pure-ftpd/passwd` to `/share/config/pure-ftpd/passwd`, the ftp user credentials will be saved in the `/share/config/pure-ftpd/passwd/pureftpd.passwd`, which make it available through out the mount point `/share/config`. 

## Any issues with implementation?
None.

## Any changes to automated tests?
None.

## Any changes to documentation?

None.

## Any technical debt repayment?
None.

## Any improvements to CI/CD pipeline?
None.
