### PR TITLE
fix 2130: order authors by rank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #2130: order authors by rank
 - Security: bump the composer group across 2 directories with 6 updates
 - Fix #2016: Avoid adding logs if the curator is not updated
 

--- a/gigadb/app/tools/files-metadata-console/tests/functional/CheckValidURLsCest.php
+++ b/gigadb/app/tools/files-metadata-console/tests/functional/CheckValidURLsCest.php
@@ -11,7 +11,7 @@ class CheckValidURLsCest
 {
     private const TEST_URLS = [
         "https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/dev/pub/10.5524/100001_101000/100006",
-        "http://gigasciencejournal.com/blog/badaboom",
+        "https://gigasciencejournal.com/blog/badaboom",
         "ftp://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/dev/pub/10.5524/100001_101000/100006/readme_100006.txt",
         "https://s3.ap-northeast-1.wasabisys.com/gigadb-datasets/dev/pub/10.5524/100001_101000/100006/",
     ];

--- a/protected/components/FormattedDatasetMainSection.php
+++ b/protected/components/FormattedDatasetMainSection.php
@@ -115,17 +115,17 @@ class FormattedDatasetMainSection extends yii\base\BaseObject implements Dataset
     {
         $links = [];
         foreach ($authors as $author) {
-            $formattedName = $author['custom_name'] ?? Author::generateDisplayName(
-                Author::generateDisplayName($author['surname'], null, null),
-                $author['first_name'],
-                $author['middle_name']
-            );
+
+            $formattedName = $author['custom_name'] ??
+                $author['middle_name'] ? $author['first_name'] . ' ' . $author['middle_name'] . ' ' . $author['surname']
+                : $author['first_name'] . ' ' . $author['surname'];
+
             array_push(
                 $links,
                 CHtml::link($formattedName, "/search/new?keyword=$formattedName&author_id=" . $author['id'], array('class' => 'result-sub-links'))
             );
         }
-        return implode('; ', $links);
+        return implode(', ', $links);
     }
 
     /**

--- a/protected/components/StoredDatasetMainSection.php
+++ b/protected/components/StoredDatasetMainSection.php
@@ -79,7 +79,7 @@ class StoredDatasetMainSection extends DatasetComponents implements DatasetMainS
         $command = $this->_db->createCommand($publishing_sql);
         $command->bindParam(":id", $this->_id, PDO::PARAM_INT);
         $publishing_result = $command->queryRow();
-        if (!empty($publishing_result)) {
+        if ($publishing_result) {
             $release_details['release_year'] =  $publishing_result['release_year'];
             $release_details['dataset_title'] =  $publishing_result['title'];
             $release_details['publisher'] =  $publishing_result['publisher_name'];

--- a/protected/models/Dataset.php
+++ b/protected/models/Dataset.php
@@ -489,10 +489,10 @@ class Dataset extends CActiveRecord
         foreach ($authors as $author) {
             $creator = $creators->addChild('creator');
             $nameType = strpos($author['surname'], 'Consortium') ? 'Organizational' : 'Personal';
-            $fullName = $author['middle_name'] ? $author['first_name'] . ', ' . $author['middle_name'] . ', ' . $author['surname'] : $author['first_name'] . ', ' . $author['surname'];
+            $fullName = $author['middle_name'] ? $author['first_name'] . ' ' . $author['middle_name'] . ' ' . $author['surname'] : $author['first_name'] . ' ' . $author['surname'];
             $creatorName = $creator->addChild('creatorName', $fullName);
             $creatorName->addAttribute('nameType', $nameType);
-            $givenName = $author['middle_name'] ? $author['first_name'] . ', ' . $author['middle_name'] : $author['first_name'];
+            $givenName = $author['middle_name'] ? $author['first_name'] . ' ' . $author['middle_name'] : $author['first_name'];
             $creator->addChild('givenName', $givenName);
             $creator->addChild('familyName', $author['surname']);
 

--- a/protected/tests/fixtures/dataset_author.php
+++ b/protected/tests/fixtures/dataset_author.php
@@ -5,19 +5,19 @@ return array(
 		'id'=>1,
 		'dataset_id'=>1,
 		'author_id'=>1,
-        'rank'=>3
+        'rank'=>3,
 	),
 	array(
 		'id'=>2,
 		'dataset_id'=>1,
 		'author_id'=>2,
-        'rank'=>2
+        'rank'=>2,
 	),
 	array(
 		'id'=>3,
 		'dataset_id'=>1,
 		'author_id'=>7,
-        'rank'=>1
+        'rank'=>1,
 	),
 
 );

--- a/tests/acceptance/DatasetMockupPage.feature
+++ b/tests/acceptance/DatasetMockupPage.feature
@@ -52,4 +52,4 @@ Feature: A curator opens the mockup page
     And I fill in the field of "id" "Dataset_publication_date" with "2020-01-01"
     And I press the button "Save"
     Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
-    And I should see "Zhang G (2020)"
+    And I should see "Guojie Zhang (2020)"

--- a/tests/acceptance/DatasetView.feature
+++ b/tests/acceptance/DatasetView.feature
@@ -4,6 +4,17 @@ Feature: a user visit the dataset page
   So that I can use it to further my research or education
 
   @ok
+  Scenario: show authors ordered by rank from the text form file
+    Given I have not signed in
+    And I am on "dataset/100006"
+    And I should see "Guojie Zhang, David M Lambert, Jun Wang"
+    And I press the button "Cite Dataset"
+    And I should see "Text"
+    When I follow "Text"
+    And I go to the new tab
+    Then I should see "Zhang, G., Lambert, D. M., & Wang, J. (2011). Genomic data from Adelie penguin (Pygoscelis adeliae). [Data set]. GigaScience. https://doi.org/10.5524/100006"
+
+  @ok
   Scenario: number of files in current page and total number of files are displayed
     Given I have not signed in
     When I am on "dataset/100142"
@@ -260,7 +271,7 @@ Feature: a user visit the dataset page
   Scenario: List ordered author list
     Given I have not signed in
     When I am on "/dataset/100020"
-    Then I should see "Liu X; Quan Z; Cheng S; Xu X; Pan S; Zeng P; Xie M; Yue Z; Zhan D; Li Y; Wang J; Zhao Z; Zhang G (2011)"
+    Then I should see "Xin Liu, Zhiwu Quan, Shifeng Cheng, Xun Xu, Shengkai Pan, Peng Zeng, Min Xie, Zhen Yue, Dongliang Zhan, Yingrui Li, J Wang, Zhihai Zhao, Gengyun Zhang"
     And I should not see "Wang, J; Quan, Z; Zhao, Z; Cheng, S; Liu, X; Li, Y; Pan, S; Xie, M; Xu, X; Yue, Z; Zeng, P; Zhan, D; Zhang, G (2011)"
 
   Scenario: Show pre print publications

--- a/tests/unit/DatasetAsXmlTest.php
+++ b/tests/unit/DatasetAsXmlTest.php
@@ -38,14 +38,14 @@ class DatasetAsXmlTest  extends CDbTestCase
 
         $creatorChildNodes = $dom->getElementsByTagName('creator')->item(0)->childNodes;
         $this->assertCount(3, $creatorChildNodes);
-        $this->assertEquals('Morten, Schiøtt,', $creatorChildNodes->item(0)->nodeValue);
+        $this->assertEquals('Morten Schiøtt,', $creatorChildNodes->item(0)->nodeValue);
         $this->assertEquals('Morten', $creatorChildNodes->item(1)->nodeValue);
         $this->assertEquals('Schiøtt,', $creatorChildNodes->item(2)->nodeValue);
 
         $creatorChildNodes = $dom->getElementsByTagName('creator')->item(1)->childNodes;
         $this->assertCount(3, $creatorChildNodes);
-        $this->assertEquals("Carlos, Ábel G, Montana,", $creatorChildNodes->item(0)->nodeValue);
-        $this->assertEquals('Carlos, Ábel G', $creatorChildNodes->item(1)->nodeValue);
+        $this->assertEquals("Carlos Ábel G Montana,", $creatorChildNodes->item(0)->nodeValue);
+        $this->assertEquals('Carlos Ábel G', $creatorChildNodes->item(1)->nodeValue);
         $this->assertEquals('Montana,', $creatorChildNodes->item(2)->nodeValue);
 
         $relatedIdentifierManuscript = $dom->getElementsByTagName('relatedIdentifier')->item(0);

--- a/tests/unit/DatasetTest.php
+++ b/tests/unit/DatasetTest.php
@@ -27,9 +27,26 @@ class DatasetTest extends CDbTestCase
         $this->assertFalse($myDataset->validate());
     }
 
-    function testGetAuthors()
+    function testGetCountAuthors()
     {
         $this->assertGreaterThan(0, count($this->datasets(0)->authors), "dataset returns its two authors");
+    }
+
+    function testGetAuthorsOrderedAsc()
+    {
+        $dataset = $this->datasets(0);
+        $authorsOrdred = $dataset->getAuthors();
+
+        $this->assertEquals('Schiøtt,', $authorsOrdred[0]['surname']);
+        $this->assertEquals('Morten', $authorsOrdred[0]['first_name']);
+        $this->assertEquals('Montana,', $authorsOrdred[1]['surname']);
+        $this->assertEquals('Carlos', $authorsOrdred[1]['first_name']);
+        $this->assertEquals('Muñoz', $authorsOrdred[2]['surname']);
+        $this->assertEquals('Ángel', $authorsOrdred[2]['first_name']);
+        $this->assertEquals(1, $authorsOrdred[0]['rank']);
+        $this->assertEquals(2, $authorsOrdred[1]['rank']);
+        $this->assertEquals(3, $authorsOrdred[2]['rank']);
+
     }
 
     function testGetAuthorNames()

--- a/tests/unit/FormattedDatasetMainSectionTest.php
+++ b/tests/unit/FormattedDatasetMainSectionTest.php
@@ -139,7 +139,7 @@ class FormattedDatasetMainSectionTest extends CTestCase
         $daoUnderTest = new FormattedDatasetMainSection($cachedDatasetMainSection);
 
         $expected = array(
-                        "authors" => '<a class="result-sub-links" href="/search/new?keyword=Montana C&amp;author_id=2">Montana C</a>; <a class="result-sub-links" href="/search/new?keyword=Muñoz ÁGG&amp;author_id=1">Muñoz ÁGG</a>; <a class="result-sub-links" href="/search/new?keyword=Schiøtt M&amp;author_id=7">Schiøtt M</a>',
+                        "authors" => '<a class="result-sub-links" href="/search/new?keyword=Carlos Ábel G Montana,&amp;author_id=2">Carlos Ábel G Montana,</a>, <a class="result-sub-links" href="/search/new?keyword=Ángel GG Muñoz&amp;author_id=1">Ángel GG Muñoz</a>, <a class="result-sub-links" href="/search/new?keyword=Morten Schiøtt,&amp;author_id=7">Morten Schiøtt,</a>',
                         "release_year" => "2018",
                         "dataset_title" => 'Supporting data for "Analyzing climate variations on multiple timescales can guide Zika virus response measures"',
                         "publisher" => "Gigascience",


### PR DESCRIPTION
# Pull request for issue: #2130  #2382

order authors by rank and each author name is separated by a comma

## How to test?

Given I navigate to the gigadb website
When I am on the dataset page
Then I can see the list of authors ordered by rank
And each author name should be of format "First name Middle Name Last Name"
and each author name is separated by a comma

## How have functionalities been implemented?

## Any issues with implementation?

## Any changes to automated tests?

acceptance and unit tests added
## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?
