### PR TITLE
feature:1667 when minting, add log entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1667: Add log entry when minting DOI
 - Fix #2094: Make Semgrep-based SAST analyzer available in tagged release
 - Feat #701: Code refactoring to separate upload status transitions and notifications to prepare for upload status overhaul
 - Security #1867: Update the gitlab static application security testing (SAST) job using the Semgrep-based analyzer

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -427,18 +427,28 @@ class AdminDatasetController extends Controller
             Yii::app()->end();
         }
 
+        $action = 'DOI Minting';
+        $log = sprintf('Dataset %s', $doi);
         $doiResponse = $client->request('GET', $mds_doi_url . '/' . $mds_prefix . '/' . $doi, [
             'http_errors' => false,
             'auth'        => [$mds_username, $mds_password]
         ]);
         $result['doi_response'] = $doiResponse->getBody()->getContents();
         $result['check_doi_status'] = $doiResponse->getStatusCode();
+        $isPresent = in_array($result['check_doi_status'], [200, 204]);
+        $log .= sprintf(' - Check DOI: %s', $isPresent ? "OK" : "DOI doesn't exist");
 
-        if ($result['check_doi_status'] === 200 || $result['check_doi_status'] === 204  || $result['check_doi_status'] === 404) {
-            $xml_data = $dataset->toXML();
+        if ($isPresent || $result['check_doi_status'] === 404) {
+            if (!$xml_data = $dataset->toXML()) {
+                $result['error'] = 'An error occurred while transforming the dataset as xml';
+                $log .= ' ERROR: An error occurred while transforming the dataset as xml';
+
+                echo json_encode($result);
+                Yii::app()->end();
+            }
             $options = [
                 'headers'     => [
-                    'Content-Type' => 'text/xml; charset=UTF8',
+                    'Content-Type' => 'text/xml;charset=UTF8',
                 ],
                 'auth'        => [$mds_username, $mds_password],
                 'body'        => $xml_data,
@@ -450,6 +460,7 @@ class AdminDatasetController extends Controller
             $keyStatus = sprintf('%s_md_status', $result['check_doi_status'] === 200 ? 'update' : 'create');
             $result[$keyResponse] = $updateMdResponse->getBody()->getContents();
             $result[$keyStatus] = $updateMdResponse->getStatusCode();
+            $log .= sprintf(' - %s md response: %s', $result['check_doi_status'] === 200 ? 'update' : 'create', 201 === $result[$keyStatus] ? "OK" : $result[$keyResponse]);
 
             if (201 === $updateMdResponse->getStatusCode() && 404 === $result['check_doi_status']) {
                 $result['doi_data'] = 'doi=' . $mds_prefix . '/' . $doi . "\n" . 'url=http://gigadb.org/dataset/' . $doi;
@@ -466,9 +477,11 @@ class AdminDatasetController extends Controller
 
                 $result['create_doi_response'] = $response->getBody()->getContents();
                 $result['create_doi_status'] = $response->getStatusCode();
+                $log .= sprintf(' - Create DOI: %s', $result['create_doi_status'] === 201 ? 'OK' : $result['create_doi_response']);
             }
         }
 
+        CurationLog::createGeneralCurationLogEntry($dataset->id, $action, $log);
         echo json_encode($result);
         Yii::app()->end();
     }

--- a/protected/models/CurationLog.php
+++ b/protected/models/CurationLog.php
@@ -114,6 +114,15 @@ class CurationLog extends CActiveRecord
         return $curationlog->save();
     }
 
+    public static function createGeneralCurationLogEntry(int $id, string $action, string $content, $author = 'system'): bool
+    {
+        $curationLog = self::makeNewInstanceForCurationLogBy($id, $author);
+        $curationLog->action = $action;
+        $curationLog->comments = $content;
+
+        return $curationLog->save();
+    }
+
     /**
      *
      * alias to allow code from develop up to commit 4ab4399 to work

--- a/protected/models/Dataset.php
+++ b/protected/models/Dataset.php
@@ -442,8 +442,8 @@ class Dataset extends CActiveRecord
     }
 
     /**
-     * toXML(): fucntion tha treturn Datacite XML for this dataset
-     * @return Datacite XML 4.0 for this dataset
+     * toXML(): function tha return Datacite XML for this dataset
+     * @return bool|string XML 4.0 for this dataset
      */
     public function toXML() {
         $xmlstr = "<?xml version='1.0' ?>\n".
@@ -593,7 +593,6 @@ class Dataset extends CActiveRecord
         $description = $descriptions->addChild('description',str_replace(array('&','>','<','"'), array('&amp;','&gt;','&lt;','&quot;'), $this->description));
         $description->addAttribute('xml:lang','en-US','http://www.w3.org/XML/1998/namespace');
         $description->addAttribute('descriptionType','Abstract');
-
 
         return $xml->asXML();
     }

--- a/protected/views/adminDataset/_form.php
+++ b/protected/views/adminDataset/_form.php
@@ -358,18 +358,22 @@ echo $form->hiddenField($model, "image_id");
                                             'data' => ['doi' => 'js:$("#Dataset_identifier").val()'],
                                             'dataType' => 'json',
                                             'success' => new CJavaScriptExpression('function(output) {
-                                                if (output.check_doi_status == 200 && output.update_md_status == 201) {
+                                                if (output.check_doi_status === 200 && output.update_md_status === 201) {
                                                     $("#minting").addClass("alert alert-info").html("This DOI exists in datacite already, no need to mint, but the metadata is updated!");
-                                                } else if (output.check_doi_status == 200 && output.update_md_status == 422) {
+                                                } else if (output.check_doi_status === 204 && output.create_md_status === 201) {
+                                                    $("#minting").addClass("alert alert-info").html("This DOI exists but is not registered, no need to mint, but the metadata has been created!");
+                                                } else if (output.check_doi_status === 200 && output.update_md_status !== 201) {
                                                     $("#minting").addClass("alert alert-info").html("This DOI exists in datacite, but failed to update metadata because of: " + output.update_md_response);
-                                                } else if (output.create_md_status == 201 && output.create_doi_status == 201) {
-                                                    $("#minting").addClass("alert alert-success").html("New DOI successfully minted");
-                                                } else if (output.check_doi_status == 404 && output.create_md_status == 422) {
+                                                } else if (output.check_doi_status === 204 && output.create_md_status !== 201) {
+                                                    $("#minting").addClass("alert alert-info").html("This DOI exists in datacite, but failed to create metadata because of: " + output.create_md_response);
+                                                } else if (output.check_doi_status === 404 && output.create_md_status !== 201) {
                                                     $("#minting").addClass("alert alert-danger").html("This DOI cannot be created because of the metadata status: " + output.create_md_status + ". Details can be found at <a href=\'https://support.datacite.org/reference/mds#api-response-codes\' target=\'_blank\'>here</a>");
-                                                } else if (output.check_doi_status == 200 && output.update_md_status != 200) {
-                                                    $("#minting").addClass("alert alert-danger").html("Error with metadata status: " + output.update_md_status + " and DOI status: " + output.check_doi_status + " Details can be found at <a href=\'https://support.datacite.org/reference/mds#api-response-codes\' target=\'_blank\'>here</a>");
+                                                } else if (output.create_md_status === 201 && output.create_doi_status !== 201) {
+                                                    $("#minting").addClass("alert alert-success").html("New DOI couldn\'t be minted");
+                                                } else if (output.create_md_status === 201 && output.create_doi_status === 201) {
+                                                    $("#minting").addClass("alert alert-success").html("New DOI successfully minted");
                                                 } else {
-                                                 $("#minting").addClass("alert alert-danger").html("DOI status: " + output.check_doi_status + ". An error occurred");
+                                                 $("#minting").addClass("alert alert-danger").html("An error occurred");
                                                 }
                                                 
                                                 if (output.error) {
@@ -380,10 +384,10 @@ echo $form->hiddenField($model, "image_id");
                                             ),
                                         ],
                                         array(
-                                            'class' => 'btn background-btn m-0',
-                                            'id' => 'mint_doi_button',
-                                            'disabled' => in_array($model->upload_status, $status_array),
-                                            'title' => 'This botton will take all the dataset information stored in GigaDB and convert it to the DataCite schema in XML and via an API call, register that information with DataCite',
+                                            'class'       => 'btn background-btn m-0',
+                                            'id'          => 'mint_doi_button',
+                                            'disabled'    => in_array($model->upload_status, $status_array),
+                                            'title'       => 'This button will take all the dataset information stored in GigaDB and convert it to the DataCite schema in XML and via an API call, register that information with DataCite',
                                             'data-toggle' => 'tooltip'
                                         )
                                     );

--- a/tests/acceptance/AdminDatasetCurationLog.feature
+++ b/tests/acceptance/AdminDatasetCurationLog.feature
@@ -1,0 +1,17 @@
+@ok-needs-secrets
+Feature: curation log entry under the dataset form
+  As a curator
+  I want to see see a curation log entry after minting DOI
+  So that the curation log entry is visible
+
+  Background:
+    Given I have signed in as admin
+
+  @ok
+  Scenario: Minting Doi and adding curation log entry
+    When I am on "/adminDataset/update/id/8"
+    And I press the button "Mint DOI"
+    And I wait "3" seconds
+    And I should see "This DOI exists in datacite already, no need to mint, but the metadata is updated!"
+    Then I am on "/adminDataset/update/id/8"
+    And I should see "Dataset 100006 - Check DOI: OK - update md response: OK"


### PR DESCRIPTION
# Pull request for issue: #1667 

Add log entry when minting

## How to test?
 when I press "Mint DOI" button on a dataset form
I will have a record of when a DOI was created or refreshed

## How have functionalities been implemented?

## Any issues with implementation?

## Any changes to automated tests?

tests added

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?
