### PR TITLE
Update FAQ "Why is submission to GigaDB not closely..."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- feat #479: Update FAQ "Why is submission to GigaDB not closely integrated with submission to GigaScience?"
 - Feat #456: Improve DataCite metadata by migrating to Datacite version 4.6
 - Fix #1727: Sort files and samples by id in descending order when querying
 
-## v4.4.1 - 2024-12-24 - 51c426dfe - 
+## v4.4.1 - 2024-12-24 - 51c426dfe -
 
 - Feat #2067: Sort files by size in dataset page
 - Feat #372: Save dataset as xml in log

--- a/protected/views/site/faq.php
+++ b/protected/views/site/faq.php
@@ -434,7 +434,7 @@ Files:
                     </div>
                     <div id="panel27" aria-labelledby="heading27" class="panel-collapse collapse">
                         <div class="panel-body">
-                            <p>Due to various differences in the BMC's editorial tools and the <em>GigaDB</em> system, unfortunately at this time it is not possible to integrate the submission process, but our editors and curators will do everything they can to make the process as smooth as possible for authors.</p>
+                            <p>Due to various technical differences in the editorial submission tools and the <em>GigaDB</em> system, unfortunately at this time it is not possible to integrate the submission process, but our editors and curators will do everything they can to make the process as smooth as possible for authors.</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
# Pull request for issue: #479

Updated text as requested in ticket
![image](https://github.com/user-attachments/assets/55eb8be9-6f8e-4601-b97d-ca9ceac5e249)

## How to test?

http://gigadb.gigasciencejournal.com/site/faq

find question "Why is submission to GigaDB not closely integrated with submission to GigaScience?" and confirm text was updated
