### PR TITLE
Rewrite file settings cookie when updating dataset view settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1965: Rewrite file settings cookie when updating dataset view settings
 - Feat #1892: Remove unused CSS and LESS files
 - Fix #1871: Allowed to save species info filling only required inputs
 

--- a/protected/components/DatasetPageSettings.php
+++ b/protected/components/DatasetPageSettings.php
@@ -90,13 +90,9 @@ class DatasetPageSettings extends yii\base\BaseObject
      */
     public function setFileSettings(array $columns, int $pageSize, CMap $cookies): array
     {
-        if (isset($cookies['file_setting'])) {
-            $cookies['file_setting']->value = json_encode([ "setting" => $columns, "page" => $pageSize]);
-        } else {
-                $cookie = new CHttpCookie('file_setting', json_encode(array('setting' => $columns, 'page' => $pageSize)));
-                $cookie->expire = time() + (60 * 60 * 24 * 30);
-                $cookies['file_setting'] = $cookie;
-        }
+        $cookie = new CHttpCookie('file_setting', json_encode(array('setting' => $columns, 'page' => $pageSize)));
+        $cookie->expire = time() + (60 * 60 * 24 * 30);
+        $cookies['file_setting'] = $cookie;
         return [ "columns" => $columns, "pageSize" => $pageSize ];
     }
 


### PR DESCRIPTION
# Pull request for issue: #1956

This is a pull request for the following functionalities:

* Upon refreshing dataset and dataset mock pages, e.g. http://gigadb.gigasciencejournal.com/dataset/view/id/100245 file settings persist

## How to test?

* Navigate to http://gigadb.gigasciencejournal.com/dataset/view/id/100245
* Update file settings and submit
* refresh page and check that file settings persist

## How have functionalities been implemented?

* protected/components/DatasetPageSettings.php setFileSettings
  * removed conditional and left only false branch that writes 'file_setting' cookie

This is the original function for reference:

```php
    public function setFileSettings(array $columns, int $pageSize, CMap $cookies): array
    {
        if (isset($cookies['file_setting'])) {
            $cookies['file_setting']->value = json_encode([ "setting" => $columns, "page" => $pageSize]);
        } else {
                $cookie = new CHttpCookie('file_setting', json_encode(array('setting' => $columns, 'page' => $pageSize)));
                $cookie->expire = time() + (60 * 60 * 24 * 30);
                $cookies['file_setting'] = $cookie;
        }
        return [ "columns" => $columns, "pageSize" => $pageSize ];
    }
```

## Any issues with implementation?

Note that the we no longer check whether the cookie is set. But i believe this is not necessary as we always write it.

I've researched how to update cookie in Yii 1.1 (as opposed to write / set) but all I found was things equivalent to the false branch, nothing like the true branch, so I am assuming my implementation is correct

## Any changes to automated tests?

tests pass