### PR TITLE
Add link to README file in dataset page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1289: Add link to README file in dataset page
 - Fix #1727: Sort files and samples by id in descending order when querying
 
-## v4.4.1 - 2024-12-24 - 51c426dfe - 
+## v4.4.1 - 2024-12-24 - 51c426dfe -
 
 - Feat #2067: Sort files by size in dataset page
 - Feat #372: Save dataset as xml in log

--- a/protected/views/dataset/view.php
+++ b/protected/views/dataset/view.php
@@ -388,7 +388,18 @@ $sampleDataProvider = $samples->getDataProvider();
                             <div role="tabpanel" class="tab-pane" id="files">
                             <?php } else { ?>
                                 <div role="tabpanel" class="tab-pane active" id="files">
-                                <?php   } ?>
+                                <?php }
+                                $file_models = $fileDataProvider->getData();
+                                $readme_file = array_filter($file_models, function($file) {
+                                    return $file['type'] === 'Readme';
+                                });
+                                $readme_file = !empty($readme_file) ? reset($readme_file) : null;
+                                ?>
+                                <?php if ($readme_file): ?>
+                                <div>
+                                  <a href="<?= $readme_file['location'] ?>" target="_blank" aria-label="Open README file for this dataset in a new tab">Open README File for this dataset</a>
+                                </div>
+                                <?php endif; ?>
                                 <p class="pull-left">
                                   Click on a table column to sort the results.
                                 </p>
@@ -410,7 +421,7 @@ $sampleDataProvider = $samples->getDataProvider();
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        <?php $file_models = $fileDataProvider->getData();
+                                        <?php
                                         foreach ($file_models as $file) {
                                         ?>
                                             <tr>

--- a/tests/acceptance/DatasetView.feature
+++ b/tests/acceptance/DatasetView.feature
@@ -228,3 +228,10 @@ Feature: a user visit the dataset page
     When I follow "[aria-label^='Size']"
     And I follow "[aria-label^='Size']"
     Then I should see "3.88 GB" in the table "#files_table" cell 1 6
+
+  @issue-1289
+  Scenario: Link to README file is displayed in files tab
+    Given I have not signed in
+    And I am on "/dataset/100006"
+    When I follow "Files"
+    Then I should see "Open README File for this dataset"


### PR DESCRIPTION
# Pull request for issue: #1289

Adds link to the readme file in the files tab of the dataset page

![image](https://github.com/user-attachments/assets/9915bb5d-4e73-4b08-840e-266baffbf7e2)

## How to test?

* go to http://gigadb.gigasciencejournal.com/dataset/100006
* open the files tab
* there should be a link to the readme file present and open in a new tab

## How have functionalities been implemented?

* It is unclear to me how to calculate the file location because I am not sure how to determine the correct range mentioned in #1289 so instead I parse the files and search for the file based on `$file['type'] === 'Readme'` and use the first match as readme file to link to. So this assumes that readme always has `$file['type'] === 'Readme'` and that there is one single readme

The heuristic could be easily changed to accomodate other requirements

## Any issues with implementation?

Unknown how to determine the correct range for the url so I used a different logic

## Any changes to automated tests?

Added one acceptance test, which is pending to be "ok" when I can run tests again
