### PR TITLE
Setup semgrep sast job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,7 +64,7 @@ image: docker:$DOCKER_VERSION
 
 
 include:
-  - template: Security/SAST.gitlab-ci.yml
+  - template: Jobs/SAST.gitlab-ci.yml
   - template: Jobs/Container-Scanning.gitlab-ci.yml
   - local: "ops/pipelines/gigadb-build-jobs.yml"
   - local: "ops/pipelines/gigadb-test-jobs.yml"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1867: Update the gitlab static application security testing (SAST) job using the Semgrep-based analyzer
 - Feat #1968: Add curators manual for operating tools on bastion server
 - Feat #1750: Switch to guzzle instead of cURL
 - Fix #2042: Batch deletion of file attributes and samples

--- a/gigadb/app/tools/files-url-updater/gitlab-config.yml
+++ b/gigadb/app/tools/files-url-updater/gitlab-config.yml
@@ -45,7 +45,7 @@ FilesUrlsUpdaterTest:
     - $LOCAL_COMPOSE ps
     - $LOCAL_COMPOSE run --rm updater ./vendor/bin/codecept run tests/unit
     - $LOCAL_COMPOSE run --rm updater ./vendor/bin/codecept run tests/functional
-  needs: ["container_scanning","phpcs-security-audit-sast"]
+  needs: ["container_scanning","semgrep-sast"]
   environment:
     name: dev
 
@@ -85,7 +85,7 @@ FilesUrlsUpdaterBuildStaging:
       - .ci_env
     when: always
     expire_in: 3 days
-  needs: ["FilesUrlsUpdaterTest"]
+  needs: ["semgrep-sast"]
 
 FilesUrlsUpdaterDeployStaging:
   stage: staging deploy

--- a/gigadb/app/tools/readme-generator/gitlab-config-test.yml
+++ b/gigadb/app/tools/readme-generator/gitlab-config-test.yml
@@ -51,6 +51,6 @@ ReadmeGeneratorTest:
     - $LOCAL_COMPOSE ps
     - $LOCAL_COMPOSE run --rm tool ./vendor/bin/codecept run tests/unit
     - $LOCAL_COMPOSE run --rm tool ./vendor/bin/codecept run tests/functional
-  needs: ["container_scanning","phpcs-security-audit-sast"]
+  needs: ["container_scanning","semgrep-sast"]
   environment:
     name: dev

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -70,10 +70,6 @@ check_PHPDoc:
 
 semgrep-sast:
   stage: conformance and security
-  artifacts:
-    untracked: true
-    when: always
-    expire_in: 1 week
 
 variables:
   CS_ANALYZER_IMAGE: "$CI_TEMPLATE_REGISTRY_HOST/security-products/container-scanning:6"

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -95,11 +95,14 @@ phpcs-security-audit-sast:
       exists:
         - '**/*.php'
 
-
 semgrep-sast:
   stage: conformance and security
-  variables:
-    SAST_DISABLED: "true"
+  artifacts:
+    untracked: true
+    when: always
+    expire_in: 1 week
+    reports:
+      sast: gl-sast-report.json
 
 spotbugs-sast:
   stage: conformance and security

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -68,47 +68,14 @@ check_PHPDoc:
     - docker-compose run --rm gigadb
     - docker-compose run --rm test ./tests/coverage_check
 
-
-bandit-sast:
-  stage: conformance and security
-  variables:
-    SAST_DISABLED: "true"
-
-eslint-sast:
-  stage: conformance and security
-  variables:
-    SAST_DISABLED: "true"
-
-nodejs-scan-sast:
-  stage: conformance and security
-  variables:
-    SAST_DISABLED: "true"
-
-phpcs-security-audit-sast:
-  stage: conformance and security
-  rules:
-    - if: $SAST_DISABLED == 'true' || $SAST_DISABLED == '1'
-      when: never
-    - if: $SAST_EXCLUDED_ANALYZERS =~ /phpcs-security-audit/
-      when: never
-    - if: $CI_COMMIT_BRANCH || $CI_COMMIT_TAG
-      exists:
-        - '**/*.php'
-
 semgrep-sast:
   stage: conformance and security
+  variables:
+    SAST_EXCLUDED_ANALYZERS: "spotbugs, bandit, eslint, nodejs-scan"
   artifacts:
     untracked: true
     when: always
     expire_in: 1 week
-    reports:
-      sast: gl-sast-report.json
-
-spotbugs-sast:
-  stage: conformance and security
-  variables:
-    SAST_DISABLED: "true"
-
 
 variables:
   CS_ANALYZER_IMAGE: "$CI_TEMPLATE_REGISTRY_HOST/security-products/container-scanning:6"

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -70,8 +70,6 @@ check_PHPDoc:
 
 semgrep-sast:
   stage: conformance and security
-  variables:
-    SAST_EXCLUDED_ANALYZERS: "spotbugs, bandit, eslint, nodejs-scan"
   artifacts:
     untracked: true
     when: always


### PR DESCRIPTION
# Pull request for issue: #1867
This is a pull request for the following functionalities:

- Replaced deprecated `phpcs-security-audit` SAST [analyzer](https://gitlab.com/gitlab-org/gitlab/-/issues/364060
) with the [latest one](https://docs.gitlab.com/ee/user/application_security/sast/analyzers.html)
- Implemented `Smegrep` to the current gitlab pipeline 
- By default enable the sast jobs for `hpcs-security-audit`, together with  `bandit`, `eslint, `nodejs` and `spot-bugs`
- Made the config of the stage `conformance and security` simpler and more concise


### pre-requisite
1. Confirm the existing `phpcs-security-audit-sast` is throwing warning by checking the log in the gitlab as below:
```
$ echo "This job was deprecated in GitLab 16.8 and removed in GitLab 17.0"
This job was deprecated in GitLab 16.8 and removed in GitLab 17.0
$ echo "For more information see https://docs.gitlab.com/ee/update/deprecations.html#sast-analyzer-coverage-changing-in-gitlab-170"
For more information see https://docs.gitlab.com/ee/update/deprecations.html#sast-analyzer-coverage-changing-in-gitlab-170
$ exit 1
```

2. And check the results in the gitlab pipeline dashboard

<img width="1636" alt="image" src="https://github.com/user-attachments/assets/b26da12f-d645-4ea1-9ab3-b9a6e88f3374">

## How to test?

Describe how the new functionalities can be tested by PR reviewers

1. Check out this PR and push it to gitlab
2. Confirm that `semgrep-sast` is executed successfully with log as below:
```
$ /analyzer run
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶ GitLab Semgrep analyzer v5.17.0
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶ Detecting project
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶ Analyzer will attempt to analyze all projects in the repository
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶ Loading ruleset for /builds/gigascience/forks/kencho-gigadb-website
[WARN] [Semgrep] [2024-10-16T05:55:28Z] ▶ /builds/gigascience/forks/kencho-gigadb-website/.gitlab/sast-ruleset.toml not found, ruleset customization will be disabled.
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶ Running analyzer
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶ 19 active rule files detected with 590 active rules
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/bandit.yml': 'eb05c3eedb03dc71ee30851f488bbde16a6ce968d593ef8761304ac753a0a174'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/eslint.yml': '6f56a19be4aaf8ef188a349df8b723f65cb84d836624860407ebc2a49704106e'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/find_sec_bugs.yml': '59014b1ea7f0f5a779267f5a9b25f31a4268fded25acf07a8fff8fcc8dd7f2b5'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/find_sec_bugs_scala.yml': '21d17f120429057b30c2ff0d450b2699f3c1209c93d807968032549c532eeebf'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/flawfinder.yml': 'd2f2b3b8de3df70e0659bd579a361f9537de1573c6b45ca972944964e4c1c52e'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/gitlab/gitlab_ee_java.yml': '48d6f2d8bcbd6eecfc498de7de2e3a64c0ec9762d07f99bfd90fb30c9c1ea83f'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/gitlab/gitlab_ee_javascript.yml': '373f01b1bbd751bdfb584d2d201bec876cf1877f8fb17b625659c058c3d6c45e'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/gitlab_ce_python.yml': '3858706bc49608dc0c1bf8ad7cbc5434125c43d738508edb6f8d4cb2532305a0'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/gitlab_ce_scala.yml': 'f809bb49f0948decd7246cc1b28e070edc35d5f1be84567774578472bdf7244b'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/gosec.yml': '8efe509470af4ef7f84c3b10438172d97b71e526ffe4140e01ccc609ee963c3b'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/lgpl-cc/brakeman.yml': 'f84af1052ba36516270a098f829636af38ccad9df482b7ca12421af9c68bfb46'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/lgpl-cc/gitlab_lgpl_cc_java.yml': 'c2894f583e8cffaec920a29e628120409d5923f26e21a252cee9c797657809e8'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/lgpl-cc/gitlab_lgpl_cc_javascript.yml': 'c33b64087eb1c366b5b216242ada36ef9d85780dffea0124c6049f75fd316d6f'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/lgpl-cc/gitlab_lgpl_cc_python.yml': '08d5acf7a3ccd2f78226f7a99d38be853708f752a5c434afd83b3fd80ca165a9'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/lgpl-cc/phpcs_security_audit.yml': '4d337d17d8ca30b831913fbb6e893c1644bcc8a842211c64b64baf3fafa93aff'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/lgpl/find_sec_bugs_kotlin.yml': '09e6ccedeb5123bb49a86e4823ef95c3113284ef1e654a69ea8e22d43434dfe7'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/lgpl/mobsf.yml': '205e7a812b2f88790507a5c6bc451ac9126310cb9cb064baf7c912eca750e833'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/lgpl/nodejs_scan.yml': '90af38d1761b1ec4330986f741ef518c6164af6253fc7fb1ab32fb81e19a4d8b'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶  * rule file '/rules/security_code_scan.yml': '12c8605979e415e86d35e61a77d1eb89906fb1780a4ee74261c301a13f5aaf04'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶ Combined rule checksum: 'b2194f729fb005a385a626ad80a75fe68b46f3bd5cb4c2b101eef80d51455c30'
[INFO] [Semgrep] [2024-10-16T05:55:28Z] ▶ Using the GitLab SAST default ruleset
[INFO] [Semgrep] [2024-10-16T05:56:11Z] ▶ Creating report
[WARN] [Semgrep] [2024-10-16T05:56:11Z] ▶ tool notification warning: Syntax error Syntax error at line protected/views/search/_result.php:54:
 `)` was unexpected
[INFO] [2024-10-16T05:56:11Z] ▶ /builds/gigascience/forks/kencho-gigadb-website/gl-report-post.json written
Saving cache for successful job
```
3. And check the results in the gitlab pipeline dashboard

<img width="1618" alt="image" src="https://github.com/user-attachments/assets/f53b911d-d931-488b-b6d0-23a932f1b64e">


## How have functionalities been implemented?

Describe how the new functionalities have been implemented by the
changed code at a high level

By replacing the deprecated template `Security/SAST.gitlab-ci.yml` with `Jobs/SAST.gitlab-ci.yml`, the `Semgrep` analyzer will be triggered automatically, and this analyzer by default will perform Static Application Security Testing (SAST) scanning on repositories containing code written in several languages:

```
C# (.NET)
C
C++
Go
Kotlin
Java
JavaScript
Objective-C
PHP
Python
Ruby
Rust
Scala
Swift
TypeScript
```

Other `Semgrep-based` analyzers will also be triggered, for example:
```
bandit
eslint
find_sec_bugs
find_sec_bugs_scala
flawfinder
phpcs_security_audit
nodejs_scan
security_code_scan
...
```


Unless `SAST_EXCLUDED_ANALYZERS` has been provided, for example:
```
variables:
  SAST_EXCLUDED_ANALYZERS: "spotbugs"
```

## Any issues with implementation?

None.

## Any changes to automated tests?

None.

## Any changes to documentation?

None.

## Any technical debt repayment?

None.

## Any improvements to CI/CD pipeline?

Replaced the deprecated template `Security/SAST.gitlab-ci.yml` with `Jobs/SAST.gitlab-ci.yml`.
