### PR TITLE
Searchable funder dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #937: Searchable funder dropdown
 - Feat #1143: Open external links in new browser tabs
 - Feat: updated upload spreadsheet template to version 19
 - Fix #1743: Accessibility tweaks on datasetSubmission/upload page

--- a/less/current.less
+++ b/less/current.less
@@ -66,3 +66,4 @@
 @import "current/modules/map.less";
 @import "current/modules/lists.less";
 @import "current/modules/tooltip.less";
+@import "current/modules/select2-overrides.less"

--- a/less/current/modules/select2-overrides.less
+++ b/less/current/modules/select2-overrides.less
@@ -1,0 +1,67 @@
+// The main container for Select2
+.select2-container {
+  // The dropdown container
+  .select2-dropdown-override {
+  }
+  // The element containing the selection
+  .select2-selection-override[role="combobox"] {
+    border-color: @color-medium-gray;
+    color: @color-darker-gray;
+    font-size: 13px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    height: 34px;
+    padding: 6px 12px;
+    &:focus {
+      box-shadow: none;
+      outline: 1px solid @color-gigadb-green;
+      border-color: @color-gigadb-green-600;
+      box-shadow: inset 0 1px 1px fade(@color-gigadb-green, 7.5%),
+        0 0 6px fade(@color-gigadb-green-600, 50%);
+    }
+    // the text input visible when the dropdown is collapsed
+    .select2-selection__rendered[role="textbox"] {
+      order: 0;
+      color: @color-darker-gray;
+      box-shadow: none;
+      border-color: @color-medium-gray;
+      color: @color-darker-gray;
+      font-size: 13px;
+      margin: 0;
+    }
+    // clear input button
+    button.select2-selection__clear {
+      order: 1;
+      font-size: 18px;
+      color: @color-darker-gray;
+    }
+    // caret
+    .select2-selection__arrow {
+      height: 100%;
+      display: flex;
+      b[role="presentation"] {
+        border: none;
+        &:after {
+          content: "\f078";
+          font-family: "FontAwesome";
+          font-size: 10px;
+          color: @color-darker-gray;
+          position: absolute;
+          transform: translate(0, -50%);
+        }
+      }
+    }
+  }
+  // The search input displayed when the dropdown is expanded
+  input.select2-search__field[type="search"] {
+  }
+  // The results list
+  .select2-results {
+    .select2-results__option.select2-results__option--selectable.select2-results__option--highlighted {
+      background-color: @gigadb-green-on-white;
+      color: @color-true-white;
+    }
+  }
+}

--- a/less/current/modules/select2-overrides.less
+++ b/less/current/modules/select2-overrides.less
@@ -1,8 +1,5 @@
 // The main container for Select2
 .select2-container {
-  // The dropdown container
-  .select2-dropdown-override {
-  }
   // The element containing the selection
   .select2-selection-override[role="combobox"] {
     border-color: @color-medium-gray;
@@ -53,9 +50,6 @@
         }
       }
     }
-  }
-  // The search input displayed when the dropdown is expanded
-  input.select2-search__field[type="search"] {
   }
   // The results list
   .select2-results {

--- a/protected/components/controls/BaseInput.php
+++ b/protected/components/controls/BaseInput.php
@@ -27,6 +27,7 @@ class BaseInput extends CWidget
     $this->groupOptions['class'] = $this->mergeCssClasses($this->groupOptions, 'form-group' . ($this->hasError() ? ' has-error' : ''));
     $this->inputOptions['class'] = $this->mergeCssClasses($this->inputOptions, 'form-control');
     $this->labelOptions['class'] = $this->mergeCssClasses($this->labelOptions, 'control-label');
+    $this->labelOptions['id'] = $this->attributeName . 'Label';
     $this->errorOptions['class'] = $this->mergeCssClasses($this->errorOptions, 'control-error help-block');
 
     if ($this->description) {

--- a/protected/views/datasetFunder/_form.php
+++ b/protected/views/datasetFunder/_form.php
@@ -83,19 +83,34 @@
   const COMBOBOX = '.select2-selection-override[role="combobox"]'
   const LISTBOX = `.select2-results__options`
   const SEARCH_INPUT = '.select2-search__field'
+  const CLEAR_BTN = 'button.select2-selection__clear'
 
   $(document).ready(function () {
-    $(SELECT2).select2({
+    const select = $(SELECT2).select2({
       placeholder: "Select an option",
       allowClear: true,
       dropdownCssClass: 'select2-dropdown-override',
       selectionCssClass: 'select2-selection-override',
       width: '100%'
-    }).on('select2:open', function () {
+    })
+
+    select.on('select2:open', function () {
+      document.querySelector(LISTBOX).setAttribute('aria-label', 'Funder')
       document.querySelector(SEARCH_INPUT).focus()
-      document.querySelector(LISTBOX).setAttribute('aria-label', 'Funders')
     });
-    $(COMBOBOX).on('keydown', function (e) {
+
+    select.on('select2:close', function () {
+      $(CLEAR_BTN).attr('aria-hidden', true)
+    });
+
+    $(CLEAR_BTN).attr('aria-hidden', true)
+
+    const cb = $(COMBOBOX)
+
+    cb.attr('aria-labelledby', `funder_idLabel ${cb.attr('aria-labelledby')}`)
+    cb.attr('aria-required', 'true')
+
+    cb.on('keydown', function (e) {
       const isExpanded = $(this).attr('aria-expanded') === 'true';
 
       if ((e.key === 'ArrowDown' || e.key === 'ArrowUp') && !isExpanded) {

--- a/protected/views/datasetFunder/_form.php
+++ b/protected/views/datasetFunder/_form.php
@@ -76,22 +76,34 @@
 
     <?php $this->endWidget(); ?>
   </div>
-
 </div>
 
-
 <script>
+  const SELECT2 = '.js-select2-combobox'
+  const COMBOBOX = '.select2-selection-override[role="combobox"]'
+  const LISTBOX = `.select2-results__options`
+  const SEARCH_INPUT = '.select2-search__field'
+
   $(document).ready(function () {
-    $('.js-select2-combobox').select2({
+    $(SELECT2).select2({
       placeholder: "Select an option",
       allowClear: true,
       dropdownCssClass: 'select2-dropdown-override',
       selectionCssClass: 'select2-selection-override',
       width: '100%'
     }).on('select2:open', function () {
-      // search input does not get automatic focus
-      const searchInput = document.querySelector('.select2-search__field')
-      searchInput.focus();
+      document.querySelector(SEARCH_INPUT).focus()
+      document.querySelector(LISTBOX).setAttribute('aria-label', 'Funders')
     });
+    $(COMBOBOX).on('keydown', function (e) {
+      const isExpanded = $(this).attr('aria-expanded') === 'true';
+
+      if ((e.key === 'ArrowDown' || e.key === 'ArrowUp') && !isExpanded) {
+        $(SELECT2).select2('open');
+      }
+      if (e.key === 'Escape' && !isExpanded) {
+        $(SELECT2).val(null).trigger('change');
+      }
+    })
   });
 </script>

--- a/protected/views/datasetFunder/_form.php
+++ b/protected/views/datasetFunder/_form.php
@@ -1,73 +1,96 @@
+<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+
 <div class="section form row">
 
-	<div class="col-md-offset-3 col-md-6">
-		<?php $form = $this->beginWidget('CActiveForm', array(
-			'id' => 'dataset-funder-form',
-			'enableAjaxValidation' => false,
-		)); ?>
+  <div class="col-md-offset-3 col-md-6">
+    <?php $form = $this->beginWidget(
+      'CActiveForm',
+      array(
+        'id' => 'dataset-funder-form',
+        'enableAjaxValidation' => false,
+      )
+    ); ?>
 
-		<p class="note">Fields with <span class="required">*</span> are required.</p>
+    <p class="note">Fields with <span class="required">*</span> are required.</p>
 
-		<?php if ($model->hasErrors()) : ?>
-			<div class="alert alert-danger">
-				<?php echo $form->errorSummary($model); ?>
-			</div>
-		<?php endif; ?>
+    <?php if ($model->hasErrors()): ?>
+      <div class="alert alert-danger">
+        <?php echo $form->errorSummary($model); ?>
+      </div>
+    <?php endif; ?>
 
-		<?php
-		$this->widget('application.components.controls.DropdownField', [
-			'form' => $form,
-			'model' => $model,
-			'attributeName' => 'dataset_id',
-			'dataset' => $datasets,
-			'inputOptions' => [
-				'required' => true,
-			],
-		]);
-		$this->widget('application.components.controls.DropdownField', [
-			'form' => $form,
-			'model' => $model,
-			'attributeName' => 'funder_id',
-			'dataset' => $funders,
-			'inputOptions' => [
-				'required' => true,
-			],
-		]);
-		$this->widget('application.components.controls.TextArea', [
-			'form' => $form,
-			'model' => $model,
-			'attributeName' => 'grant_award',
-			'inputOptions' => [
-				'rows' => 6,
-				'cols' => 50
-			],
-		]);
-		$this->widget('application.components.controls.TextArea', [
-			'form' => $form,
-			'model' => $model,
-			'attributeName' => 'awardee',
-			'inputOptions' => [
-				'rows' => 6,
-				'cols' => 50
-			],
-		]);
-		$this->widget('application.components.controls.TextArea', [
-			'form' => $form,
-			'model' => $model,
-			'attributeName' => 'comments',
-			'inputOptions' => [
-				'rows' => 6,
-				'cols' => 50
-			],
-		]);
-		?>
+    <?php
+    $this->widget('application.components.controls.DropdownField', [
+      'form' => $form,
+      'model' => $model,
+      'attributeName' => 'dataset_id',
+      'dataset' => $datasets,
+      'inputOptions' => [
+        'required' => true,
+      ],
+    ]);
+    $this->widget('application.components.controls.DropdownField', [
+      'form' => $form,
+      'model' => $model,
+      'attributeName' => 'funder_id',
+      'dataset' => $funders,
+      'inputOptions' => [
+        'required' => true,
+        'class' => 'select2-combobox js-select2-combobox'
+      ],
+    ]);
+    $this->widget('application.components.controls.TextArea', [
+      'form' => $form,
+      'model' => $model,
+      'attributeName' => 'grant_award',
+      'inputOptions' => [
+        'rows' => 6,
+        'cols' => 50
+      ],
+    ]);
+    $this->widget('application.components.controls.TextArea', [
+      'form' => $form,
+      'model' => $model,
+      'attributeName' => 'awardee',
+      'inputOptions' => [
+        'rows' => 6,
+        'cols' => 50
+      ],
+    ]);
+    $this->widget('application.components.controls.TextArea', [
+      'form' => $form,
+      'model' => $model,
+      'attributeName' => 'comments',
+      'inputOptions' => [
+        'rows' => 6,
+        'cols' => 50
+      ],
+    ]);
+    ?>
 
-		<div class="pull-right btns-row">
-			<a href="/datasetFunder/admin" class="btn background-btn-o">Cancel</a>
-			<?php echo CHtml::submitButton($model->isNewRecord ? 'Create' : 'Save', array('class' => 'btn background-btn')); ?>
-		</div>
+    <div class="pull-right btns-row">
+      <a href="/datasetFunder/admin" class="btn background-btn-o">Cancel</a>
+      <?php echo CHtml::submitButton($model->isNewRecord ? 'Create' : 'Save', array('class' => 'btn background-btn')); ?>
+    </div>
 
-		<?php $this->endWidget(); ?>
-	</div>
+    <?php $this->endWidget(); ?>
+  </div>
 
 </div>
+
+
+<script>
+  $(document).ready(function () {
+    $('.js-select2-combobox').select2({
+      placeholder: "Select an option",
+      allowClear: true,
+      dropdownCssClass: 'select2-dropdown-override',
+      selectionCssClass: 'select2-selection-override'
+    }).on('select2:open', function () {
+      // search input does not get automatic focus
+      const searchInput = document.querySelector('.select2-search__field')
+      searchInput.focus();
+    });
+  });
+</script>

--- a/protected/views/datasetFunder/_form.php
+++ b/protected/views/datasetFunder/_form.php
@@ -86,7 +86,8 @@
       placeholder: "Select an option",
       allowClear: true,
       dropdownCssClass: 'select2-dropdown-override',
-      selectionCssClass: 'select2-selection-override'
+      selectionCssClass: 'select2-selection-override',
+      width: '100%'
     }).on('select2:open', function () {
       // search input does not get automatic focus
       const searchInput = document.querySelector('.select2-search__field')


### PR DESCRIPTION
# Pull request for issue: #937

This is a pull request for the following functionalities:

* Uses Select2 library (a widely used jQuery library) to implement a searchable combobox that makes the funder dropdown more usable (http://gigadb.gigasciencejournal.com/datasetFunder/update/id/1)

[Screencast from 27-06-24 12:55:23.webm](https://github.com/gigascience/gigadb-website/assets/143437854/a36fa8a3-5a57-4c92-8c7d-c8afb75d3f2d)

## How to test?

* Navigate to http://gigadb.gigasciencejournal.com/datasetFunder/update/id/1
* Interact with Funder select
* type something to filter results
* select result with enter
* clean box with esc (when dropdown is collapsed)

Note: if you want to add / see more options, you can add them to data/dev/funder_name.csv and rebuild

## How have functionalities been implemented?

* Select2 library was implemented for this specific element by adding it from CDN to this specific page
* Default styles were overriden to make it match the site theme
* Keyboard navigation programmatically improved:
  * down and up arrow expand dropdown
  * esc key clears input
* A11y improvements over default Select2
  * Labeled combobox so that label is read
  * hide clear button from screen readers as it is not focusable
  * Added label to listbox

## Any issues with implementation?

Making the select2 fully accessible following this spec (https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-both/) is quite challenging, particularly in regards of screen reader support, and it's essentially a different widget structure. If this pattern needs to be exactly replicated to match a11y spec, it would be probably better to build it from scratch, or perhaps use a less wide-spread library

## Any changes to automated tests?

--

## Any changes to documentation?

--