### PR TITLE
fix 1959: dataset relation wrong attrribute name relationship

### DIFF
--- a/data/dev/relationship.csv
+++ b/data/dev/relationship.csv
@@ -1,3 +1,4 @@
 id,name
 1,IsCitedBy
+2,Cites
 13,IsReferencedBy

--- a/protected/components/controls/CheckBoxField.php
+++ b/protected/components/controls/CheckBoxField.php
@@ -23,6 +23,7 @@ class CheckBoxField extends CWidget
   public $checkboxOptions;
   public $labelOptions;
   public $errorOptions;
+  public $label = null;
 
   private function hasError()
   {
@@ -48,7 +49,15 @@ class CheckBoxField extends CWidget
 
     echo CHtml::openTag('div', $this->groupOptions);
     echo $this->form->checkBox($this->model, $this->attributeName, $this->checkboxOptions);
-    echo $this->form->labelEx($this->model, $this->attributeName, $this->labelOptions);
+    if ($this->label) {
+        echo CHtml::tag('div', [], CHtml::tag(
+            'label',
+            [],
+            CHtml::encode($this->label)
+        ));
+    } else {
+        echo $this->form->labelEx($this->model, $this->attributeName, $this->labelOptions);
+    }
     echo $this->form->error($this->model, $this->attributeName, $this->errorOptions);
     echo CHtml::closeTag('div');
   }

--- a/protected/models/Relation.php
+++ b/protected/models/Relation.php
@@ -21,6 +21,8 @@ class Relation extends CActiveRecord
 	 */
     public $doi_search;
     public $relationship_name;
+    public $add_reciprocal = true;
+
 	public static function model($className=__CLASS__)
 	{
 		return parent::model($className);
@@ -42,9 +44,9 @@ class Relation extends CActiveRecord
 		// NOTE: you should only define rules for those attributes that
 		// will receive user inputs.
 		return array(
-			array('dataset_id, related_doi, relationship_id', 'required'),
-			array('dataset_id, relationship_id', 'numerical', 'integerOnly'=>true),
-			array('related_doi', 'length', 'max'=>15),
+			array('dataset_id, related_doi, relationship_id', 'required', 'message' => 'Please select a value'),
+			array('dataset_id, relationship_id', 'numerical', 'integerOnly' => true, 'message' => 'Wrong format'),
+			array('related_doi', 'length', 'max'=> 6, 'message' => 'Cannot exceed 6 characters'),
 			// The following rule is used by search().
 			// Please remove those attributes that should not be searched.
 			array('id, dataset_id, related_doi, relationship , doi_search, relationship_id', 'safe', 'on'=>'search'),
@@ -138,7 +140,7 @@ class Relation extends CActiveRecord
 
     /**
 	 *
-	 * @return string $relationship
+	 * @return Relationship
 	 **/
     public function getRelationship() {
     	return $this->relationship;

--- a/protected/models/RelationDAO.php
+++ b/protected/models/RelationDAO.php
@@ -9,6 +9,43 @@
 */
 class RelationDAO
 {
+     const RECIPROCAL_RELATION = [
+		 "IsCitedBy"           => "Cites",
+		 "Cites"               => "IsCitedBy",
+         "IsSupplementTo"      => "IsSupplementedBy",
+         "IsSupplementedBy"    => "IsSupplementTo",
+		 "IsContinuedBy"       => "Continues",
+		 "Continues"           => "IsContinuedBy",
+		 "Describes"           => "IsDescribedBy",
+		 "IsDescribedBy"       => "Describes",
+		 "HasMetadata"         => "isMetadataFor",
+		 "IsMetadataFor"       => "HasMetadata",
+		 "HasVersion"          => "IsVersionOf",
+		 "IsVersionOf"         => "HasVersion",
+         "IsNewVersionOf"      => "IsPreviousVersionOf",
+         "IsPreviousVersionOf" => "IsNewVersionOf",
+         "IsPartOf"            => "HasPart",
+         "HasPart"             => "IsPartOf",
+         "IsReferencedBy"      => "References",
+         "References"          => "IsReferencedBy",
+		 "IsDocumentedBy"      => "Documents",
+		 "Documents"           => "IsDocumentedBy",
+		 "IsCompiledBy"        => "Compiles",
+		 "Compiles"            => "IsCompiledBy",
+		 "IsReviewedBy"        => "Reviews",
+		 "Reviews"             => "IsReviewedBy",
+		 "IsRequiredBy"        => "Requires",
+		 "Requires"            => "IsRequiredBy",
+		 "IsObsoletedBy"       => "Obsoletes",
+		 "Obsoletes"           => "IsObsoletedBy",
+		 "IsCollectedBy"       => "Collects",
+		 "Collects"            => "IsCollectedBy",
+		 "IsVariantFormOf"     => "IsOriginalFormOf",
+		 "IsOriginalFormOf"    => "IsVariantFormOf",
+		 "IsIdenticalTo"       => "IsIdenticalTo",
+		 "IsDerivedFrom"       => "IsSourceOf",
+		 "IsSourceOf"          => "IsDerivedFrom"
+     ];
 
 	/**
 	 * It sets up and save a supplied relation object to reciprocate a given persisted relation
@@ -18,52 +55,16 @@ class RelationDAO
 	 **/
 	public function createReciprocalTo(Relation $relating_rel, Relation $reciprocal_rel)
 	{
-
-
 		$dataset_id = Dataset::model()->findByAttributes(array('identifier' => $relating_rel->getRelatedDOI()))->id ;
 		$related_doi = Dataset::model()->findByAttributes(array('id' => $relating_rel->getDatasetID()))->identifier ;
+		$reciprocal_rel->setDatasetID($dataset_id);
+		$reciprocal_rel->setRelatedDOI($related_doi);
+        $reciprocal_rel->setRelationship(self::RECIPROCAL_RELATION[$relating_rel->getRelationship()->getName()]);
 
-		$reciprocal_rel->setDatasetID( $dataset_id );
-
-		$reciprocal_rel->setRelatedDOI( $related_doi );
-
-		if ($relating_rel->getRelationship()=="IsSupplementTo") {
-
-			$reciprocal_rel->setRelationship('IsSupplementedBy');
+		if (!$reciprocal_rel->save()) {
+			throw new CException('Failed as it was unable to save the reciprocal relation');
 		}
-
-		elseif ($relating_rel->getRelationship()=="IsSupplementedBy") {
-
-			$reciprocal_rel->setRelationship('IsSupplementTo');
-		}
-		elseif ($relating_rel->getRelationship()=="IsNewVersionOf") {
-
-			$reciprocal_rel->setRelationship('IsPreviousVersionOf');
-		}
-		elseif ($relating_rel->getRelationship()=="IsPreviousVersionOf") {
-
-			$reciprocal_rel->setRelationship('IsNewVersionOf');
-		}
-		elseif ($relating_rel->getRelationship()=="IsPartOf") {
-
-			$reciprocal_rel->setRelationship('HasPart');
-		}
-		elseif ($relating_rel->getRelationship()=="HasPart") {
-
-			$reciprocal_rel->setRelationship('IsPartOf');
-		}
-		elseif ($relating_rel->getRelationship()=="IsReferencedBy") {
-
-			$reciprocal_rel->setRelationship('References');
-		}
-		elseif ($relating_rel->getRelationship()=="References") {
-
-			$reciprocal_rel->setRelationship('IsReferencedBy');
-		}
-
-		$reciprocal_rel->save();
 	}
-
 }
 
 ?>

--- a/protected/models/Relationship.php
+++ b/protected/models/Relationship.php
@@ -86,4 +86,21 @@ class Relationship extends CActiveRecord
 			'criteria'=>$criteria,
 		));
 	}
+
+    /**
+     * @param $name
+     *
+     * @return void
+     */
+    public function setName($name) {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName() {
+        return $this->name;
+    }
+
 }

--- a/protected/views/adminRelation/_form.php
+++ b/protected/views/adminRelation/_form.php
@@ -8,6 +8,12 @@
 
 		<p class="note">Fields with <span class="required">*</span> are required.</p>
 
+        <?php if(Yii::app()->user->hasFlash('error')):?>
+            <div class="alert alert-danger">
+                <?php echo Yii::app()->user->getFlash('error'); ?>
+            </div>
+        <?php endif; ?>
+
 		<?php if ($model->hasErrors()) : ?>
 			<div class="alert alert-danger">
 				<?php echo $form->errorSummary($model); ?>
@@ -44,13 +50,21 @@
 		$this->widget('application.components.controls.DropdownField', [
 			'form' => $form,
 			'model' => $model,
-			'attributeName' => 'relationship',
+			'attributeName' => 'relationship_id',
 			'listDataOptions' => [
 				'data' => Relationship::model()->findAll(),
 				'valueField' => 'id',
 				'textField' => 'name',
 			],
 		]);
+        if ('insert' === $model->getScenario()) {
+            $this->widget('application.components.controls.CheckBoxField', [
+                'form' => $form,
+                'model' => $model,
+                'attributeName' => 'add_reciprocal',
+                'label' => 'Do you want to add a reciprocal relation model'
+            ]);
+        }
 		?>
 
 		<div class="pull-right btns-row">

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -388,4 +388,35 @@ class AcceptanceTester extends \Codeception\Actor
     {
         $this->seeElement('a', ['class' => "sort-link $order", 'text' => $column]);
     }
+
+    /**
+     * @Then I should see the table with the following rows:
+     */
+    public function iShouldSeeTheTableWithTheFollowingRows(\Behat\Gherkin\Node\TableNode $table)
+    {
+        $rows = $table->getRows();
+        foreach ($rows as $index => $expectedRow) {
+            $expectedRow = implode(' ', $expectedRow);
+            $tableRows = $this->grabMultiple('table tr');
+            //remove headers and search bar
+            $tableRows = array_slice($tableRows, 2);
+
+            $this->assertEquals($expectedRow, $tableRows[$index]);
+        }
+    }
+
+    /**
+     * @Then I should not see the table with the following index :index
+     */
+    public function iShouldNotSeeTheTableWithTheFollowingIndex($index, \Behat\Gherkin\Node\TableNode $table)
+    {
+        $rows = $table->getRows();
+        $expectedRow = implode(' ', $rows[$index]);
+
+        $tableRows = $this->grabMultiple('table tr');
+        //remove headers and search bar
+        $tableRows = array_slice($tableRows, 2);
+
+        $this->assertNotEquals($expectedRow, $tableRows[$index]);
+    }
 }

--- a/tests/acceptance/RelationDAO.feature
+++ b/tests/acceptance/RelationDAO.feature
@@ -1,0 +1,53 @@
+@ok-can-offline
+Feature: admin page for dataset relations
+  as a curator
+  I want to see a table of all relations
+  So that quickly navigate to the relation related data I am interested in
+
+  Background:
+    Given I have signed in as admin
+
+  @ok
+  Scenario: Add a relation and the reciprocal relation
+    Given I am on "/adminRelation/create"
+    And I should see "Create Relation"
+    When I select "8" from the field "Relation_dataset_id"
+    And I select "100039" from the field "Relation_related_doi"
+    And I select "1" from the field "Relation_relationship_id"
+    And I press the button "Create"
+    And I wait "1" seconds
+    Then I should see "View Relation"
+    And I should see "8"
+    And I should see "100039"
+    Then I am on "adminRelation/admin"
+    Then I should see the table with the following rows:
+      | 100039  | 100006      | Cites             |
+      | 100006  | 100039      | IsCitedBy         |
+
+  @ok
+  Scenario: Add a relation without the reciprocal relation
+    Given I am on "/adminRelation/create"
+    And I should see "Create Relation"
+    When I select "8" from the field "Relation_dataset_id"
+    And I select "100039" from the field "Relation_related_doi"
+    And I select "1" from the field "Relation_relationship_id"
+    Then I uncheck "Relation_add_reciprocal" checkbox
+    And I press the button "Create"
+    And I wait "1" seconds
+    Then I should see "View Relation"
+    And I should see "8"
+    And I should see "100039"
+    Then I am on "adminRelation/admin"
+    Then I should not see the table with the following index 0:
+      | 100039  | 100006 | Cites |
+
+  @ok
+  Scenario: Fail To save relation with same DOI
+    Given I am on "/adminRelation/create"
+    And I should see "Create Relation"
+    When I select "5" from the field "Relation_dataset_id"
+    And I select "100039" from the field "Relation_related_doi"
+    And I select "1" from the field "Relation_relationship_id"
+    And I press the button "Create"
+    And I wait "1" seconds
+    Then I should see "Can't refer the same DOI"

--- a/tests/functional/RelationDAOCest.php
+++ b/tests/functional/RelationDAOCest.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * run with:
+ * docker-compose run --rm test ./vendor/codeception/codeception/codecept run functional RelationDAOCest
+ */
+class RelationDAOCest
+{
+    public function tryToCreateRelationWithoutReciprocalRelation(FunctionalTester $I)
+    {
+        $I->amOnPage('/site/login');
+        $I->submitForm('form.form-horizontal', [
+                'LoginForm[username]' => 'admin@gigadb.org',
+                'LoginForm[password]' => 'gigadb'
+            ]
+        );
+
+        $I->canSee('Admin');
+        $I->click('Admin');
+        $I->click('Dataset:Relations');
+        $I->click('Create A New Relation');
+        $I->canSee('Create Relation');
+        $I->selectOption('select#Relation_dataset_id', '5');
+        $I->selectOption('select#Relation_related_doi', '100006');
+        $I->selectOption('select#Relation_relationship_id', '13');
+        $I->uncheckOption('#Relation_add_reciprocal');
+        $I->click('Create');
+
+        $I->seeInDatabase('relation',
+            ['dataset_id' => 5, 'related_doi' => '100006', 'relationship_id' => 13]
+        );
+        $I->canSee('View Relation');
+    }
+
+    public function tryToCreateRelationWithReciprocalRelationAndFail(FunctionalTester $I)
+    {
+        $I->amOnPage('/site/login');
+        $I->submitForm('form.form-horizontal', [
+                'LoginForm[username]' => 'admin@gigadb.org',
+                'LoginForm[password]' => 'gigadb'
+            ]
+        );
+
+        $I->canSee('Admin');
+        $I->click('Admin');
+        $I->click('Dataset:Relations');
+        $I->click('Create A New Relation');
+        $I->canSee('Create Relation');
+        $I->selectOption('select#Relation_dataset_id', '5');
+        $I->selectOption('select#Relation_related_doi', '100006');
+        $I->selectOption('select#Relation_relationship_id', '13');
+        $I->click('Create');
+
+        $I->dontSeeInDatabase('relation',
+            ['dataset_id' => 5, 'related_doi' => '100006', 'relationship_id' => 13]
+        );
+
+        $I->canSee('Failed as it was unable to save the reciprocal relation');
+    }
+
+    public function tryToCreateRelationWithReciprocalRelation(FunctionalTester $I)
+    {
+        $I->amOnPage('/site/login');
+        $I->submitForm('form.form-horizontal', [
+                'LoginForm[username]' => 'admin@gigadb.org',
+                'LoginForm[password]' => 'gigadb'
+            ]
+        );
+
+        $I->canSee('Admin');
+        $I->click('Admin');
+        $I->click('Dataset:Relations');
+        $I->click('Create A New Relation');
+        $I->canSee('Create Relation');
+        $I->selectOption('select#Relation_dataset_id', '5');
+        $I->selectOption('select#Relation_related_doi', '100006');
+        $I->selectOption('select#Relation_relationship_id', '1');
+        $I->click('Create');
+
+        $I->seeInDatabase('relation',
+            ['dataset_id' => 5, 'related_doi' => '100006', 'relationship_id' => 1]
+        );
+        $I->seeInDatabase('relation',
+            ['dataset_id' => 8, 'related_doi' => '100039', 'relationship_id' => 2]
+        );
+    }
+
+    public function tryToCreateRelationWithSameDOIAndFail(FunctionalTester $I)
+    {
+        $I->amOnPage('/site/login');
+        $I->submitForm('form.form-horizontal', [
+                'LoginForm[username]' => 'admin@gigadb.org',
+                'LoginForm[password]' => 'gigadb'
+            ]
+        );
+
+        $I->canSee('Admin');
+        $I->click('Admin');
+        $I->click('Dataset:Relations');
+        $I->click('Create A New Relation');
+        $I->canSee('Create Relation');
+        $I->selectOption('select#Relation_dataset_id', '5');
+        $I->selectOption('select#Relation_related_doi', '100039');
+        $I->selectOption('select#Relation_relationship_id', '13');
+        $I->click('Create');
+
+        $I->dontSeeInDatabase('relation',
+            ['dataset_id' => 5, 'related_doi' => '100006', 'relationship_id' => 13]
+        );
+
+        $I->canSee("Can't refer the same DOI");
+    }
+}

--- a/tests/unit/RelationDAOTest.php
+++ b/tests/unit/RelationDAOTest.php
@@ -1,58 +1,66 @@
 <?php
 
-class RelationDAOTest extends CDbTestCase
+/**
+ * run with:
+ * docker-compose run --rm test ./vendor/codeception/codeception/codecept run unit RelationDAOTest
+ */
+class RelationDAOTest extends \CDbTestCase
 {
     /**
      * @dataProvider relationshipProvider
      */
-    public function testItshouldAddReciprocalRelation($relationship, $expected_reciprocal)
+    public function testItShouldAddReciprocalRelation($relationship, $expected_reciprocal)
     {
         $relation_stub = $this->createMock(Relation::class);
+        $relationshipMock = $this->createMock(Relationship::class);
+        $relationshipMock->method('getName')
+            ->willReturn($relationship);
 
         // Configure the stub for the relation for which to create a reciprocal relation
         $relation_stub->method('getRelatedDOI')
-             ->willReturn('100249'); //of id 2
+            ->willReturn('100249'); //of id 2
         $relation_stub->method('getDatasetID')
-             ->willReturn('1'); // of identifier 100243
+            ->willReturn('1'); // of identifier 100243
         $relation_stub->method('getRelationship')
-             ->willReturn($relationship);
+            ->willReturn($relationshipMock);
 
         // Create a mock for the Relation class,
         // only mock the setDatasetID, setRelatedDOI, setRelationship methods.
         $reciprocal_relation = $this->getMockBuilder(Relation::class)
-                         ->setMethods(['setDatasetID', 'setRelatedDOI', 'setRelationship', 'save'])
-                         ->getMock();
+            ->setMethods(['setDatasetID', 'setRelatedDOI', 'setRelationship', 'save'])
+            ->getMock();
 
         // Set up the expectation for the setDatasetID method
         // to be called only once and with:
         // the id of the related dataset (of DOI 100249)
         // as its parameter.
         $reciprocal_relation->expects($this->once())
-                 ->method('setDatasetID')
-                 ->with($this->equalTo(2));
+            ->method('setDatasetID')
+            ->with($this->equalTo(2));
 
         // Set up the expectation for the setRelatedDOI method
         // to be called only once and with:
         // the DOI of the relating dataset (of id 1)
         // as its parameter.
         $reciprocal_relation->expects($this->once())
-                 ->method('setRelatedDOI')
-                 ->with($this->equalTo('100243'));
+            ->method('setRelatedDOI')
+            ->with($this->equalTo('100243'));
 
         // Set up the expectation for the setRelationship method
         // to be called only once and with:
         // the reciprocal relationship supplied by dataProvider
         // as its parameter.
         $reciprocal_relation->expects($this->once())
-                 ->method('setRelationship')
-                 ->with($this->equalTo($expected_reciprocal));
+            ->method('setRelationship')
+            ->with($this->equalTo($expected_reciprocal));
 
         // Set up the expectation for the save method
         // to be called only once
         $reciprocal_relation->expects($this->once())
-                 ->method('save');
+            ->method('save')
+            ->willReturn(true);
 
-        $system_under_test = new RelationDAO() ;
+        $system_under_test = new RelationDAO();
         // createReciprocalTo make use of dependency injection for the reciprocal relation instantiation
         $system_under_test->createReciprocalTo($relation_stub, $reciprocal_relation);
     }
@@ -60,14 +68,14 @@ class RelationDAOTest extends CDbTestCase
     public function relationshipProvider()
     {
         return [
-            ["IsSupplementTo", "IsSupplementedBy"],
-            ["IsSupplementedBy", "IsSupplementTo"],
-            ["IsNewVersionOf", "IsPreviousVersionOf"],
-            ["IsPreviousVersionOf", "IsNewVersionOf"],
-            ["IsPartOf", "HasPart"],
-            ["HasPart", "IsPartOf"],
-            ["IsReferencedBy", "References"],
-            ["References", "IsReferencedBy"],
+            ['IsSupplementTo', 'IsSupplementedBy'],
+            ['IsSupplementedBy', 'IsSupplementTo'],
+            ['IsNewVersionOf', 'IsPreviousVersionOf'],
+            ['IsPreviousVersionOf', 'IsNewVersionOf'],
+            ['IsPartOf', 'HasPart'],
+            ['HasPart', 'IsPartOf'],
+            ['IsReferencedBy', 'References'],
+            ['References', 'IsReferencedBy'],
         ];
     }
 }


### PR DESCRIPTION
# Pull request for issue: #1959 

This is a pull request for the following functionalities:

- create relation without error: fix
- add tests
- add checkbox in order to decide if the reciprocal relation should be also created (yes by default)


## How to test?

Go to https://gigadb.org/adminRelation/admin
Click on "Create a new relation"
Try to enter the doi and relation, click create.

## How have functionalities been implemented?

- fix attribute name
- fix returnType
- update all relationships
- add checkbox
- handle errors

## Any issues with implementation?

## Any changes to automated tests?

unit test fixed / functional tests added

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?



