### PR TITLE
fix: create a mockup for all upload status exception published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #2033: Create a mockup for all upload statuses except published
+
 ## v4.4.7 - 2025-03-18 - c9bccd170 -
+
 - Fix #2180: Add user in curation log when minting the DOI
 - Feat #2066: Wrap edit file attribute form in a modal
 - Fix #2203: Update the curation log without requiring a page refresh when minting a DOI

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -326,16 +326,26 @@ class AdminDatasetController extends Controller
      */
     public function actionPrivate()
     {
-        $id = $_GET['identifier'];
+        $id = Yii::$app->request->get('identifier');
         $model= Dataset::model()->find("identifier=?", array($id));
         $datasetPageSettings = new DatasetPageSettings($model);
-        if ( "invalid" === $datasetPageSettings->getPageType() ) {
+        $pageType = $datasetPageSettings->getPageType();
+
+        if (!in_array($pageType, ['invalid', 'public', 'hidden', 'draft', 'mockup'])) {
+            throw new CHttpException(404, 'Page type not found');
+        }
+
+        if ("invalid" === $pageType) {
             $this->redirect('/site/index');
-        } elseif ( "public" === $datasetPageSettings->getPageType() ) {
+        } elseif ("public" === $pageType) {
             $this->redirect('/dataset/'.$model->identifier);
-        } elseif ( "hidden" === $datasetPageSettings->getPageType() || "draft" === $datasetPageSettings->getPageType() ) {
+        } else {
             $model->token = Yii::$app->security->generateRandomString(16);
-            $model->save();
+
+            if (!$model->save()) {
+                throw new CHttpException(500, 'Fail to update dataset token');
+            }
+
             $this->redirect('/dataset/'.$model->identifier.'/token/'.$model->token);
         }
     }

--- a/protected/views/adminDataset/_form.php
+++ b/protected/views/adminDataset/_form.php
@@ -5,7 +5,7 @@
 <?php } ?>
 
 <?php if ($flashError = Yii::app()->user->getFlash('updateError')) { ?>
-    <div class="alert alert-danger" role="alert">
+    <div id="flashError" class="alert alert-danger" role="alert">
         <?= $flashError ?>
     </div>
 <?php } ?>
@@ -532,7 +532,7 @@ echo $form->hiddenField($model, "image_id");
 
       if ($showCreateResetUrlBtn) {
         ?>
-        <a class="btn background-btn-o" href="<?php echo Yii::app()->createUrl('/adminDataset/private/identifier/' . $model->identifier) ?>" title="This will save any changes made on this page AND create a new mockup page URL/token link" data-toggle="tooltip">Create/Reset Private URL</a>
+        <a id="mockup" class="btn background-btn-o" href="<?php echo Yii::app()->createUrl('/adminDataset/private/identifier/' . $model->identifier) ?>" title="This will save any changes made on this page AND create a new mockup page URL/token link" data-toggle="tooltip">Create/Reset Private URL</a>
         <?php
       }
       if ($showMockupBtn) {
@@ -621,6 +621,32 @@ echo $form->hiddenField($model, "image_id");
     </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
 <script>
+    $(document).ready(function () {
+        $('#mockup').on('click', function (event) {
+            event.preventDefault();
+
+            mockupUrl = $(this).attr("href");
+            form = $('#dataset-form');
+
+            $.ajax({
+                url: form.attr('action'),
+                method: 'POST',
+                data: form.serialize(),
+                success: function (response, textStatus, xhr) {
+                    if (200 === xhr.status) {
+                        window.location.href = mockupUrl;
+                    } else {
+                        $('#flashError').html('An error occurred while trying to save the dataset')
+                    }
+
+                },
+                error: function (error) {
+                    $('#flashError').html('An error occurred while trying to save the dataset')
+                }
+            })
+        });
+    });
+
     $(function() {
 
         var publication_date = $('.js-date-pub');

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -131,9 +131,15 @@ Feature: form to update dataset details
   Scenario: Can create/reset private url
     When I am on "/adminDataset/update/id/5"
     And I press the button "Create/Reset Private URL"
-    And I wait "1" seconds
+    And I wait "3" seconds
     Then I should see current url contains "/dataset/100039/token/"
     And I should see "Genomic data of the Puerto Rican Parrot (Amazona vittata) from a locally funded project."
+
+  @ok @dataset-status
+  Scenario: Can't see create/reset private url for a published dataset
+    When I am on "/adminDataset/update/id/8"
+    Then I should not see "Create/Reset Private URL"
+    And I should not see "Open Private URL"
 
   @ok @issue-1023
   Scenario: Open private url is working
@@ -189,6 +195,7 @@ Feature: form to update dataset details
     And I fill in the field of "name" "Dataset[title]" with "test dataset"
     And I fill in the field of "name" "Dataset[identifier]" with "123789"
     And I fill in the field of "name" "Dataset[ftp_site]" with "ftp://test"
+    When I check the field "Dataset_Epigenomic"
     And I press the button "Create"
     And I wait "1" seconds
     And I am on "/adminDataset/update/id/2741"
@@ -477,15 +484,20 @@ Feature: form to update dataset details
       | "DataAvailableForReview" |
       | "DataPending"            |
 
-  @ok @dataset-status
-  Scenario: Links to create mockup or to open mockup are not present for a published dataset
+  @ok
+  Scenario: Links to create mockup is present for a submitted dataset
     Given I am on "/adminDataset/update/id/5"
-    And I select "Published" from the field "Dataset_upload_status"
+    And I select "DataAvailableForReview" from the field "Dataset_upload_status"
     And I press the button "Save"
     When I am on "/adminDataset/update/id/5"
-    Then I should not see "Create/Reset Private URL"
-    And I should not see "Open Private URL"
-
+    And I select "Submitted" from the field "Dataset_upload_status"
+    And I press the button "Save"
+    When I am on "/adminDataset/update/id/5"
+    Then I should see "Create/Reset Private URL"
+    And I press the button "Create/Reset Private URL"
+    And I wait "3" seconds
+    Then I should see current url contains "/dataset/100039/token/"
+    And I should see "Genomic data of the Puerto Rican Parrot (Amazona vittata) from a locally funded project."
 
   @ok @issue-1812 @mockup
   Scenario: Navigating mockup page tables does not generate errors


### PR DESCRIPTION
# Pull request for issue: #2033

This is a pull request for the following functionalities:

create a mockup for all upload status exception published
Also, save the dataset before creating the mockup

## How to test?

Given I am on the dataset Admin page of any dataset with a status of anything EXCEPT "Published"
When I look at the bottom of the page
Then I should see a create/reset private URL button
And when I click that button it does create or reset the private URL for that dataset.

## How have functionalities been implemented?

call submit action before calling create/reset url

## Any issues with implementation?

## Any changes to automated tests?

test added

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?
