### PR TITLE
feat-549: update datacite metadata api command + check if doi exists in Datacite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #549: create commands: check if DOI exists in Datacite + update Datacite api metadata
+
 ## v4.4.10 - 2025-05-16 - 07a8f63b2 - 
 
 - Fix #2294: Add dedicated username variable for authenticating to email service

--- a/docs/sop/DATACITE.md
+++ b/docs/sop/DATACITE.md
@@ -1,0 +1,116 @@
+# DATACITE API
+
+
+## Check for missing DOIs on the DATACITE API
+
+### Dev environment
+
+#### Check if DOI exists in batch mode
+
+```
+$ docker-compose run --rm application ./protected/yiic checkdoiexistsindataciteapi
+Processing batch of 10 datasets with offset 0
+[OK] DOI exists for dataset 100020
+[ERROR] DOI not found for dataset 300070: 404
+[OK] DOI exists for dataset 100006
+...
+[ERROR] Some errors were detected. Please check details above.
+```
+
+#### Check single doi exists
+
+```
+docker-compose run --rm application ./protected/yiic checkdoiexistsindataciteapi --doi=100006
+Processing batch of 1 datasets with offset 0
+[OK] DOI exists for dataset 100006
+[OK] All DOIs are correctly found in the DataCite API.
+```
+
+#### Skip first 8 DOIs
+
+```
+docker-compose run --rm application ./protected/yiic checkdoiexistsindataciteapi --offset=8
+Processing batch of 10 datasets with offset 8
+[OK] DOI exists for dataset 100006
+[OK] DOI exists for dataset 100020
+...
+[OK] All DOIs are correctly found in the DataCite API.
+```
+
+### Live environment
+
+Same as above for the options, but to run the check command on AWS deployment, from the bastion server:
+
+```
+$ docker run --rm -e YII_PATH=/var/www/vendor/yiisoft/yii -v /home/centos:/var/www/protected/runtime registry.gitlab.com/gigascience/forks/rija-gigadb-website/production_app:staging /var/www/protected/yiic checkdoiexistsindataciteapi
+```
+
+## Update metadata to the DATACITE API
+
+### Dev environment
+
+#### Batch processing (default 50)
+
+```
+$ docker-compose run --rm application ./protected/yiic updatedatasetdatacite
+Processing 10 datasets
+[OK] Dataset 100035 successfully updated.
+[OK] Dataset 100056 successfully updated.
+...
+Finished processing 10 datasets
+```
+
+#### Update datacite metadata in batches of 3
+
+```
+$ docker-compose run --rm application ./protected/yiic updatedatasetdatacite --batchSize=3
+Processing 3 datasets
+[OK] Dataset 100006 successfully updated.
+[OK] Dataset 100056 successfully updated.
+[OK] Dataset 100020 successfully updated.
+...
+Finished processing 10 datasets
+```
+
+#### Skip first 8 DOIs
+
+```
+$ docker-compose run --rm application ./protected/yiic updatedatasetdatacite --offset=8
+Processing 2 datasets
+[OK] Dataset 100094 successfully updated.
+[OK] Dataset 100035 successfully updated.
+Finished processing 2 datasets
+All datasets processed successfully.
+```
+
+#### Update single dataset
+
+```
+$ docker-compose run --rm application ./protected/yiic updatedatasetdatacite --doi=100039
+Finished processing 0 datasets
+All datasets processed successfully.
+```
+
+### Live environment
+
+Same as above for the options, but to run the update command on AWS deployment, from the bastion server:
+
+```
+docker run --rm -e YII_PATH=/var/www/vendor/yiisoft/yii -v /home/centos:/var/www/protected/runtime registry.gitlab.com/gigascience/forks/rija-gigadb-website/production_app:staging /var/www/protected/yiic updatedatasetdatacite
+```
+
+## Optional Parameters:
+
+- Limit (--limit): Defines the batch size (default is 50). If you set a value greater that 450, it will automatically be capped at 450 to comply
+with the rate limiter imposed by the Datacite API. 
+
+- Offset (--offset): Specifies the starting point if you want to skip a number of records.
+- DOI (--doi): Allows you to update a specific DOI.
+
+## Logging:
+
+you can redirect both standard and error output to a log file using:
+
+```
+> my_log.txt 2>&1
+```

--- a/ops/configuration/yii-conf/console.php.dist
+++ b/ops/configuration/yii-conf/console.php.dist
@@ -21,6 +21,7 @@ return CMap::mergeArray($pre_config, array(
     # autoloading model and component classes
     'import'=>array(
         'application.models.*',
+        'application.interfaces.*',
         'application.components.*',
         'application.behaviors.*',
         'application.vendors.*',

--- a/protected/commands/CheckDoiExistsInDataciteApiCommand.php
+++ b/protected/commands/CheckDoiExistsInDataciteApiCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 class CheckDoiExistsInDataciteApiCommand extends CConsoleCommand
 {
+    private bool $hasError = false;
+
     public function actionIndex($doi = null)
     {
         $mds_doi_url = Yii::app()->params['mds_doi_url'];
@@ -27,11 +29,13 @@ class CheckDoiExistsInDataciteApiCommand extends CConsoleCommand
             $promises[] = $client->getAsync($mds_doi_url . '/' . $mds_prefix . '/' . $dataset->identifier, $options)->then(
                 function ($response) use ($dataset) {
                     if ($response->getStatusCode() !== 200) {
+                        $this->hasError = true;
                         Yii::log(sprintf('DOI not found for dataset %s', $dataset->identifier), 'info');
                     }
                 },
                 function ($exception) use ($dataset) {
                     $errors[$dataset->id] = $dataset->identifier;
+                    $this->hasError = true;
                     Yii::log(sprintf('Error while checking DOI for dataset %s: %s', $dataset->identifier, $e->getMessage()), 'error');
                 }
             );
@@ -41,7 +45,14 @@ class CheckDoiExistsInDataciteApiCommand extends CConsoleCommand
         try {
             \GuzzleHttp\Promise\Utils::settle($promises)->wait();
         } catch(\Exception $e) {
+            $this->hasError = true;
             Yii::log('Error while handling promises %s: %s', 'error');
+        }
+
+        if ($this->hasError) {
+            echo 'check the logs: some errors have been detected';
+        } else {
+            echo 'All good';
         }
     }
 }

--- a/protected/commands/CheckDoiExistsInDataciteApiCommand.php
+++ b/protected/commands/CheckDoiExistsInDataciteApiCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 class CheckDoiExistsInDataciteApiCommand extends CConsoleCommand
 {
     private bool $hasError = false;
+    private array $errors = [];
 
     public function actionIndex($doi = null)
     {
@@ -13,46 +14,58 @@ class CheckDoiExistsInDataciteApiCommand extends CConsoleCommand
         $mds_password = Yii::app()->params['mds_password'];
         $mds_prefix = Yii::app()->params['mds_prefix'];
         $client = new \GuzzleHttp\Client();
-        $promises = [];
-        $errors = [];
 
-        $condition = $doi ? ['upload_status' => 'Published', 'identifier' => $doi] : ['upload_status' => 'Published'];
+        $condition = $doi
+            ? ['upload_status' => 'Published', 'identifier' => $doi]
+            : ['upload_status' => 'Published'];
+
         $datasets = Dataset::model()->findAllByAttributes($condition);
+
+        if (!$datasets) {
+            fwrite(STDOUT, "No datasets found.\n");
+
+            return;
+        }
 
         $options = [
             'http_errors' => false,
-            'auth'        => [$mds_username, $mds_password]
+            'auth'        => [$mds_username, $mds_password],
         ];
 
-        $var = 0;
+        $promises = [];
+
         foreach ($datasets as $dataset) {
-            $promises[] = $client->getAsync($mds_doi_url . '/' . $mds_prefix . '/' . $dataset->identifier, $options)->then(
-                function ($response) use ($dataset) {
-                    if (!in_array($response->getStatusCode(), [200, 204])) {
+            $url = $mds_doi_url . '/' . $mds_prefix . '/' . $dataset->identifier;
+
+            $promises[] = $client->getAsync($url, $options)->then(
+                function ($response) use ($dataset, $url) {
+                    $code = $response->getStatusCode();
+
+                    if (!in_array($code, [200, 204])) {
                         $this->hasError = true;
-                        Yii::log(sprintf('DOI not found for dataset %s', $dataset->identifier), 'info');
+                        fwrite(STDERR, sprintf("[ERROR] DOI not found for dataset %s: %s\n", $dataset->identifier, $code));
+                    } else {
+                        fwrite(STDOUT, sprintf("[OK] DOI exists for dataset %s\n", $dataset->identifier));
                     }
                 },
-                function ($exception) use ($dataset, $errors) {
-                    $errors[$dataset->id] = $dataset->identifier;
+                function ($exception) use ($dataset, $url) {
                     $this->hasError = true;
-                    Yii::log(sprintf('Error while checking DOI for dataset %s: %s', $dataset->identifier, $exception->getMessage()), 'error');
+                    fwrite(STDERR, sprintf("[ERROR] Error checking DOI for dataset %s: %s\n", $dataset->identifier, $exception->getMessage()));
                 }
             );
-            $var++;
         }
 
         try {
             \GuzzleHttp\Promise\Utils::settle($promises)->wait();
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             $this->hasError = true;
-            Yii::log('Error while handling promises %s: %s', 'error');
+            fwrite(STDERR, '[ERROR] Error during request promises: ' . $e->getMessage() . "\n");
         }
 
         if ($this->hasError) {
-            echo 'check the logs: some errors have been detected';
+            fwrite(STDERR, "[ERROR] Some errors were detected. Please check details above.\n");
         } else {
-            echo 'All good';
+            fwrite(STDOUT, "[OK] All DOIs are correctly found in the DataCite API.\n");
         }
     }
 }

--- a/protected/commands/CheckDoiExistsInDataciteApiCommand.php
+++ b/protected/commands/CheckDoiExistsInDataciteApiCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+class CheckDoiExistsInDataciteApiCommand extends CConsoleCommand
+{
+    public function actionIndex($doi = null)
+    {
+        $mds_doi_url = Yii::app()->params['mds_doi_url'];
+        $mds_username = Yii::app()->params['mds_username'];
+        $mds_password = Yii::app()->params['mds_password'];
+        $mds_prefix = Yii::app()->params['mds_prefix'];
+        $client = new \GuzzleHttp\Client();
+        $promises = [];
+        $errors = [];
+
+        $condition = $doi ? ['upload_status' => 'Published', 'identifier' => $doi] : ['upload_status' => 'Published'];
+        $datasets = Dataset::model()->findAllByAttributes($condition);
+
+        $options = [
+            'http_errors' => false,
+            'auth'        => [$mds_username, $mds_password]
+        ];
+
+        $var = 0;
+        foreach ($datasets as $dataset) {
+            $promises[] = $client->getAsync($mds_doi_url . '/' . $mds_prefix . '/' . $dataset->identifier, $options)->then(
+                function ($response) use ($dataset) {
+                    if ($response->getStatusCode() !== 200) {
+                        Yii::log(sprintf('DOI not found for dataset %s', $dataset->identifier), 'info');
+                    }
+                },
+                function ($exception) use ($dataset) {
+                    $errors[$dataset->id] = $dataset->identifier;
+                    Yii::log(sprintf('Error while checking DOI for dataset %s: %s', $dataset->identifier, $e->getMessage()), 'error');
+                }
+            );
+            $var++;
+        }
+
+        try {
+            \GuzzleHttp\Promise\Utils::settle($promises)->wait();
+        } catch(\Exception $e) {
+            Yii::log('Error while handling promises %s: %s', 'error');
+        }
+    }
+}

--- a/protected/commands/CheckDoiExistsInDataciteApiCommand.php
+++ b/protected/commands/CheckDoiExistsInDataciteApiCommand.php
@@ -28,15 +28,15 @@ class CheckDoiExistsInDataciteApiCommand extends CConsoleCommand
         foreach ($datasets as $dataset) {
             $promises[] = $client->getAsync($mds_doi_url . '/' . $mds_prefix . '/' . $dataset->identifier, $options)->then(
                 function ($response) use ($dataset) {
-                    if ($response->getStatusCode() !== 200) {
+                    if (!in_array($response->getStatusCode(), [200, 204])) {
                         $this->hasError = true;
                         Yii::log(sprintf('DOI not found for dataset %s', $dataset->identifier), 'info');
                     }
                 },
-                function ($exception) use ($dataset) {
+                function ($exception) use ($dataset, $errors) {
                     $errors[$dataset->id] = $dataset->identifier;
                     $this->hasError = true;
-                    Yii::log(sprintf('Error while checking DOI for dataset %s: %s', $dataset->identifier, $e->getMessage()), 'error');
+                    Yii::log(sprintf('Error while checking DOI for dataset %s: %s', $dataset->identifier, $exception->getMessage()), 'error');
                 }
             );
             $var++;

--- a/protected/commands/CheckDoiExistsInDataciteApiCommand.php
+++ b/protected/commands/CheckDoiExistsInDataciteApiCommand.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 class CheckDoiExistsInDataciteApiCommand extends CConsoleCommand
 {
     private bool $hasError = false;
-    private array $errors = [];
 
-    public function actionIndex($doi = null)
+    public function actionIndex(int $batchSize = 50, int $offset = 0, $doi = null)
     {
+        $batchSize = $batchSize >= 450 ?  450 : $batchSize;
+        $throttleLimit = 450;
+        $throttleWindow = 300;
+
         $mds_doi_url = Yii::app()->params['mds_doi_url'];
         $mds_username = Yii::app()->params['mds_username'];
         $mds_password = Yii::app()->params['mds_password'];
@@ -19,53 +22,88 @@ class CheckDoiExistsInDataciteApiCommand extends CConsoleCommand
             ? ['upload_status' => 'Published', 'identifier' => $doi]
             : ['upload_status' => 'Published'];
 
-        $datasets = Dataset::model()->findAllByAttributes($condition);
+        $processed = 0;
+        $sentInWindow = 0;
+        $windowStart = time();
 
-        if (!$datasets) {
-            fwrite(STDOUT, "No datasets found.\n");
+        while (true) {
+            $criteria = new CDbCriteria();
+            foreach($condition as $k => $v) {
+                $criteria->addCondition("$k = :$k");
+                $criteria->params[":$k"] = $v;
+            }
+            $criteria->limit = $batchSize;
+            $criteria->offset = $offset;
+            $criteria->order = 'identifier DESC';
 
-            return;
-        }
+            $datasets = Dataset::model()->findAll($criteria);
 
-        $options = [
-            'http_errors' => false,
-            'auth'        => [$mds_username, $mds_password],
-        ];
+            if (!$datasets) {
+                fwrite(STDOUT, "No datasets found.\n");
 
-        $promises = [];
+                break;
+            }
 
-        foreach ($datasets as $dataset) {
-            $url = $mds_doi_url . '/' . $mds_prefix . '/' . $dataset->identifier;
+            $count = count($datasets);
+            fwrite(STDOUT, sprintf("Processing batch of %d datasets with offset %d\n", $count, $offset));
 
-            $promises[] = $client->getAsync($url, $options)->then(
-                function ($response) use ($dataset, $url) {
-                    $code = $response->getStatusCode();
+            $options = [
+                'http_errors' => false,
+                'auth'        => [$mds_username, $mds_password],
+            ];
 
-                    if (!in_array($code, [200, 204])) {
+            $promises = [];
+
+            foreach ($datasets as $dataset) {
+                $url = $mds_doi_url . '/' . $mds_prefix . '/' . $dataset->identifier;
+
+                $promises[] = $client->getAsync($url, $options)->then(
+                    function ($response) use ($dataset, $url) {
+                        $code = $response->getStatusCode();
+
+                        if (!in_array($code, [200, 204])) {
+                            $this->hasError = true;
+                            fwrite(STDERR, sprintf("[ERROR] DOI not found for dataset %s: %s\n", $dataset->identifier, $code));
+                        } else {
+                            fwrite(STDOUT, sprintf("[OK] DOI exists for dataset %s\n", $dataset->identifier));
+                        }
+                    },
+                    function ($exception) use ($dataset, $url) {
                         $this->hasError = true;
-                        fwrite(STDERR, sprintf("[ERROR] DOI not found for dataset %s: %s\n", $dataset->identifier, $code));
-                    } else {
-                        fwrite(STDOUT, sprintf("[OK] DOI exists for dataset %s\n", $dataset->identifier));
+                        fwrite(STDERR, sprintf("[ERROR] Error checking DOI for dataset %s: %s\n", $dataset->identifier, $exception->getMessage()));
                     }
-                },
-                function ($exception) use ($dataset, $url) {
-                    $this->hasError = true;
-                    fwrite(STDERR, sprintf("[ERROR] Error checking DOI for dataset %s: %s\n", $dataset->identifier, $exception->getMessage()));
+                );
+            }
+
+            try {
+                \GuzzleHttp\Promise\Utils::settle($promises)->wait();
+            } catch (\Exception $e) {
+                $this->hasError = true;
+                fwrite(STDERR, '[ERROR] Error during request promises: ' . $e->getMessage() . "\n");
+            }
+
+
+            $sentInWindow += $count;
+            $processed    += $count;
+            $offset       += $batchSize;
+
+            if ($sentInWindow >= $throttleLimit) {
+                $elapsed = time() - $windowStart;
+                if ($elapsed < $throttleWindow) {
+                    $sleep = $throttleWindow - $elapsed;
+                    fwrite(STDOUT, sprintf("[THROTTLE] reached %d requests; sleeping %d seconds\n", $throttleLimit, $sleep));
+                    sleep($sleep);
                 }
-            );
-        }
+                $windowStart  = time();
+                $sentInWindow = 0;
+            }
 
-        try {
-            \GuzzleHttp\Promise\Utils::settle($promises)->wait();
-        } catch (\Exception $e) {
-            $this->hasError = true;
-            fwrite(STDERR, '[ERROR] Error during request promises: ' . $e->getMessage() . "\n");
-        }
 
-        if ($this->hasError) {
-            fwrite(STDERR, "[ERROR] Some errors were detected. Please check details above.\n");
-        } else {
-            fwrite(STDOUT, "[OK] All DOIs are correctly found in the DataCite API.\n");
+            if ($this->hasError) {
+                fwrite(STDERR, "[ERROR] Some errors were detected. Please check details above.\n");
+            } else {
+                fwrite(STDOUT, "[OK] All DOIs are correctly found in the DataCite API.\n");
+            }
         }
     }
 }

--- a/protected/commands/UpdateDatasetDataciteCommand.php
+++ b/protected/commands/UpdateDatasetDataciteCommand.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+// docker-compose run --rm application ./protected/yiic updatedatasetdatacite --limit --offset --doi
+class UpdateDatasetDataciteCommand extends CConsoleCommand
+{
+    private ?\GuzzleHttp\Client $client = null;
+    private array $options = [];
+    private $db = null;
+
+    public function init()
+    {
+        parent::init();
+        $this->client = new \GuzzleHttp\Client();
+        $mds_username = Yii::app()->params['mds_username'];
+        $mds_password = Yii::app()->params['mds_password'];
+        $this->options = [
+            'headers'     => [
+                'Content-Type' => 'text/xml;charset=UTF8',
+            ],
+            'auth'        => [$mds_username, $mds_password],
+            'http_errors' => false
+        ];
+        $this->db = $db = Yii::app()->db;
+    }
+
+    public function actionIndex($batchSize = 50, $offset = 0, $doi = null) {
+        $mds_metadata_url= Yii::app()->params['mds_metadata_url'];
+        $mds_prefix = Yii::app()->params['mds_prefix'];
+        $count = 0;
+
+        while(true) {
+            $criteria = new CDbCriteria();
+            $criteria->addCondition("upload_status = 'Published'");
+            if ($doi) {
+                $criteria->addCondition("identifier = :doi");
+                $criteria->params = [':doi' => $doi];
+            }
+            $criteria->limit = $batchSize;
+            $criteria->offset = $offset;
+
+            $datasets = Dataset::model()->findAll($criteria);
+
+            if (!$datasets) {
+                break;
+            }
+
+            $this->processBatch($datasets, $mds_metadata_url, $mds_prefix);
+            $offset += $batchSize;
+        }
+    }
+
+    private function processBatch($datasets, $mds_metadata_url, $mds_prefix) {
+        $promises = [];
+        if (!$this->options) {
+            Yii::log('no options defined', 'info');
+
+            return;
+        }
+
+        $xmlByIds = [];
+        $i = 0;
+        foreach ($datasets as $dataset) {
+            $xmlData = $dataset->toXml();
+
+            if (!$xmlData) {
+                Yii::log(sprintf('empty xml for dataset %s', $dataset->identifier), 'info');
+                continue;
+            }
+
+            $options['body'] = $xmlData;
+
+            $promises[] = $this->client->postAsync($mds_metadata_url . '/' . $mds_prefix . '/' . $dataset->identifier, $this->options)->then(
+                function ($response) use ($dataset, $xmlData, $xmlByIds, $i) {
+                    if ($response->getStatusCode() === 201) {
+                        $xmlByIds[] = [$dataset->id, $xmlData];
+
+                        return $xmlByIds;
+                    }
+
+                    Yii::log(sprintf('call datacite api returns %s for dataset %s', $response->getStatusCode(), $dataset->identifier), 'info');
+                },
+                function ($exception) use ($dataset) {
+                    Yii::log(sprintf('call api - exception for dataset %s: %s', $dataset->identifier, $exception->getMessage()), 'info');
+                }
+            );
+
+            $i++;
+        }
+
+        try {
+            $xmlByIds = \GuzzleHttp\Promise\Utils::settle($promises)->wait();
+            $this->updateEntityStatus($xmlByIds);
+        } catch(\Exception $e) {
+            Yii::log('Error while handling promises %s: %s', 'error');
+        }
+    }
+
+    private function updateEntityStatus($xmlByIds) {
+        $values = '';
+        $count = count($xmlByIds);
+        $sql = '';
+        $params = [];
+
+        foreach ($xmlByIds as $k => $xmlById) {
+            if (is_null($xmlById['value'])) {
+                Yii::log($xmlById['state'], 'info');
+                continue;
+            }
+
+            $key = $xmlById['value'][0][0];
+            $xml = $xmlById['value'][0][1];
+            $sql .= sprintf('(:id%s, :action%s, :comments%s)%s', $key, $key, $key, $k + 1 !== $count ? ',' : '');
+            $params += [":id$key" => $key, ":action$key" => 'xml', ":comments$key" => $xml];
+        }
+
+        if (!$sql) {
+            return;
+        }
+
+        $sql = rtrim($sql, ',');
+        $sql = 'INSERT INTO curation_log (dataset_id, action, comments) VALUES ' . $sql;
+        $command = $this->db->createCommand($sql);
+        $command->execute($params);
+    }
+}

--- a/protected/commands/UpdateDatasetDataciteCommand.php
+++ b/protected/commands/UpdateDatasetDataciteCommand.php
@@ -133,40 +133,55 @@ class UpdateDatasetDataciteCommand extends CConsoleCommand
     {
         $params = [];
         $params2 = [];
+        $params3 = [];
         $sql = '';
         $sql2 = '';
+        $sql3 = '';
 
         foreach ($xmlByIds as $entry) {
             if (!isset($entry['value'])) {
                 continue;
             }
+            $date = date('Y-m-d H:i:s');
 
             list($id, $xml, $action, $code, $message) = $entry['value'];
 
-            $sql .= "(:id$id, :action$id, :comments$id),";
+            $sql .= "(:id$id, :action$id, :comments$id, :creation_date$id),";
             $params += [
-                ":id$id"       => $id,
-                ":action$id"   => $action,
-                ":comments$id" => $xml
+                ":id$id"            => $id,
+                ":action$id"        => $action,
+                ":comments$id"      => $xml,
+                ":creation_date$id" => $date
             ];
 
-            $sql2 .= "(:cid$id, :cmessage$id),";
+            $sql2 .= "(:cid$id, :caction$id, :ccomments$id, :ccreation_date$id),";
             $params2 += [
+                ":cid$id"           => $id,
+                ":caction$id"       => 'DOI Minting',
+                ":ccomments$id"     =>sprintf('Metadata response: %s - %s', $code, $message),
+                "ccreation_date$id" => $date
+            ];
+
+            $sql3 .= "(:cid$id, :cmessage$id),";
+            $result = in_array($code, [200, 201]) ? 'OK' : 'ERROR';
+            $params3 += [
                 ":cid$id"       => $id,
-                ":cmessage$id"   => sprintf('DOI Minting - Metadata response: %s - %s', $code, $message),
+                ":cmessage$id"  => sprintf('Metadata response: %s', $result),
             ];
         }
 
-        if ($sql) {
+        if ($sql && $sql2) {
             $sql = rtrim($sql, ',');
-            $command = $this->db->createCommand("INSERT INTO curation_log (dataset_id, action, comments) VALUES $sql");
-            $command->execute($params);
+            $sql2 = rtrim($sql2, ',');
+            $command = $this->db->createCommand("INSERT INTO curation_log (dataset_id, action, comments, creation_date) VALUES $sql, $sql2");
+            $command->execute(array_merge($params, $params2));
         }
 
-        if ($sql2) {
-            $sql2 = rtrim($sql2, ',');
-            $command = $this->db->createCommand("INSERT INTO dataset_log (dataset_id, message) VALUES $sql2");
-            $command->execute($params2);
+        if ($sql3) {
+
+            $sql3 = rtrim($sql3, ',');
+            $command = $this->db->createCommand("INSERT INTO dataset_log (dataset_id, message) VALUES $sql3");
+            $command->execute($params3);
         }
     }
 }

--- a/protected/commands/UpdateDatasetDataciteCommand.php
+++ b/protected/commands/UpdateDatasetDataciteCommand.php
@@ -8,6 +8,7 @@ class UpdateDatasetDataciteCommand extends CConsoleCommand
     private ?\GuzzleHttp\Client $client = null;
     private array $options = [];
     private $db = null;
+    private bool $hasError = false;
 
     public function init()
     {
@@ -49,6 +50,12 @@ class UpdateDatasetDataciteCommand extends CConsoleCommand
             $this->processBatch($datasets, $mds_metadata_url, $mds_prefix);
             $offset += $batchSize;
         }
+
+        if ($this->hasError) {
+            echo "check the logs: some errors have been detected";
+        } else {
+            echo 'All good';
+        }
     }
 
     private function processBatch($datasets, $mds_metadata_url, $mds_prefix) {
@@ -65,6 +72,7 @@ class UpdateDatasetDataciteCommand extends CConsoleCommand
             $xmlData = $dataset->toXml();
 
             if (!$xmlData) {
+                $this->hasError = true;
                 Yii::log(sprintf('empty xml for dataset %s', $dataset->identifier), 'info');
                 continue;
             }
@@ -79,9 +87,11 @@ class UpdateDatasetDataciteCommand extends CConsoleCommand
                         return $xmlByIds;
                     }
 
+                    $this->hasError = true;
                     Yii::log(sprintf('call datacite api returns %s for dataset %s', $response->getStatusCode(), $dataset->identifier), 'info');
                 },
                 function ($exception) use ($dataset) {
+                    $this->hasError = true;
                     Yii::log(sprintf('call api - exception for dataset %s: %s', $dataset->identifier, $exception->getMessage()), 'info');
                 }
             );
@@ -93,6 +103,7 @@ class UpdateDatasetDataciteCommand extends CConsoleCommand
             $xmlByIds = \GuzzleHttp\Promise\Utils::settle($promises)->wait();
             $this->updateEntityStatus($xmlByIds);
         } catch(\Exception $e) {
+            $this->hasError = true;
             Yii::log('Error while handling promises %s: %s', 'error');
         }
     }

--- a/protected/commands/UpdateDatasetDataciteCommand.php
+++ b/protected/commands/UpdateDatasetDataciteCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-// docker-compose run --rm application ./protected/yiic updatedatasetdatacite --limit --offset --doi
+// docker-compose run --rm application ./protected/yiic updatedatasetdatacite --limit --offset --doi > my_log.txt 2>&1
 class UpdateDatasetDataciteCommand extends CConsoleCommand
 {
     private ?\GuzzleHttp\Client $client = null;
@@ -14,28 +14,31 @@ class UpdateDatasetDataciteCommand extends CConsoleCommand
     {
         parent::init();
         $this->client = new \GuzzleHttp\Client();
-        $mds_username = Yii::app()->params['mds_username'];
-        $mds_password = Yii::app()->params['mds_password'];
         $this->options = [
             'headers'     => [
                 'Content-Type' => 'text/xml;charset=UTF8',
             ],
-            'auth'        => [$mds_username, $mds_password],
+            'auth'        => [
+                Yii::app()->params['mds_username'],
+                Yii::app()->params['mds_password']
+            ],
             'http_errors' => false
         ];
-        $this->db = $db = Yii::app()->db;
+        $this->db = Yii::app()->db;
     }
 
-    public function actionIndex($batchSize = 50, $offset = 0, $doi = null) {
-        $mds_metadata_url= Yii::app()->params['mds_metadata_url'];
+    public function actionIndex($batchSize = 50, $offset = 0, $doi = null)
+    {
+        $mds_metadata_url = Yii::app()->params['mds_metadata_url'];
         $mds_prefix = Yii::app()->params['mds_prefix'];
-        $count = 0;
 
-        while(true) {
+        $processed = 0;
+
+        while (true) {
             $criteria = new CDbCriteria();
             $criteria->addCondition("upload_status = 'Published'");
             if ($doi) {
-                $criteria->addCondition("identifier = :doi");
+                $criteria->addCondition('identifier = :doi');
                 $criteria->params = [':doi' => $doi];
             }
             $criteria->limit = $batchSize;
@@ -47,92 +50,123 @@ class UpdateDatasetDataciteCommand extends CConsoleCommand
                 break;
             }
 
+            $count = count($datasets);
+            fwrite(STDOUT, sprintf("Processing %d datasets \n", $count));
             $this->processBatch($datasets, $mds_metadata_url, $mds_prefix);
             $offset += $batchSize;
+            $processed += $count;
         }
 
+        fwrite(STDOUT, sprintf("Finished processing %d datasets\n", $processed));
+
         if ($this->hasError) {
-            echo "check the logs: some errors have been detected";
+            fwrite(STDERR, "Some errors occurred. See details above.\n");
         } else {
-            echo 'All good';
+            fwrite(STDOUT, "All datasets processed successfully.\n");
         }
     }
 
-    private function processBatch($datasets, $mds_metadata_url, $mds_prefix) {
+    private function processBatch($datasets, $mds_metadata_url, $mds_prefix)
+    {
         $promises = [];
-        if (!$this->options) {
-            Yii::log('no options defined', 'info');
-
-            return;
-        }
-
-        $xmlByIds = [];
-        $i = 0;
         foreach ($datasets as $dataset) {
-            $xmlData = $dataset->toXml();
 
+            $xmlData = $dataset->toXml();
             if (!$xmlData) {
                 $this->hasError = true;
-                Yii::log(sprintf('empty xml for dataset %s', $dataset->identifier), 'info');
+                fwrite(STDERR, sprintf("[ERROR] Empty XML for dataset: %s\n", $dataset->identifier));
+
                 continue;
             }
 
+            $url = $mds_metadata_url . '/' . $mds_prefix . '/' . $dataset->identifier;
+            $options = $this->options;
             $options['body'] = $xmlData;
 
-            $promises[] = $this->client->postAsync($mds_metadata_url . '/' . $mds_prefix . '/' . $dataset->identifier, $this->options)->then(
-                function ($response) use ($dataset, $xmlData, $xmlByIds, $i) {
-                    if ($response->getStatusCode() === 201) {
-                        $xmlByIds[] = [$dataset->id, $xmlData];
+            $promises[] = $this->client->postAsync($url, $options)->then(
+                function ($response) use ($dataset, $xmlData) {
+                    $code = $response->getStatusCode();
+                    $message = $response->getBody()->getContents();
 
-                        return $xmlByIds;
+                    if ($code !== 201) {
+                        $this->hasError = true;
+                        fwrite(STDERR, sprintf("[ERROR] Failed for dataset %s: %d - %s\n", $dataset->identifier, $code, $message));
+
+                        return [
+                            $dataset->id,
+                            $xmlData,
+                            'Failed to send DataCite XML',
+                            $code,
+                            $message
+                        ];
                     }
 
-                    $this->hasError = true;
-                    Yii::log(sprintf('call datacite api returns %s for dataset %s', $response->getStatusCode(), $dataset->identifier), 'info');
+                    fwrite(STDOUT, sprintf("[OK] Dataset %s successfully updated.\n", $dataset->identifier));
+
+                    return [
+                        $dataset->id,
+                        $xmlData,
+                        'Sent DataCite XML',
+                        $code,
+                        $message
+                    ];
                 },
-                function ($exception) use ($dataset) {
+                function ($e) use ($dataset) {
                     $this->hasError = true;
-                    Yii::log(sprintf('call api - exception for dataset %s: %s', $dataset->identifier, $exception->getMessage()), 'info');
+                    fwrite(STDERR, sprintf("[ERROR] Exception for dataset %s: %s\n", $dataset->identifier, $e->getMessage()));
+
+                    return null;
                 }
             );
-
-            $i++;
         }
 
         try {
-            $xmlByIds = \GuzzleHttp\Promise\Utils::settle($promises)->wait();
-            $this->updateEntityStatus($xmlByIds);
-        } catch(\Exception $e) {
+            $results = \GuzzleHttp\Promise\Utils::settle($promises)->wait();
+            $this->updateEntityStatus($results);
+        } catch (\Exception $e) {
             $this->hasError = true;
-            Yii::log('Error while handling promises %s: %s', 'error');
+            fwrite(STDERR, '[CRITICAL] Error while waiting for promises: ' . $e->getMessage() . "\n");
         }
     }
 
-    private function updateEntityStatus($xmlByIds) {
-        $values = '';
-        $count = count($xmlByIds);
-        $sql = '';
+    private function updateEntityStatus(array $xmlByIds)
+    {
         $params = [];
+        $params2 = [];
+        $sql = '';
+        $sql2 = '';
 
-        foreach ($xmlByIds as $k => $xmlById) {
-            if (is_null($xmlById['value'])) {
-                Yii::log($xmlById['state'], 'info');
+        foreach ($xmlByIds as $entry) {
+            if (!isset($entry['value'])) {
                 continue;
             }
 
-            $key = $xmlById['value'][0][0];
-            $xml = $xmlById['value'][0][1];
-            $sql .= sprintf('(:id%s, :action%s, :comments%s)%s', $key, $key, $key, $k + 1 !== $count ? ',' : '');
-            $params += [":id$key" => $key, ":action$key" => 'xml', ":comments$key" => $xml];
+            list($id, $xml, $action, $code, $message) = $entry['value'];
+
+            $sql .= "(:id$id, :action$id, :comments$id),";
+            $params += [
+                ":id$id"       => $id,
+                ":action$id"   => $action,
+                ":comments$id" => $xml
+            ];
+
+            $sql2 .= "(:cid$id, :cmessage$id),";
+            $params2 += [
+                ":cid$id"       => $id,
+                ":cmessage$id"   => sprintf('DOI Minting - Metadata response: %s - %s', $code, $message),
+            ];
         }
 
-        if (!$sql) {
-            return;
+        if ($sql) {
+            $sql = rtrim($sql, ',');
+            $command = $this->db->createCommand("INSERT INTO curation_log (dataset_id, action, comments) VALUES $sql");
+            $command->execute($params);
         }
 
-        $sql = rtrim($sql, ',');
-        $sql = 'INSERT INTO curation_log (dataset_id, action, comments) VALUES ' . $sql;
-        $command = $this->db->createCommand($sql);
-        $command->execute($params);
+        if ($sql2) {
+            $sql2 = rtrim($sql2, ',');
+            $command = $this->db->createCommand("INSERT INTO dataset_log (dataset_id, message) VALUES $sql2");
+            $command->execute($params2);
+        }
     }
 }

--- a/protected/commands/UpdateDatasetDataciteCommand.php
+++ b/protected/commands/UpdateDatasetDataciteCommand.php
@@ -29,8 +29,14 @@ class UpdateDatasetDataciteCommand extends CConsoleCommand
 
     public function actionIndex($batchSize = 50, $offset = 0, $doi = null)
     {
+        $batchSize = $batchSize > 450 ?  450 : $batchSize;
         $mds_metadata_url = Yii::app()->params['mds_metadata_url'];
         $mds_prefix = Yii::app()->params['mds_prefix'];
+        $dataciteLimit = 450;
+        // 5 minutes period
+        $window = 300;
+        $sentInWindow = 0;
+        $windowStart = time();
 
         $processed = 0;
 
@@ -43,6 +49,7 @@ class UpdateDatasetDataciteCommand extends CConsoleCommand
             }
             $criteria->limit = $batchSize;
             $criteria->offset = $offset;
+            $criteria->order = 'identifier DESC';
 
             $datasets = Dataset::model()->findAll($criteria);
 
@@ -53,8 +60,21 @@ class UpdateDatasetDataciteCommand extends CConsoleCommand
             $count = count($datasets);
             fwrite(STDOUT, sprintf("Processing %d datasets \n", $count));
             $this->processBatch($datasets, $mds_metadata_url, $mds_prefix);
-            $offset += $batchSize;
-            $processed += $count;
+
+            $sentInWindow += $count;
+            $processed    += $count;
+            $offset       += $batchSize;
+
+            if ($sentInWindow >= $dataciteLimit) {
+                $elapsed = time() - $windowStart;
+                if ($elapsed < $window) {
+                    $sleep = $window - $elapsed;
+                    fwrite(STDOUT, sprintf("[THROTTLE] limit reached: Sleeping %d seconds\n", $sleep));
+                    sleep($sleep);
+                }
+                $windowStart  = time();
+                $sentInWindow = 0;
+            }
         }
 
         fwrite(STDOUT, sprintf("Finished processing %d datasets\n", $processed));

--- a/tests/_support/CliTester.php
+++ b/tests/_support/CliTester.php
@@ -1,0 +1,26 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method void pause()
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class CliTester extends \Codeception\Actor
+{
+    use _generated\CliTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/_support/Helper/Cli.php
+++ b/tests/_support/Helper/Cli.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Helper;
+
+class Cli extends \Codeception\Module
+{
+
+}

--- a/tests/cli.suite.yml
+++ b/tests/cli.suite.yml
@@ -1,0 +1,14 @@
+actor: CliTester
+modules:
+    enabled:
+        - \Helper\Cli
+        - Cli
+        - Db:
+            dsn: "pgsql:host=%GIGADB_HOST%;dbname=%GIGADB_DB%;port=%GIGADB_PORT%"
+            user: "%GIGADB_USER%"
+            password: "%GIGADB_PASSWORD%"
+            dump: 'sql/gigadb.pgdmp'
+            populate: true # run populator before all tests
+            cleanup: true # run populator before each test
+            # Can use --verbose in pg_restore command to output progress messages
+            populator: "PGPASSWORD=$password pg_restore -h %GIGADB_HOST% -p $port -U %GIGADB_USER% -d %GIGADB_DB% --no-owner /var/www/sql/gigadb.pgdmp"

--- a/tests/cli/UpdateDatasetDataciteCest.php
+++ b/tests/cli/UpdateDatasetDataciteCest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+class UpdateDatasetDataciteCest
+{
+    public function TryRunningCommand(\CliTester $I)
+    {
+        $I->seeInDatabase('dataset', ['id' => 8]);
+
+        $I->runShellCommand('./protected/yiic updatedatasetdatacite 2>&1');
+
+        $I->seeInShellOutput('[OK] Dataset 100006 successfully updated');
+        $I->seeInShellOutput('[ERROR] Failed for dataset 102484: 422 - DOI 10.80027/102484: Missing child element(s). Expected is ( {http://datacite.org/schema/kernel-4}creator ). at line 4, column 0');
+
+        $I->seeInDatabase('curation_log', ['dataset_id' => 8]);
+        $I->seeInDatabase('curation_log', ['dataset_id' => 8, 'comments' => 'Metadata response: 201 - OK (10.80027/100006)']);
+        $I->seeInDatabase('curation_log', ['dataset_id' => 2740, 'comments' => 'Metadata response: 422 - DOI 10.80027/102484: Missing child element(s). Expected is ( {http://datacite.org/schema/kernel-4}creator ). at line 4, column 0']);
+        $I->seeInDatabase('dataset_log', ['dataset_id' => 2740, 'message' => 'Metadata response: ERROR']);
+        $I->seeInDatabase('dataset_log', ['dataset_id' => 8, 'message' => 'Metadata response: OK']);
+    }
+}


### PR DESCRIPTION
# Pull request for issue: #549 
update datacite metadata api via a command + check if doi exists in Datacite

## How to test?

to test locally, you can run
docker-compose run --rm application ./protected/yiic updatedatasetdatacite --doi=100295 for a specific doi

options: --limit --offset --doi 

For all published datasets, it will format he dataset data in XML and update it on the Datacite API
or
docker-compose run --rm application ./protected/yiic updatedatasetdatacite

if you want to write to a file add > my_log.txt 2>&1

For all published datasets, it will check if the DOI exists on Datacite API

## How have functionalities been implemented?

## Any issues with implementation?

## Any changes to automated tests?

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?
