### PR TITLE
File adminfile new attr bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-## v4.3.6 - 2024-09-13 - 2d935c496 - 
+- Fix #2029: Add new file attribute even if edit attribute fields are visible
+
+## v4.3.6 - 2024-09-13 - 2d935c496 -
 
 - Feat #1858: Relabel button that saves attribute in adminFile to avoid ambiguity
 - Feat #1849: Able to toggle expand dataset sample attributes field

--- a/protected/controllers/AdminFileController.php
+++ b/protected/controllers/AdminFileController.php
@@ -382,7 +382,7 @@ class AdminFileController extends Controller
         // Uncomment the following line if AJAX validation is needed
         // $this->performAjaxValidation($model);
         if (isset($_POST['edit_attr'])) {
-            $args = $_POST['FileAttributes'];
+            $args = $_POST['FileAttributes']['edit'];
             $fa = FileAttributes::model()->findByPk($args['id']);
             if($fa) {
                 $fa->attribute_id = $args['attribute_id'];
@@ -400,7 +400,7 @@ class AdminFileController extends Controller
             }
         }
         elseif(isset($_POST['submit_attr'])) {
-            $attrs = $_POST['FileAttributes'];
+            $attrs = $_POST['FileAttributes']['new'];
             $attribute->attribute_id = $attrs['attribute_id'];
             $attribute->value = $attrs['value'];
             if($attrs['unit_id'])

--- a/protected/views/adminFile/_attr.php
+++ b/protected/views/adminFile/_attr.php
@@ -1,12 +1,11 @@
 <td>
-	<?php echo CHtml::activeHiddenField($attribute, 'id') ?>
-	<?php echo CHtml::activeDropDownList($attribute, 'attribute_id', CHtml::listData(Attributes::model()->findAll(), 'id', 'attribute_name'), array('class' => 'attr-form form-control', 'empty' => 'Select name', 'title' => 'Choose the appropriate attribute name from the dropdown menu', 'data-toggle' => 'tooltip')); ?>
+	<?php echo CHtml::activeHiddenField($attribute, '[edit]id') ?>
+	<?php echo CHtml::activeDropDownList($attribute, '[edit]attribute_id', CHtml::listData(Attributes::model()->findAll(), 'id', 'attribute_name'), array('class' => 'attr-form form-control', 'empty' => 'Select name', 'title' => 'Choose the appropriate attribute name from the dropdown menu', 'data-toggle' => 'tooltip')); ?>
+<td>
+	<?php echo CHtml::activeTextField($attribute, '[edit]value', array('class' => 'attr-form form-control', 'title' => 'Choose the appropriate attribute name from the dropdown menu', 'data-toggle' => 'tooltip')); ?>
 </td>
 <td>
-	<?php echo CHtml::activeTextField($attribute, 'value', array('class' => 'attr-form form-control', 'title' => 'Choose the appropriate attribute name from the dropdown menu', 'data-toggle' => 'tooltip')); ?>
-</td>
-<td>
-	<?php echo CHtml::activeDropDownList($attribute, 'unit_id', CHtml::listData(Unit::model()->findAll(), 'id', 'name'), array('class' => 'attr-form form-control', 'empty' => 'Select unit', 'title' => 'Choose the appropriate attribute name from the dropdown menu', 'data-toggle' => 'tooltip')); ?>
+	<?php echo CHtml::activeDropDownList($attribute, '[edit]unit_id', CHtml::listData(Unit::model()->findAll(), 'id', 'name'), array('class' => 'attr-form form-control', 'empty' => 'Select unit', 'title' => 'Choose the appropriate attribute name from the dropdown menu', 'data-toggle' => 'tooltip')); ?>
 </td>
 <td>
 	<button type="submit" class="btn background-btn js-save" name="edit_attr">Save Attribute</button>

--- a/protected/views/adminFile/_form.php
+++ b/protected/views/adminFile/_form.php
@@ -125,7 +125,7 @@
                         $this->widget('application.components.controls.DropdownField', [
                             'form' => $form,
                             'model' => $attribute,
-                            'attributeName' => 'attribute_id',
+                            'attributeName' => '[new]attribute_id',
                             'listDataOptions' => [
                                 'data' => Attributes::model()->findAll(),
                                 'valueField' => 'id',
@@ -144,7 +144,7 @@
                         $this->widget('application.components.controls.TextField', [
                             'form' => $form,
                             'model' => $attribute,
-                            'attributeName' => 'value',
+                            'attributeName' => '[new]value',
                             'inputOptions' => [
                                 'class' => 'attr-form'
                             ],
@@ -157,7 +157,7 @@
                         $this->widget('application.components.controls.DropdownField', [
                             'form' => $form,
                             'model' => $attribute,
-                            'attributeName' => 'unit_id',
+                            'attributeName' => '[new]unit_id',
                             'listDataOptions' => [
                                 'data' => Unit::model()->findAll(),
                                 'valueField' => 'id',

--- a/tests/_support/Steps/CuratorSteps.php
+++ b/tests/_support/Steps/CuratorSteps.php
@@ -236,4 +236,20 @@ class CuratorSteps extends \Codeception\Actor
 
     }
 
+    /**
+     * @When I select :arg1 in menu :arg2
+     */
+    public function iSelectInMenu($arg1, $arg2)
+    {
+        $this->I->selectOption("//*[@id='$arg2']", $arg1);
+    }
+
+    /**
+     * @When I fill in the text input :arg1 with :arg2
+     */
+    public function iFillInTheTextInputWith($arg1, $arg2)
+    {
+        $this->I->fillField(['name' => $arg1], $arg2);
+    }
+
 }

--- a/tests/acceptance/AdminFileAttributes.feature
+++ b/tests/acceptance/AdminFileAttributes.feature
@@ -145,3 +145,17 @@ Feature: A curator can manage file attributes in admin file update page
     And I wait 2 seconds
     Then I should see "Save Attribute"
     And I should see a submit button "Save"
+
+  @ok @issue-2029
+  Scenario: When both the edit from and the new attribute form are open, duplicate are not created
+    Given I have signed in as admin
+    And I am on "/adminFile/update/id/13973"
+    And I press the button "Edit"
+    And I press the button "Show New Attribute Fields"
+    When I select "age" in menu "FileAttributes_new_attribute_id"
+    And I fill in the text input "FileAttributes[new][value]" with "35"
+    And I press the button "Add attribute"
+    Then I should see a file attribute table
+      | Attribute Name | Value     | Unit |
+      | last_modified  | 2013-7-15 |      |
+      | age            | 35        |      |


### PR DESCRIPTION
# Pull request for issue: #2029

This is a pull request for the following functionalities:

* Fix bug where if adding a new attribute when the edit attribute fields are visible, then the new attr is the same as the exisitng attr

## How to test?

Follow steps in #2029 and confirm the bug is not longer reproduced

## How have functionalities been implemented?

Given distinct names to the edit attribute and new attribute fields so that backend can distinguish which values to pick

## Any issues with implementation?

--

## Any changes to automated tests?

--