### PR TITLE
Line wrap long filenames in dataset files table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Fix #1960: Truncate long filenames in dataset files table
+- Fix #1960: Let long filenames wrap anywhere in dataset files table
 - Fix #1912: Enable curators to save Gigadb forms from many browser tabs at once
 - Feat #1840: Make create readme tool available as part of postUpload script
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1960: Truncate long filenames in dataset files table
 - Fix #1912: Enable curators to save Gigadb forms from many browser tabs at once
 - Feat #1840: Make create readme tool available as part of postUpload script
 

--- a/less/current/modules/tables.less
+++ b/less/current/modules/tables.less
@@ -241,3 +241,11 @@ table.dataset-view-table > tbody > tr {
   display: flex;
   justify-content: space-between;
 }
+
+#files_table .file-name-cell a {
+  max-width: 230px;
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/less/current/modules/tables.less
+++ b/less/current/modules/tables.less
@@ -245,7 +245,5 @@ table.dataset-view-table > tbody > tr {
 #files_table .file-name-cell a {
   max-width: 230px;
   display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  word-break: break-word;
 }

--- a/less/current/modules/tables.less
+++ b/less/current/modules/tables.less
@@ -242,6 +242,10 @@ table.dataset-view-table > tbody > tr {
   justify-content: space-between;
 }
 
+#files_table thead .file-name-header {
+  min-width: 100px;
+}
+
 #files_table .file-name-cell a {
   max-width: 230px;
   display: block;

--- a/protected/views/dataset/view.php
+++ b/protected/views/dataset/view.php
@@ -396,7 +396,7 @@ $sampleDataProvider = $samples->getDataProvider();
                                 <table id="files_table" class="table table-striped table-bordered" style="width:100%">
                                     <thead>
                                         <tr>
-                                            <th title="The name of the file. Click header to sort by A-Z/Z-A.">File Name</th>
+                                            <th title="The name of the file. Click header to sort by A-Z/Z-A." class="file-name-header">File Name</th>
                                             <th title="Short description of file contents. Click header to sort by A-Z/Z-A.">Description</th>
                                             <th title="Name or ID of sample used to generate this file.">Sample ID</th>
                                             <th title="The type of data in the file, see [help](http://gigadb.org/site/help#vocabulary) page for definitions of individual data types.  Click header to sort by A-Z/Z-A.">Data Type</th>

--- a/protected/views/dataset/view.php
+++ b/protected/views/dataset/view.php
@@ -412,7 +412,7 @@ $sampleDataProvider = $samples->getDataProvider();
                                         foreach ($file_models as $file) {
                                         ?>
                                             <tr>
-                                                <td><?= $file['nameHtml'] ?></td>
+                                                <td class="file-name-cell"><?= $file['nameHtml'] ?></td>
                                                 <td><?= $file['description'] ?></td>
                                                 <td><?php
                                                     //TODO: huge performance issue with large numbers of fileDatasetKeywordsTest.php:49, manifesting when disabling cache


### PR DESCRIPTION
# Pull request for issue: #1960

* Allow overly long filenames to wrap anywhere in files table in dataset page 
![image](https://github.com/user-attachments/assets/5a1fc79e-3365-4703-bc4c-2da2fba9fe47)


## How to test?

* Go to http://gigadb.gigasciencejournal.com/dataset/100094
* Edit the html of the page directly from the dev tools, to add an overly long filename in any one row of the files table. the file name should be truncated on display

## How have functionalities been implemented?

* Added styles such that:
  * minimum width of the column is 100px
  * maximum width is 230px and any text will wrap to the next line:
    * if there are acceptable line breaks, text will wrap there
    * if there are no acceptable line breaks, text will wrap anywhere

Note: filename truncation (ellipsis as in showing "..." if filename is too long) was considered but showing the full filename always was preferred

## Any issues with implementation?

--

## Any changes to automated tests?

--
