### PR TITLE
Make semgrep available in tag release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #2094: Make Semgrep-based SAST analyzer available in tagged release
 - Feat #701: Code refactoring to separate upload status transitions and notifications to prepare for upload status overhaul
 - Security #1867: Update the gitlab static application security testing (SAST) job using the Semgrep-based analyzer
 

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -70,6 +70,8 @@ check_PHPDoc:
 
 semgrep-sast:
   stage: conformance and security
+  rules:
+    - if: $CI_COMMIT_BRANCH || $CI_COMMIT_TAG
 
 variables:
   CS_ANALYZER_IMAGE: "$CI_TEMPLATE_REGISTRY_HOST/security-products/container-scanning:6"


### PR DESCRIPTION
# Pull request for issue: #2094 

This is a pull request for the following functionalities:

Make the `Semgrep` SAST job available in a tagged release, which is essential for the production release.

## How to test?

Describe how the new functionalities can be tested by PR reviewers

Follow the steps in `docs/RELEASE_PROCESS.md` to make a mock release.

## How have functionalities been implemented?

Describe how the new functionalities have been implemented by the
changed code at a high level


Since only tagged release can be deploy to productions, the `semgrep-sast` job introduced in https://github.com/gigascience/gigadb-website/pull/2063 needs to be refactored that the `semgrep-sast` can also be triggered in the tagged release by adding the following block to the config:
```
  rules:
    - if: $CI_COMMIT_BRANCH || $CI_COMMIT_TAG
```

## Any issues with implementation?

None.

## Any changes to automated tests?
None.

## Any changes to documentation?

None.

## Any technical debt repayment?

None.

## Any improvements to CI/CD pipeline?

None.
