### PR TITLE
Fix 1975 remove empty line at the beginning of the xml result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1975: Remove empty line at the beginning of the xml result
 - Feat #456: Improve DataCite metadata by migrating to Datacite version 4.6
 - Fix #1727: Sort files and samples by id in descending order when querying
 

--- a/protected/controllers/ApiController.php
+++ b/protected/controllers/ApiController.php
@@ -2,9 +2,6 @@
 
 class ApiController extends Controller
 {
-    // Members
-
-
     const RESULTS = ['file', 'sample', 'dataset'];
 
 	/**
@@ -81,9 +78,14 @@ class ApiController extends Controller
             $this->_sendResponse(400, 'An error occurred, please check your parameters');
         }
 
+        // needed in order to remove the empty line
+        ob_start();
+        $image = $model->image;
+        ob_get_clean();
+
          switch ($result) {
                 case "dataset":
-                    $this->renderPartial('singledatasetonly',array('model'=> $model));
+                    $this->renderPartial('singledatasetonly',array('model'=> $model, 'image' => $image));
                     break;
                 case "sample":
                     $this->renderPartial('singlesample',array('model'=> $model));
@@ -92,7 +94,7 @@ class ApiController extends Controller
                     $this->renderPartial('singlefile',array('model'=> $model));
                     break;
                 case "all":
-                    $this->renderPartial('singledataset',array('model'=> $model));
+                    $this->renderPartial('singledataset',array('model'=> $model, 'image' => $image));
                     break;
                 default:
                     $this->_sendResponse(500, 'A problem occurred');

--- a/protected/views/api/singledataset.php
+++ b/protected/views/api/singledataset.php
@@ -57,7 +57,6 @@ foreach($dataset_types as $dataset_type) {
 }
 $xml.="  </data_types>\n";
 //image
-$image=$model->image;
 $xml.="  <image>\n";
 $xml.="   <image_filename>$image->location</image_filename>\n";
 $xml.="   <tag>$image->tag</tag>\n";
@@ -77,18 +76,17 @@ $xml.="  </publication>\n";
 $xml.="  <links>\n";
 $xml.="   <external_links>\n";
 $external_links=$model->externalLinks;
-if(isset($external_links)){
+
 foreach($external_links as $external_link)
 {
     $external_link_type=  ExternalLinkType::model()->findByAttributes(array('id'=>$external_link->external_link_type_id));
     $xml.="    <external_link type=\"$external_link_type->name\">$external_link->url</external_link>\n";
     
 }
-}
+
 $xml.="   </external_links>\n";
 $xml.="   <project_links>\n";
 $project_links=$model->projects;
-if(isset($project_links)){
 foreach($project_links as $project){
     $dataset_project=  DatasetProject::model()->findByAttributes(array('project_id'=>$project->id));
     $xml.="    <project_link>\n";
@@ -96,21 +94,19 @@ foreach($project_links as $project){
     $xml.="     <project_url>$project->url</project_url>\n";
     $xml.="    </project_link>\n";    
 }
-}
+
 $xml.="   </project_links>\n";
 $xml.="   <internal_links>\n";
 $internal_links=$model->relations;
-if(isset($internal_links)){
 foreach($internal_links as $relation)
 {
     $relationship=  Relationship::model()->findByAttributes(array('id'=>$relation->relationship_id));
     $xml.="    <related_DOI relationship=\"$relationship->name\">$relation->related_doi</related_DOI>\n";
 }
-}
+
 $xml.="   </internal_links>\n";
 $xml.="   <manuscript_links>\n";
 $manuscripts=$model->manuscripts;
-if(isset($manuscripts)){
 foreach($manuscripts as $manuscript){
     
     $xml.="    <manuscript_link>\n";
@@ -119,11 +115,10 @@ foreach($manuscripts as $manuscript){
     $xml.="    </manuscript_link>\n";
     
 }
-}
+
 $xml.="   </manuscript_links>\n";
 $xml.="   <alternative_identifiers>\n";
 $alternative_identifiers=$model->links;
-if(isset($alternative_identifiers)){
 foreach($alternative_identifiers as $link){
     $linkname=explode(":", $link->link);
     $name=$linkname[0];
@@ -137,11 +132,10 @@ foreach($alternative_identifiers as $link){
     $xml.="    <alternative_identifier is_primary=\"$link->is_primary\" prefix=\"$linkname[0]\">$linkname[1]</alternative_identifier>\n";    
     }
 }
-}
+
 $xml.="   </alternative_identifiers>\n";
 $xml.="   <funding_links>\n";
 $dataset_funders=$model->datasetFunders;
-if(isset($dataset_funders)){
 foreach($dataset_funders as $dataset_funder){
     $xml.="    <grant>\n";
     $funder=Funder::model()->findByAttributes(array('id'=>$dataset_funder->funder_id));
@@ -151,13 +145,12 @@ foreach($dataset_funders as $dataset_funder){
     $xml.="    <comment>$dataset_funder->comments</comment>\n";
     $xml.="    </grant>\n";
 }
-}
+
 $xml.="   </funding_links>\n";
 $xml.="  </links>\n";
 //dataset attribute
 $xml.="  <ds_attributes>\n";
 $dataset_attributes=$model->datasetAttributes;
-if(isset($dataset_attributes)){
 foreach($dataset_attributes as $dataset_attribute)
 {
     if(isset($dataset_attribute->value) && $dataset_attribute->value!=""){
@@ -179,7 +172,7 @@ foreach($dataset_attributes as $dataset_attribute)
     }
     
 }
-}
+
 $xml.="  </ds_attributes>\n";
 $xml.=" </dataset>\n";
 //samples
@@ -291,4 +284,5 @@ $xml.=" </files>\n";
 $xml.="</gigadb_entry>";
 $xml=preg_replace('/&(?!#?[a-z0-9]+;)/', '&amp;', $xml);
 $output= simplexml_load_string($xml);
+
 echo $output->asXML();

--- a/protected/views/api/singledatasetonly.php
+++ b/protected/views/api/singledatasetonly.php
@@ -57,7 +57,6 @@ foreach($dataset_types as $dataset_type) {
 }
 $xml.="</data_types>";
 //image
-$image=$model->image;
 $xml.="<image>";
 $xml.="<image_filename>$image->location</image_filename>";
 $xml.="<tag>$image->tag</tag>";

--- a/tests/api/ApiSearchTestCest.php
+++ b/tests/api/ApiSearchTestCest.php
@@ -8,6 +8,22 @@ declare(strict_types=1);
  */
 class ApiSearchTestCest
 {
+    public function tryToQueryASingleDatasetWithAValidXml(ApiTester$I)
+    {
+        $response = $I->sendGET('/dataset?doi=100006');
+        $I->seeResponseCodeIs(\Codeception\Util\HttpCode::OK);
+        $I->seeResponseIsXml();
+        $I->assertStringStartsWith("<?xml", $I->grabResponse());
+    }
+
+    public function tryToQueryASingleDatasetOnlyWithAValidXml(ApiTester $I)
+    {
+        $response = $I->sendGET('/dataset?doi=100006&result=dataset');
+        $I->seeResponseCodeIs(\Codeception\Util\HttpCode::OK);
+        $I->seeResponseIsXml();
+        $I->assertStringStartsWith('<?xml', $I->grabResponse());
+    }
+
     public function tryToQueryDatasetsWithSamplesSorted(ApiTester$I, \Codeception\Module\Db $db)
     {
         $query = "SELECT d.identifier, d.upload_status


### PR DESCRIPTION
# Pull request for issue: #1975

This is a pull request for the following functionalities:

need https://github.com/gigascience/gigadb-website/pull/1978 merged before

remove empty line at the beginning of the xml

## How to test?

Given I follow the instructions on the API help page (https://gigadb.org/site/help#interface)
When I select the example as shown "http://gigadb.org/api/dataset?doi=100051"
Then I see the correct results and not an error message

## How have functionalities been implemented?

## Any issues with implementation?

## Any changes to automated tests?

tests added

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?
