### PR TITLE
fix 2138: avoid deleting type when deleting a dataset type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #2138: Avoid deleting a type when deleting a dataset type
+
 ## v4.4.4 - 2025-02-17 - c17c44843 - 
 
 - Fix #2099: Add missing permission for CLOCKSS

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -253,7 +253,7 @@ class AdminDatasetController extends Controller
         if ($model->save()) {
             $postDatasetTypes = array_keys(Yii::$app->request->post('datasettypes'));
             if (!$postDatasetTypes) {
-                Yii::app()->user->setFlash('updateError', 'Fail to update your types');
+                Yii::app()->user->setFlash('updateError', 'Fail to update your types. You need to select at least one type');
                 $hasPartialError = true;
             } else {
                 $model->updateDatasetTypes($postDatasetTypes);

--- a/protected/models/Dataset.php
+++ b/protected/models/Dataset.php
@@ -715,12 +715,14 @@ class Dataset extends CActiveRecord
     public function updateDatasetTypes($postDatasetTypes)
     {
         $actualTypeIdsByDataset = [];
+        //fetch types
         $datasetTypeMaps = $this->datasetTypes;
+        $command = Yii::app()->db->createCommand();
 
         foreach ($datasetTypeMaps as $datasetTypeMap) {
             $actualTypeIdsByDataset[] = $typeId = $datasetTypeMap->id;
             if (!in_array($typeId, $postDatasetTypes, true)) {
-                $datasetTypeMap->delete();
+                $command->delete('dataset_type', 'dataset_id=:dataset_id AND type_id=:type_id ', array(':dataset_id' => $this->id, ':type_id' => $typeId));
             }
         }
 

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -325,6 +325,14 @@ class AcceptanceTester extends \Codeception\Actor
     }
 
     /**
+     * @Then I should see :checkbox checkbox is unchecked
+     */
+    public function iShouldSeeCheckboxIsUnchecked($checkbox)
+    {
+        $this->dontSeeCheckboxIsChecked("//input[@id='$checkbox']");
+    }
+
+    /**
      * @Then I check :checkbox checkbox
      */
     public function iCheckCheckbox($checkbox)

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -521,3 +521,18 @@ Feature: form to update dataset details
     And I wait "5" seconds
     When I am on "/adminDataset/update/id/5"
     Then I should see "Dataset_Genomic" checkbox is checked
+
+  @ok
+  Scenario: Check checkbox for type is working
+    Given I am on "/adminDataset/update/id/8"
+    And I should see "Dataset_Genomic" checkbox is checked
+    When I uncheck "Dataset_Genomic" checkbox
+    Then I should see "Dataset_Genomic" checkbox is unchecked
+    And I should see "Dataset_Workflow" checkbox is unchecked
+    When I check "Dataset_Workflow" checkbox
+    Then I should see "Dataset_Workflow" checkbox is checked
+    When I press the button "Save"
+    And I wait "5" seconds
+    And I am on "/adminDataset/update/id/8"
+    Then I should see "Dataset_Workflow" checkbox is checked
+    Then I should see "Dataset_Genomic" checkbox is unchecked

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -496,3 +496,28 @@ Feature: form to update dataset details
     And I press the button "Next >"
     And I wait "1" seconds
     Then I should see "Parrot.k31.NetworkTest.txt"
+
+  @ok
+  Scenario: Check type is not removed when uncheck a dataset type
+    Given I am on "/adminDataset/update/id/8"
+    Then I should see "Workflow"
+    Then I check "Dataset_Workflow" checkbox
+    And I press the button "Save"
+    When I am on "/adminDataset/update/id/8"
+    Then I should see "Dataset_Workflow" checkbox is checked
+    Then I uncheck "Dataset_Workflow" checkbox
+    And I press the button "Save"
+    When I am on "/adminDataset/update/id/8"
+    Then I should see "Workflow"
+
+  @ok
+  Scenario: Check type is not removed from other dataset when uncheck for another dataset
+    Given I am on "/adminDataset/update/id/8"
+    Then I should see "Genomic"
+    Then I should see "Dataset_Genomic" checkbox is checked
+    Then I check "Dataset_Workflow" checkbox
+    Then I uncheck "Dataset_Genomic" checkbox
+    And I press the button "Save"
+    And I wait "5" seconds
+    When I am on "/adminDataset/update/id/5"
+    Then I should see "Dataset_Genomic" checkbox is checked

--- a/tests/functional/AdminDatasetTypeCest.php
+++ b/tests/functional/AdminDatasetTypeCest.php
@@ -18,7 +18,7 @@ class AdminDatasetTypeCest
         $I->uncheckOption("#Dataset_Genomic");
         $I->click('Save');
 
-        $I->canSee('Fail to update your types');
+        $I->canSee('Fail to update your types. You need to select at least one type');
     }
 
     public function tryToAddADatasetType(FunctionalTester $I)


### PR DESCRIPTION
# Pull request for issue: #2138

avoid deleting type when deleting a dataset type

## How to test?

Describe how the new functionalities can be tested by PR reviewers

## How have functionalities been implemented?

Go to 'dataset'
uncheck a dataset type
Scroll down to save
you should see the dataset type but unchecked

## Any issues with implementation?

## Any changes to automated tests?

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?
