### PR TITLE
Feat: Code refactoring to separate upload status transition and notifications (e.g: email) in preparation for upcoming work on dataset status overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-
 ## Unreleased
 
+- fix #1848: Separate the status transition from the notification
 - Feat #1867: Update the gitlab static application security testing (SAST) job using the Semgrep-based analyzer
 - Fix #2066: Max length for attribute value set to 1000 in file admin form
 - Feat #1968: Add curators manual for operating tools on bastion server

--- a/ops/configuration/php-conf/composer.json.dist
+++ b/ops/configuration/php-conf/composer.json.dist
@@ -33,7 +33,8 @@
          "nyholm/psr7": "1.8.1",
          "unleash/client": "v1.1.173",
          "cache/filesystem-adapter": "^1.2.0",
-         "kriswallsmith/buzz": "^1.2.1"
+         "kriswallsmith/buzz": "^1.2.1",
+         "symfony/string": "^5.4"
     },
     "require-dev": {
         "behat/behat": "^3.5",

--- a/protected/components/DatasetUpload.php
+++ b/protected/components/DatasetUpload.php
@@ -95,55 +95,37 @@ class DatasetUpload extends yii\base\BaseObject
     }
 
     /**
-     * method to set Dataset Upload status to Submitted,  notify curators and add curation log
+     * method to set Dataset Upload status to Submitted
      *
-     * @param string $content email content of notification
      * @param string|null $previousStatus useful if dataset has already been updated
      *
      * @return bool whether operation is successful
      */
-    public function setStatusToSubmitted(string $content, string $previousStatus = null): bool
+    public function setStatusToSubmitted(string $previousStatus = null): bool
     {
-        $statusChanged = $this->_datasetDAO->transitionStatus("DataAvailableForReview", "Submitted", null, $previousStatus);
-
-        if ($statusChanged) {
-            Yii::log("Status changed to Submitted", 'info');
-            $emailSent = $this->_fileUploadSrv->emailSend(
-                $this->_config["sender"],
-                $this->_config["curators_email"],
-                "Dataset has been submitted",
-                $content
-            );
-            return $emailSent;
-        }
-        Yii::log("Failed to change status to Submitted", 'error');
-        return $statusChanged;
+        return $this->_datasetDAO->transitionStatus("DataAvailableForReview", "Submitted", null, $previousStatus);
     }
 
     /**
-     * method to set Dataset Upload status to DataPwnding and notify curators
+     * method to set Dataset Upload status to DataPending
      *
-     * @param string $content email content of notification
-     * @param string $authorEmail email of the author
      * @param string|null $previousStatus useful if dataset has already been updated
      *
      * @return bool whether operation is successful
      */
-    public function setStatusToDataPending(string $content, string $authorEmail, string $previousStatus = null): bool
+    public function setStatusToDataPending(string $previousStatus = null): bool
     {
-        $statusChanged = $this->_datasetDAO->transitionStatus("Submitted", "DataPending", null, $previousStatus);
-        if ($statusChanged) {
-            Yii::log("Status changed to DataPending", 'info');
-            $emailSent = $this->_fileUploadSrv->emailSend(
-                $this->_config["sender"],
-                $authorEmail,
-                "Dataset has been set to DataPending",
-                $content
-            );
-            return $emailSent;
-        }
-        Yii::log("Failed to change status to DataPending", 'error');
-        return $statusChanged;
+        return $this->_datasetDAO->transitionStatus("Submitted", "DataPending", null, $previousStatus);
+    }
+
+    public function sendNotificationEmailBody(string $content, string $uploadStatus, string $authorEmail = null): bool
+    {
+        return $this->_fileUploadSrv->emailSend(
+            $this->_config['sender'],
+            $authorEmail ?: $this->_config['curators_email'],
+            sprintf('Dataset has been %s', $uploadStatus),
+            $content
+        );
     }
 
     /**

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -207,6 +207,26 @@ class AdminDatasetController extends Controller
         Yii::log('**** new attributes: ' . print_r($postDataset, true), 'warning');
         $uploadStatus = $postDataset['upload_status'];
         $previousUploadStatus = $model->upload_status;
+        $isStatusAvailable = true;
+
+        // setting DatasetUpload, the busisness object for File uploading
+        $datasetUpload = $this->getDatasetUpload($model->identifier);
+
+        if ($uploadStatus && $uploadStatus !== $previousUploadStatus) {
+            $isStatusAvailable = $this->checkAndSetTransition($datasetUpload, $model, $uploadStatus);
+        }
+
+        if (!$isStatusAvailable) {
+            Yii::app()->user->setFlash('updateError', 'Fail to update status!');
+            Yii::log(sprintf('Failed to change status to %s', $uploadStatus), 'error');
+
+            return $this->render('update', array(
+                'model' => $model,
+                'datasetPageSettings' => $datasetPageSettings,
+                'curationlog'=> $dataProvider,
+                'dataset_id'=> $id,
+            ));
+        }
 
         //curator
         $curatorId = $postDataset['curator_id'];
@@ -239,8 +259,9 @@ class AdminDatasetController extends Controller
                 $model->updateDatasetTypes($postDatasetTypes);
             }
 
-            if ($uploadStatus !== $previousUploadStatus) {
-                $this->renderNotificationsAccordingToStatus($uploadStatus, $previousUploadStatus, $model);
+            if ($uploadStatus && $uploadStatus !== $previousUploadStatus) {
+                Yii::log('Status changed to '.$uploadStatus, 'info');
+                $this->renderNotificationsAccordingToStatus($datasetUpload, $model);
             }
 
             // semantic kewyords update, using remove all and re-create approach
@@ -492,36 +513,46 @@ class AdminDatasetController extends Controller
         return $model;
     }
 
-    private function renderNotificationsAccordingToStatus($uploadStatus, $previousStatus, $model)
+    private function getDatasetUpload(string $identifier): DatasetUpload
     {
         // setting DatasetUpload, the busisness object for File uploading
         $webClient = \Yii::$container->get('guzzleHttpClient');
-        $fileUploadSrv = Yii::app()->fileUploadService->getFileUploadService($webClient, $model->identifier);
-        $datasetUpload = new DatasetUpload(
+        $fileUploadSrv = Yii::app()->fileUploadService->getFileUploadService($webClient, $identifier);
+
+        return new DatasetUpload(
             $fileUploadSrv->dataset,
             $fileUploadSrv,
             Yii::$app->params['dataset_upload']
         );
+    }
 
-        switch ($uploadStatus) {
+    private function checkAndSetTransition(DatasetUpload $datasetUpload, Dataset $model, string $newStatus): bool
+    {
+        switch ($newStatus) {
+            case 'Submitted':
+                return $datasetUpload->setStatusToSubmitted($model->upload_status);
+
+            case 'DataPending':
+                return $datasetUpload->setStatusToDataPending($model->upload_status);
+
+            default:
+                return true;
+        }
+    }
+
+    private function renderNotificationsAccordingToStatus(DatasetUpload $datasetUpload, Dataset $model)
+    {
+        switch ($model->upload_status) {
             case 'Submitted':
                 $contentToSend = $datasetUpload->renderNotificationEmailBody('Submitted');
-                $statusIsSet = $datasetUpload->setStatusToSubmitted($contentToSend, $previousStatus);
+                $statusIsSet = $datasetUpload->sendNotificationEmailBody($contentToSend, $model->upload_status);
 
                 break;
             case 'DataPending':
-                $contentToSend = $datasetUpload->renderNotificationEmailBody('DataPending');
+                $contentToSend = ($emailBody = Yii::$app->request->post('Dataset')['emailBody']) ?
+                    $this->processTemplateString($emailBody, ['identifier' => $model->identifier]) : $datasetUpload->renderNotificationEmailBody('DataPending');
 
-                // If formdata has a defined custom email body, user it instead of the twig template
-                if (isset($_POST['Dataset']['emailBody']) && $_POST['Dataset']['emailBody'] != '') {
-                    $contentToSend = $this->processTemplateString($_POST['Dataset']['emailBody'], [
-                        'identifier' => $model->identifier
-                    ]);
-                }
-
-                $statusIsSet = $datasetUpload->setStatusToDataPending(
-                    $contentToSend, $model->submitter->email, $previousStatus
-                );
+                $statusIsSet = $datasetUpload->sendNotificationEmailBody($contentToSend, $model->upload_status, $model->submitter->email);
 
                 break;
             default:
@@ -529,8 +560,8 @@ class AdminDatasetController extends Controller
         }
 
         if ($statusIsSet) {
-            CurationLog::createlog($uploadStatus, $model->id);
+            CurationLog::createlog($model->upload_status, $model->id);
         }
     }
 }
-?>
+

--- a/protected/models/DatasetDAO.php
+++ b/protected/models/DatasetDAO.php
@@ -113,7 +113,7 @@ class DatasetDAO extends yii\base\BaseObject
 			$dataset = Dataset::model()->findByAttributes(['identifier' => $this->_identifier]);
 		}
 
-		if (!$toStatus || $fromStatus !== ($previousStatus ?: $dataset->upload_status)) {
+		if ($fromStatus !== ($previousStatus ?: $dataset->upload_status)) {
 			return false;
 		}
 

--- a/protected/tests/unit/DatasetUploadTest.php
+++ b/protected/tests/unit/DatasetUploadTest.php
@@ -70,16 +70,6 @@ class DatasetUploadTest extends CDbTestCase
         $mockDatasetDAO->expects($this->once())
                  ->method('transitionStatus')
                  ->with("DataAvailableForReview", "Submitted")
-                 ->willReturn(true);    
-
-        $mockFileUploadSrv->expects($this->once())
-                 ->method('emailSend')
-                 ->with(
-                 	$config["sender"], 
-                 	"database@gigadb.test", 
-                 	"Dataset has been submitted", 
-                 	$content
-                 )
                  ->willReturn(true);
 
 
@@ -91,7 +81,6 @@ class DatasetUploadTest extends CDbTestCase
 
 	public function testRenderNotificationEmailBody()
 	{
-
 		$config = [
 			"sender" => "admin@gigadb.org",
 			"recipient" => "editorial@gigadb.test",
@@ -108,6 +97,31 @@ class DatasetUploadTest extends CDbTestCase
 		$datasetFileUpload = new DatasetUpload($mockDatasetDAO, $mockFileUploadSrv, $config);
 		$renderedContent = $datasetFileUpload->renderNotificationEmailBody("DataAvailableForReview");
 		$this->assertTrue(1 == preg_match('/dataset with DOI 003000/', $renderedContent));
+	}
+
+	public function testSendNotificationEmailBody()
+	{
+		$config = [
+			'sender'        => 'admin@gigadb.org',
+			"curators_email" => "database@gigadb.test",
+		];
+
+		$mockDatasetDAO = $this->createMock(DatasetDAO::class);
+		$mockFileUploadSrv = $this->createMock(FileUploadService::class);
+
+		$mockFileUploadSrv->expects($this->once())
+			->method('emailSend')
+			->with(
+				$config['sender'],
+				'database@gigadb.test',
+				'Dataset has been Submitted',
+				'test content'
+			)
+			->willReturn(true);
+
+		$datasetFileUpload = new DatasetUpload($mockDatasetDAO, $mockFileUploadSrv, $config);
+		$result = $datasetFileUpload->sendNotificationEmailBody('test content', 'Submitted');
+		$this->assertTrue($result);
 	}
 
 	/**


### PR DESCRIPTION
# Pull request for issue: #701

This is a pull request for the following functionalities:

separate the transition and notification concerning upload_status update. 
If the transition is not allowed, the model shouldn't be saved.

It's temporary, while waiting for a PR creating a dedicated service 

## How to test?

- Go to a dataset form
- try  "UserStartedIncomplete" to "Submitted" or to "DataPending"
- Scroll down to Save
- changes should not been saved.

## How have functionalities been implemented?

## Any issues with implementation?

## Any changes to automated tests?

## Any changes to documentation?


## Any technical debt repayment?

## Any improvements to CI/CD pipeline?

