### PR TITLE
Upgrade bootstrap to 3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-## v4.3.6 - 2024-09-13 - 2d935c496 - 
+- Feat #2: Upgrade Bootstrap from v3.3.7 to v3.4.1
+
+## v4.3.6 - 2024-09-13 - 2d935c496 -
 
 - Feat #1858: Relabel button that saves attribute in adminFile to avoid ambiguity
 - Feat #1849: Able to toggle expand dataset sample attributes field

--- a/protected/views/layouts/main.php
+++ b/protected/views/layouts/main.php
@@ -15,7 +15,7 @@
 
   <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.css">
   <link rel="stylesheet" type="text/css"
-    href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css">
+    href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/css/bootstrap.min.css">
   <link rel="stylesheet" type="text/css"
     href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <link rel="stylesheet" type="text/css" href="/fonts/open_sans/v13/open_sans.css">
@@ -27,7 +27,7 @@
   <?php if (isset($this->loadBaBbqPolyfills) && $this->loadBaBbqPolyfills) {
     $this->renderPartial('//shared/_baBbqPolyfills');
   } ?>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" defer></script>
   <title>
     <?php echo CHtml::encode($this->pageTitle); ?>
   </title>


### PR DESCRIPTION
# Pull request for issue: #2

Issue: https://github.com/gigascience/security/issues/2

This is a pull request for the following functionalities:

* Upgrade bootstrap to 3.4.1

## How to test?

Confirm by opening html DOM in dev tools and checking bootstrap version

## How have functionalities been implemented?

replaced version number in layout file protected/views/layouts/main.php

Since this is a minor upgrade nothing should "break", and the docs do not mention any action to migrate

As stated here: https://getbootstrap.com/docs/3.4/getting-started/#still-on-bootstrap-3-or-4

- bootstrap 3.4.1 is the latest version of b3 and patches a XSS vulnerability among other
- bootstrap 3 is EOL so it would be an option to consider NES support (paid service) or upgrade to bootstrap 5 (probably quite costly in terms of refactoring the codebase as there are numerous breaking changes, i.e. https://getbootstrap.com/docs/5.0/migration/ and there are two steps: v3 -> v4 -> v5)

## Any issues with implementation?

--

## Any changes to automated tests?

--