### PR TITLE
fix: error when deleting file from admin dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #2015: Error when deleting file on admin dasboard
 - Fix #2029: Add new file attribute even if edit attribute fields are visible
 
 ## v4.3.6 - 2024-09-13 - 2d935c496 -

--- a/protected/controllers/AdminFileController.php
+++ b/protected/controllers/AdminFileController.php
@@ -483,40 +483,56 @@ class AdminFileController extends Controller
     /**
      * Deletes a particular model.
      * If deletion is successful, the browser will be redirected to the 'admin' page.
+     *
      * @param integer $id the ID of the model to be deleted
      */
-   public function actionDelete($id)
+   public function actionDelete(int $id)
     {
-
-        if (Yii::app()->request->isPostRequest) {
-            // we only allow deletion via POST request
-            $file = File::model()->findByPk($id);
-            // $file->fileSamples->delete();
-          foreach ($file->fileAttributes as $fileattributes) {
-              print_r($fileattributes);
-              $fileattributes->delete();
-
-          }
-         foreach ($file->fileSamples as $filesample) {
-              print_r($filesample);
-              $filesample->delete();
-
-          }
-
-         $file->delete();
-
-        }
-
-            // if AJAX request (triggered by deletion via admin grid view), we should not redirect the browser
-
-        if (!isset($_GET['ajax'])) {
-            $this->redirect(isset($_POST['returnUrl']) ? $_POST['returnUrl'] : array('admin'));
-        } else {
+        // we only allow deletion via POST request
+        if (!Yii::app()->request->isPostRequest) {
             throw new CHttpException(400, 'Invalid request. Please do not repeat this request again.');
         }
 
-    }
+        $file = File::model()->findByPk($id);
 
+        $transaction = Yii::app()->db->beginTransaction();
+
+        try {
+            foreach ($file->fileAttributes as $fileAttribute) {
+                $isDeleted = $fileAttribute->delete();
+
+                if (!$isDeleted) {
+                    throw new CHttpException(500, 'There was an error while deleting the file');
+                }
+            }
+
+            foreach ($file->fileSamples as $fileSample) {
+                $isDeleted = $fileSample->delete();
+
+                if (!$isDeleted) {
+                    throw new CHttpException(500, 'There was an error while deleting the file');
+                }
+            }
+
+            $isDeleted = $file->delete();
+
+            if (!$isDeleted) {
+                throw new CHttpException(500, 'There was an error while deleting the file');
+            }
+        } catch(\Throwable $e) {
+            if ($transaction->getActive()) {
+                $transaction->rollback();
+            }
+
+            throw new CHttpException(500, 'There was an error while deleting the file');
+        }
+
+        if (!$transaction->getActive()) {
+            throw new CHttpException(500, 'There was an error while deleting the file');
+        }
+
+        $transaction->commit();
+    }
 
     /**
      * Lists all models.

--- a/tests/acceptance/AdminFiles.feature
+++ b/tests/acceptance/AdminFiles.feature
@@ -1,0 +1,19 @@
+@ok-can-offline
+Feature: Files dashboard
+  As a curator
+  I want to be able to delete a file from the dashboard
+  So that I can quickly manage all the files from the dashboard
+
+
+  Background:
+    Given I have signed in as admin
+
+  @ok
+  Scenario: I can delete a file from the dashboard
+    Given I am on "/adminFile/admin"
+    And I should see "readme.txt"
+    When I press the button ".table tbody tr:first-child td:nth-child(8) .icon-delete"
+    When I wait "3" seconds
+    When I confirm to "Are you sure you want to delete this item?"
+    And I wait "1" seconds
+    Then I should not see "readme.txt"


### PR DESCRIPTION
#2015
This is a pull request for the following functionalities:

fix the error when deleting file from admin dashboard

## How to test?

Go to https://gigadb.org/adminFile/admin
Search for the files that I want to remove
Click on the delete button
remove the line/file

## How have functionalities been implemented?
Needed to remove the final if else statement in order to avoid the error

## Any issues with implementation?

## Any changes to automated tests?

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?
