### PR TITLE
fix: sample attribute lat lon regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #831: Check if longitude and lagitude match the WGS84 format for sample attributes
+
 ## v4.4.16 - 2025-08-15 - 6e04c0b9e -
 
 - Fix #2428: AdminUserController should target AdminUserController when validating or rejecting a claim

--- a/data/dev/attribute.csv
+++ b/data/dev/attribute.csv
@@ -18,6 +18,8 @@ id,attribute_name,definition,model,structured_comment_name,value_syntax,allowed_
 347,last_modified,the date the file was last modified,modified,last_modified,date,"",1,"",""
 356,Description,"description of the sample (may include many attributes as human readable text, but these should also be added as independent attribute:value pairs).","",description,text,"",1,"",""
 376,estimated genome size,"An estimate of the size of the genome of the species being studied, in basepairs (Gb, Mb or Kb)","",est_genome_size,text,"",1,"",""
+391,geographic location (latitude),"The geographical latitudinal origin of the sample, the value should be reported in decimal degrees and in WGS84 system","",latitude,number,"","","",""
+392,geographic location (longitude),"The geographical longitudinal origin of the sample, the value should be reported in decimal degrees and in WGS84 system","",longitude,number,"","","",""
 448,alternative accession-biosample,"","",alt_acc_biosample,"","","","",""
 455,keyword,"","",keywords,"","","","",""
 472,camera parameters,"","",camera_parameters,text,"",m,"",""

--- a/protected/controllers/AdminSampleController.php
+++ b/protected/controllers/AdminSampleController.php
@@ -23,7 +23,7 @@ class AdminSampleController extends Controller
 	{
 		return array(
 			array('allow', // admin only
-				'actions'=>array('admin','delete','index','view','create','update'),
+				'actions'=>array('admin','delete','index','view','create','update', 'checkAttribute'),
 				'roles'=>array('admin'),
 			),
                         array('allow', 'actions' => array('create1', 'choose'), 'users' => array('@')),
@@ -312,6 +312,47 @@ class AdminSampleController extends Controller
 		}
 	}
 
+    public function actionCheckAttribute()
+    {
+        if (!Yii::app()->request->isAjaxRequest) {
+            throw new CHttpException(400,'Invalid request. An Error occurred');
+        }
+
+        $errorMessage = [];
+        $attributesList = Yii::$app->request->post('attr');
+
+        foreach (explode('",', $attributesList) as $attributes) {
+            $attributes = str_replace('"', '', $attributes);
+            $attributeData = explode('=', $attributes);
+            if (count($attributeData) === 2) {
+                $attributeData[0] = trim($attributeData[0]);
+                if ($attributeData[0] !== 'longitude' && $attributeData[0] !== 'latitude') {
+                    continue;
+                }
+
+                $errorMessage = $this->checkWrongLatLongAttribute($attributeData[0], $attributeData[1]);
+            }
+        }
+
+        echo CJSON::encode(['messages' => $errorMessage]);
+        Yii::app()->end();
+    }
+
+    private function checkWrongLatLongAttribute(string $attribute, string $attributeValue): array
+    {
+        $errorMessage = [];
+        if (preg_match('/^[^0-9]*$/', $attributeValue)) {
+            $errorMessage[] = sprintf('Attribute value for %s doesn\'t match WGS84 decimal format.
+                    For geographic location (country, sea, region) use another attribute name', $attribute);
+        } else if ($attribute === 'latitude' && !preg_match('/^[-+]?(?:90(?:\.0+)?|[1-8]?\d(?:\.\d+)?)$/', $attributeValue)) {
+            $errorMessage[] = sprintf('Attribute value for %s doesn\'t match WGS84 decimal format', $attribute);
+        } else if ($attribute === 'longitude' && !preg_match('/^[-+]?(?:180(?:\.0+)?|1[0-7]\d(?:\.\d+)?|\d{1,2}(?:\.\d+)?)$/', $attributeValue)) {
+            $errorMessage[] = sprintf('Attribute value for %s doesn\'t match WGS84 decimal format', $attribute);
+        }
+
+        return $errorMessage;
+    }
+
     /**
      * Upate sample attribute
      *
@@ -329,20 +370,28 @@ class AdminSampleController extends Controller
                 $sampleAttribute->sample_id = $model->id;
                 $attributes = str_replace('"', '', $attributes);
                 $attributeData = explode('=', $attributes);
-                if (count($attributeData) == 2) {
+                if (count($attributeData) === 2) {
                     // Get attribute model
                     $attribute = Attributes::model()->findByAttributes(array('structured_comment_name' => trim($attributeData[0])));
                     if (!$attribute) {
                         $model->addError('error', 'Attribute name for the input ' . $attributeData[0] . "=" . $attributeData[1] . ' is not valid - please select a valid attribute name!');
-                    } else {
-                        // Let's save the new sample attribute
-                        $sampleAttribute->value = trim($attributeData[1]);
-                        $sampleAttribute->attribute_id = $attribute->id;
-                        if (!$sampleAttribute->save(true)) {
-                            foreach ($sampleAttribute->getErrors() as $errors) {
-                                foreach ($errors as $errorMessage) {
-                                    $model->addError('error', $errorMessage);
-                                }
+
+                        continue;
+                    }
+
+                    if ($attributeData[0] === 'longitude' || $attributeData[0] === 'latitude') {
+                        if ($this->checkWrongLatLongAttribute($attributeData[0], $attributeData[1])) {
+                            continue;
+                        }
+                    }
+
+                    // Let's save the new sample attribute
+                    $sampleAttribute->value = trim($attributeData[1]);
+                    $sampleAttribute->attribute_id = $attribute->id;
+                    if (!$sampleAttribute->save()) {
+                        foreach ($sampleAttribute->getErrors() as $errors) {
+                            foreach ($errors as $errorMessage) {
+                                $model->addError('error', $errorMessage);
                             }
                         }
                     }

--- a/protected/views/adminSample/_form.php
+++ b/protected/views/adminSample/_form.php
@@ -117,7 +117,8 @@
                 url: "<?php echo  Yii::app()->createUrl('adminSample/checkAttribute') ?> ",
                 type: 'POST',
                 data:  {
-                    attr: $('.form').find("textarea[name='Sample[attributesList]']").val()
+                    attr: $('.form').find("textarea[name='Sample[attributesList]']").val(),
+                    '<?php echo Yii::app()->request->csrfTokenName; ?>': '<?php echo Yii::app()->request->csrfToken; ?>'
                 },
                 dataType: 'json',
                 success: function(response) {

--- a/protected/views/adminSample/_form.php
+++ b/protected/views/adminSample/_form.php
@@ -9,10 +9,12 @@
         <p class="note">Fields with <span class="required">*</span> are required.</p>
 
         <?php if ($model->hasErrors()) : ?>
-            <div class="alert alert-danger">
+            <div id="sample_error" class="alert alert-danger">
                 <?php echo $form->errorSummary($model); ?>
             </div>
         <?php endif; ?>
+
+        <div id="ajax-error" class='alert alert-danger' style="display: none;">An error occurred</div>
 
         <div class="form-group">
             <?php echo $form->labelEx($model, 'species_id', array('class' => 'control-label')); ?>
@@ -65,10 +67,86 @@
 
         <div class="pull-right btns-row">
             <a href="/adminSample/admin" class="btn background-btn-o">Cancel</a>
-            <?php echo CHtml::submitButton($model->isNewRecord ? 'Create' : 'Save', array('class' => 'btn background-btn')); ?>
+            <button id='checkAttribute' type='button' class="btn btn-primary"><?php echo $model->isNewRecord ? 'Create' : 'Save'?></button>
+
         </div>
 
+        <div class='modal fade' id='confirmation_sample_modal' role='dialog'>
+            <div class='modal-dialog modal-lg'>
+                <div class='modal-content'>
+                    <div class='modal-header'>
+                        <button type='button' class='close' data-dismiss='modal'>&times;</button>
+                        <h4 class='modal-title'>Important</h4>
+                    </div>
+                    <div class='modal-body'>
+                        <div id='check-attribute-warning' class='alert alert-danger' style='display: none;'>
+                        </div>
+                        <div id="check-attribute-confirmation" class="mt-4">
+                        </div>
+                    </div>
+                    <div class='modal-footer'>
+                        <a id="hideModal" class='btn background-btn-o'>Cancel</a>
+                        <?php echo CHtml::submitButton('Confirm', array('id' => 'submit_confirmation', 'class' => 'btn background-btn')); ?>
+                    </div>
+                </div>
+
+            </div>
+        </div>
         <?php $this->endWidget(); ?>
     </div>
 
 </div>
+<script>
+    $(document).ready(function() {
+        $('#hideModal').click(function(e) {
+            $('#confirmation_sample_modal').modal('hide');
+        })
+
+        $('#checkAttribute').click(function (e) {
+            e.preventDefault()
+
+            let myWarning = $('#check-attribute-warning')[0];
+            let myConfirmation = $('#check-attribute-confirmation')[0];
+            myWarning.innerHTML = '';
+            myWarning.style.display = 'none'
+            myConfirmation.innerHTML = '';
+            $('#submit_confirmation')[0].style.display = ''
+            $('#ajax-error')[0].style.display = 'none';
+
+            $.ajax({
+                url: "<?php echo  Yii::app()->createUrl('adminSample/checkAttribute') ?> ",
+                type: 'POST',
+                data:  {
+                    attr: $('.form').find("textarea[name='Sample[attributesList]']").val()
+                },
+                dataType: 'json',
+                success: function(response) {
+                    $('#confirmation_sample_modal').modal('show');
+                    let messages = response.messages
+
+                    if (!messages.length) {
+                        let el = document.createElement('div');
+                        el.textContent= 'Are you sure you want to continue?'
+                        el.className = 'mt-4'
+                        myConfirmation.appendChild(el);
+
+                        return;
+                    }
+
+                    myWarning.style.display = 'block'
+                    $('#submit_confirmation')[0].style.display = 'none'
+
+                    messages.forEach((message) => {
+                        let el = document.createElement('li');
+                        el.textContent = message;
+
+                        myWarning.appendChild(el);
+                    })
+                },
+                error: function(xhr, status, error) {
+                    $('#ajax-error')[0].style.display = 'block';
+                }
+            });
+        });
+    });
+</script>

--- a/tests/acceptance/AdminSample.feature
+++ b/tests/acceptance/AdminSample.feature
@@ -20,6 +20,9 @@ Feature: admin page for samples
     When I fill in the field of "name" "Sample[species_id]" with ":Foxtail millet"
     And I press the button "Save"
     And I wait "1" seconds
+    Then I should see "Are you sure you want to continue?"
+    And I press the button "Confirm"
+    And I wait "1" seconds
     Then I should see "Please fix the following input errors:"
     And I should see "Taxon ID is empty!"
 
@@ -29,6 +32,8 @@ Feature: admin page for samples
     And I should see "lat_lon"
     When I fill in the field of "name" "Sample[attributesList]" with "source_mat_id=\"David Lambert & BGI\",est_genome_size=\"1.32\",alternative_names=\"PYGAD\",animal=\"tiger\""
     And I press the button "Save"
+    And I wait "1" seconds
+    And I press the button "Confirm"
     And I wait "1" seconds
     Then I should see "Please fix the following input errors:"
     And I should see "Attribute name for the input animal=\tiger\ is not valid - please select a valid attribute name!"
@@ -42,6 +47,8 @@ Feature: admin page for samples
     And I should see "lat_lon"
     And I press the button "Save"
     And I wait "1" seconds
+    And I press the button "Confirm"
+    And I wait "1" seconds
     And I should see "David Lambert"
     And I should see "1.32"
     And I should see "PYGAD"
@@ -53,6 +60,8 @@ Feature: admin page for samples
     When I fill in the field of "name" "Sample[species_id]" with "4555=Foxtail millet"
     And I press the button "Save"
     And I wait "1" seconds
+    And I press the button "Confirm"
+    And I wait "1" seconds
     Then I should see "Please fix the following input errors:"
     And I should see "The input format is wrong, should be tax_id:common_name"
 
@@ -62,6 +71,8 @@ Feature: admin page for samples
     And I should see "lat_lon"
     When I fill in the field of "name" "Sample[attributesList]" with "animal=\"tiger\",plant=\"rose\""
     And I press the button "Save"
+    And I wait "1" seconds
+    And I press the button "Confirm"
     And I wait "1" seconds
     Then I should see "Please fix the following input errors:"
     And I should see "Attribute name for the input animal=\tiger\ is not valid - please select a valid attribute name!"
@@ -73,6 +84,8 @@ Feature: admin page for samples
     When I fill in the field of "name" "Sample[name]" with "test"
     And I press the button "Save"
     And I wait "1" seconds
+    And I press the button "Confirm"
+    And I wait "1" seconds
     Then I should see "test"
     Then I am on "/adminSample/view/id/432"
     And I should see "test"
@@ -83,6 +96,8 @@ Feature: admin page for samples
     When I fill in the field of "name" "Sample[name]" with ""
     And I press the button "Save"
     And I wait "1" seconds
+    And I press the button "Confirm"
+    And I wait "1" seconds
     Then I should see "Sample ID cannot be blank"
 
   @ok
@@ -91,6 +106,8 @@ Feature: admin page for samples
     And I should see "Create"
     When I fill in the field of "name" "Sample[species_id]" with "Human"
     And I press the button "Create"
+    And I wait "1" seconds
+    And I press the button "Confirm"
     And I wait "1" seconds
     Then I should see "Please fix the following input errors:"
     And I should see "Taxon ID Human is not numeric!"
@@ -101,6 +118,8 @@ Feature: admin page for samples
     And I should see "Create"
     When I fill in the field of "name" "Sample[species_id]" with "789123"
     And I press the button "Create"
+    And I wait "1" seconds
+    And I press the button "Confirm"
     And I wait "1" seconds
     Then I should see "Please fix the following input errors:"
     And I should see "Taxon ID 789123 is not found!"
@@ -113,8 +132,94 @@ Feature: admin page for samples
     And I fill in the field of "name" "Sample[attributesList]" with "animal=\"tiger\""
     And I press the button "Create"
     And I wait "1" seconds
+    And I press the button "Confirm"
+    And I wait "1" seconds
     Then I should see "Please fix the following input errors:"
     And I should see "Attribute name for the input animal=\tiger\ is not valid - please select a valid attribute name!"
+
+  @ok
+  Scenario: display 1 warning message when create with wrong latitude beyond 90
+    Given I am on "/adminSample/create"
+    And I should see "Create"
+    When I fill in the field of "name" "Sample[species_id]" with "87676:Eucalyptus pauciflora"
+    And I fill in the field of "name" "Sample[attributesList]" with "latitude=\"95.1234\""
+    And I press the button "Create"
+    And I wait "1" seconds
+    Then I should not see "Are you sure you want to continue?"
+    And I should see "Attribute value for latitude doesn't match WGS84 decimal format"
+    And I should not see "Confirm"
+
+  @ok
+  Scenario: display 1 warning message when create with wrong latitude below -90
+    Given I am on "/adminSample/create"
+    And I should see "Create"
+    When I fill in the field of "name" "Sample[species_id]" with "87676:Eucalyptus pauciflora"
+    And I fill in the field of "name" "Sample[attributesList]" with "latitude=\"-95.1234\""
+    And I press the button "Create"
+    And I wait "1" seconds
+    Then I should not see "Are you sure you want to continue?"
+    And I should see "Attribute value for latitude doesn't match WGS84 decimal format"
+    And I should not see "Confirm"
+
+  @ok
+  Scenario: display 1 warning message when create with wrong longitude beyond 180
+    Given I am on "/adminSample/create"
+    And I should see "Create"
+    When I fill in the field of "name" "Sample[species_id]" with "87676:Eucalyptus pauciflora"
+    And I fill in the field of "name" "Sample[attributesList]" with "longitude=\"200.1234\""
+    And I press the button "Create"
+    And I wait "1" seconds
+    Then I should not see "Are you sure you want to continue?"
+    And I should see "Attribute value for longitude doesn't match WGS84 decimal format"
+    And I should not see "Confirm"
+
+  @ok
+  Scenario: display 1 warning message when create with wrong longitude below -180
+    Given I am on "/adminSample/create"
+    And I should see "Create"
+    When I fill in the field of "name" "Sample[species_id]" with "87676:Eucalyptus pauciflora"
+    And I fill in the field of "name" "Sample[attributesList]" with "longitude=\"-200.1234\""
+    And I press the button "Create"
+    And I wait "1" seconds
+    Then I should see "Attribute value for longitude doesn't match WGS84 decimal format"
+    And I should not see "Are you sure you want to continue?"
+    And I should not see "Confirm"
+
+  @ok
+  Scenario: display 1 warning message when create with incorrect formatting
+    Given I am on "/adminSample/create"
+    And I should see "Create"
+    When I fill in the field of "name" "Sample[species_id]" with "87676:Eucalyptus pauciflora"
+    And I fill in the field of "name" "Sample[attributesList]" with "longitude=\"123.456.789\""
+    And I press the button "Create"
+    And I wait "1" seconds
+    Then I should not see "Are you sure you want to continue?"
+    And I should see "Attribute value for longitude doesn't match WGS84 decimal format"
+    And I should not see "Confirm"
+
+  @ok
+  Scenario: display 1 extra message when create longitude with extra symbol
+    Given I am on "/adminSample/create"
+    And I should see "Create"
+    When I fill in the field of "name" "Sample[species_id]" with "87676:Eucalyptus pauciflora"
+    And I fill in the field of "name" "Sample[attributesList]" with "longitude=\"123.4567°\""
+    And I press the button "Create"
+    And I wait "1" seconds
+    Then I should not see "Are you sure you want to continue?"
+    And I should see "Attribute value for longitude doesn't match WGS84 decimal format"
+    And I should not see "Confirm"
+
+  @ok
+  Scenario: display 1 warning message when create with region for latitude
+    Given I am on "/adminSample/create"
+    And I should see "Create"
+    When I fill in the field of "name" "Sample[species_id]" with "87676:Eucalyptus pauciflora"
+    And I fill in the field of "name" "Sample[attributesList]" with "latitude=something"
+    And I press the button "Create"
+    And I wait "1" seconds
+    Then I should not see "Are you sure you want to continue?"
+    And I should see "Attribute value for latitude doesn't match WGS84 decimal format. For geographic location (country, sea, region) use another attribute name"
+    And I should not see "Confirm"
 
   @ok
   Scenario: display 2 input error messages when create
@@ -123,6 +228,8 @@ Feature: admin page for samples
     When I fill in the field of "name" "Sample[species_id]" with "87676:Eucalyptus pauciflora"
     And I fill in the field of "name" "Sample[attributesList]" with "animal=\"tiger\",plant=\"rose\""
     And I press the button "Create"
+    And I wait "1" seconds
+    And I press the button "Confirm"
     And I wait "1" seconds
     Then I should see "Please fix the following input errors:"
     And I should see "Attribute name for the input animal=\tiger\ is not valid - please select a valid attribute name!"
@@ -135,6 +242,8 @@ Feature: admin page for samples
     When I fill in the field of "name" "Sample[species_id]" with "87676:Eucalyptus pauciflora"
     And I fill in the field of "name" "Sample[attributesList]" with "sex=\"male\",alternative_names=\"Alternative name here\""
     And I press the button "Create"
+    And I wait "1" seconds
+    And I press the button "Confirm"
     And I wait "1" seconds
     Then I should see "View Sample #451"
     And I should see "male"


### PR DESCRIPTION
# Pull request for issue: [#831](https://github.com/gigascience/gigadb-website/issues/831)

This is a pull request for the following functionalities:

check attribute modal (latitude and longitude) + tests

## How to test?
connect as admin
click samples
edit or create a ne sample
in attribute list field add longitude=200.1234 e.g
click save
you should see a popup alert with "Attribute value for longitude doesn't match WGS84 decimal format"
you can confirm it if you want to override the alert and save 

## How have functionalities been implemented?

add method in adminSampleController

## Any issues with implementation?


## Any changes to automated tests?

test added

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?

