### PR TITLE
Fix 1991 admin samples update sample id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1991: Update and save sample ID when updating
 - Feat #2008: Remove Dimensions citation link
 - Fix #2074: Update contact website URL
 - Feat #2089: Update team members

--- a/protected/controllers/AdminSampleController.php
+++ b/protected/controllers/AdminSampleController.php
@@ -193,50 +193,47 @@ class AdminSampleController extends Controller
     public function actionUpdate($id)
     {
         $model = $this->loadModel($id);
-                //$old_code= $model->code;
-        // Uncomment the following line if AJAX validation is needed
-        // $this->performAjaxValidation($model);
 
-        if (isset($_POST['Sample'])) {
-            $model->attributes = $_POST['Sample'];
-                        $model->name = $_POST['Sample']['name'];
+        if ($sampleAttribute = Yii::$app->request->post('Sample')) {
+            $hasErrors = false;
+            $model->name = $sampleAttribute['name'];
 
-            if (strpos($_POST['Sample']['species_id'], ":") !== false) {
-                $array = explode(":", $_POST['Sample']['species_id']);
-                $tax_id = $array[0];
-                if (!empty($tax_id)) {
-                    $species = $this->findSpeciesRecord($tax_id, $model);
-                    $this->updateSampleAttributes($model);
-                    if (!$model->hasErrors()) {
-                        $this->redirect(array('view', 'id' => $model->id));
-                    }
-                } else {
-                    $model->addError('error', 'Taxon ID is empty!');
-                }
-            } else {
+            if (!strpos($sampleAttribute['species_id'], ':')) {
                 $model->addError('error', 'The input format is wrong, should be tax_id:common_name');
+                $hasErrors = true;
+            }
+
+            $array = explode(':', $sampleAttribute['species_id']);
+            $tax_id = $array[0];
+
+            if (!$tax_id) {
+                $model->addError('error', 'Taxon ID is empty!');
+                $hasErrors = true;
+            }
+
+            if (!$this->findSpeciesRecord($tax_id, $model)) {
+                $model->addError('error', 'The species does not exist');
+                $hasErrors = true;
+            }
+
+            if (!$hasErrors && $model->save()) {
+                $this->updateSampleAttributes($model);
+            }
+
+            if (!$model->hasErrors()) {
+                $this->redirect(array('view', 'id' => $model->id));
             }
         }
 
-            $species = Species::model()->findByPk($model->species_id);
+        $species = Species::model()->findByPk($model->species_id);
 
-            $model->species_id = $species->tax_id . ":";
-            $has_common_name = false;
-        if ($species->common_name != null) {
-                   $has_common_name = true;
-                   $model->species_id .= $species->common_name;
-        }
+        $model->species_id = sprintf('%s: %s', $species->tax_id, $species->common_name ?: '');
+        $model->species_id .= sprintf('%s%s', $species->common_name ? ', ' : '', $species->scientific_name ?: '');
 
-        if ($species->scientific_name != null) {
-            if ($has_common_name) {
-                $model->species_id .= ",";
-            }
-                    $model->species_id .= $species->scientific_name;
-        }
-            $this->render('update', array(
-                'model' => $model,
-                'species' => $species,
-            ));
+        $this->render('update', array(
+            'model'   => $model,
+            'species' => $species,
+        ));
     }
 
 	/**

--- a/protected/models/Sample.php
+++ b/protected/models/Sample.php
@@ -57,7 +57,7 @@ class Sample extends CActiveRecord
 		// NOTE: you should only define rules for those attributes that
 		// will receive user inputs.
 		return array(
-			array('species_id', 'required'),
+			array('species_id, name', 'required'),
 			array('species_id, submitted_id', 'numerical', 'integerOnly'=>true),
 			array('name', 'length', 'max'=>100),
             		array('consent_document, contact_author_name', 'length', 'max'=>45),

--- a/tests/acceptance/AdminSample.feature
+++ b/tests/acceptance/AdminSample.feature
@@ -69,6 +69,24 @@ Feature: admin page for samples
     And I should see "Attribute name for the input plant=\rose\ is not valid - please select a valid attribute name!"
 
   @ok
+  Scenario: display updated sample name when update
+    Given I am on "/adminSample/update/id/432"
+    When I fill in the field of "name" "Sample[name]" with "test"
+    And I press the button "Save"
+    And I wait "1" seconds
+    Then I should see "test"
+    Then I am on "/adminSample/view/id/432"
+    And I should see "test"
+
+  @ok
+  Scenario: display error with an empty name
+    Given I am on "/adminSample/update/id/432"
+    When I fill in the field of "name" "Sample[name]" with ""
+    And I press the button "Save"
+    And I wait "1" seconds
+    Then I should see "Sample ID cannot be blank"
+
+  @ok
   Scenario: display error message for non numeric taxon id when create
     Given I am on "/adminSample/create"
     And I should see "Create"


### PR DESCRIPTION
# Pull request for issue: #1991

This is a pull request for the following functionalities:

* update sample id

## How to test?

Go to https://gigadb.org/adminSample/view/id/187284
Update the Sample ID from [HiC_lib of NAS] to [HiC_lib_of_NAS]
Click 'Save'
The Sample ID is now [HiC_lib_of_NAS]

## How have functionalities been implemented?

Controller updated

## Any issues with implementation?

## Any changes to automated tests?

adminSampleCest test added

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?

Describe any improvements to the Gitlab pipeline
