### PR TITLE
Fix: Add missing permission for CLOCKSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #2099: Add missing permission for CLOCKSS
+
 ## v4.4.3 - 2025-02-03 - c62107e5e
 
 - Feat #474: Update FAQ "What journals are integrated with GigaDB?"

--- a/docs/SETUP_CI_CD_PIPELINE.md
+++ b/docs/SETUP_CI_CD_PIPELINE.md
@@ -424,4 +424,9 @@ The following Gitlab variables are needed for the acceptance run, both in the pi
 | AWS_SECRET_ACCESS_KEY | your secret key to AWS | All |
 
 
+## Troubleshooting
 
+### permissions
+
+If you find seeing Unauthorised/authentication errors when the Gitlab variables are downloaded by the configuration script,
+ensure that your membership to the "Gigascience" group has the role "Owner".

--- a/lockss.txt
+++ b/lockss.txt
@@ -1,0 +1,1 @@
+CLOCKSS system has permission to ingest, preserve, and serve this open access Archival Unit.

--- a/ops/configuration/gigadb-public/lockss.txt
+++ b/ops/configuration/gigadb-public/lockss.txt
@@ -1,0 +1,1 @@
+CLOCKSS system has permission to ingest, preserve, and serve this open access Archival Unit.

--- a/ops/configuration/nginx-conf/nginx.production.conf
+++ b/ops/configuration/nginx-conf/nginx.production.conf
@@ -40,7 +40,7 @@ http {
   open_file_cache off; # Disabled for issue 619
   charset UTF-8;
 
-  limit_req_zone $binary_remote_addr zone=gigadbsearch:1m rate=30r/s;
+  limit_req_zone $binary_remote_addr zone=gigadbsearch:1m rate=5r/s;
   limit_conn_zone $binary_remote_addr zone=gigadb_php_periplimit:10m;
   # see http://kbeezie.com/securing-nginx-php/2/
 

--- a/ops/packaging/Production-Web-Dockerfile
+++ b/ops/packaging/Production-Web-Dockerfile
@@ -5,7 +5,7 @@ ARG GIGADB_ENV=dev
 
 ARG CONN_LIMIT_STATE=disabled
 COPY ops/configuration/nginx-conf/phplimit.conf.${CONN_LIMIT_STATE} /etc/nginx/phplimit.conf
-COPY ops/configuration/nginx-conf/nginx.conf /etc/nginx/nginx.conf
+COPY ops/configuration/nginx-conf/nginx.production.conf /etc/nginx/nginx.conf
 COPY ops/configuration/nginx-conf/upstream.conf /etc/nginx/conf.d/upstream.conf
 COPY ops/configuration/nginx-conf/enable_sites /usr/local/bin/enable_sites
 COPY css /var/www/css

--- a/ops/packaging/Production-Web-Dockerfile
+++ b/ops/packaging/Production-Web-Dockerfile
@@ -12,6 +12,7 @@ COPY css /var/www/css
 COPY docs /var/www/docs
 COPY favicon.ico /var/www/favicon.ico
 COPY robots.txt /var/www/robots.txt
+COPY lockss.txt /var/www/lockss.txt
 COPY fonts /var/www/fonts
 COPY images /var/www/images
 COPY index.php /var/www/index.php

--- a/ops/packaging/VueDev-Dockerfile
+++ b/ops/packaging/VueDev-Dockerfile
@@ -12,14 +12,6 @@ RUN apt-get update && \
 	    build-essential \
 	     apt-utils \
 	    wget && \
-	# Install Firefox
-	apt-get install -y --no-install-recommends \
-	    ca-certificates \
-		libdbus-glib-1-dev \
-		libx11-xcb1 \
-		packagekit-gtk3-module && \
-	/usr/bin/wget -q -O - "${FFOX_DOWNLOAD_URL}" | tar xjv -C /opt && \
-	ln -s /opt/firefox/firefox /usr/local/bin/firefox && \
 	# Remove all temporary files to reduce bloat on that layer
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/ops/packaging/Web-Dockerfile
+++ b/ops/packaging/Web-Dockerfile
@@ -10,6 +10,7 @@ COPY configuration/nginx-conf/enable_sites /usr/local/bin/enable_sites
 COPY configuration/gigadb-public/favicon.ico /var/www/favicon.ico
 COPY configuration/gigadb-public/index.php /var/www/index.php
 COPY configuration/gigadb-public/robots.txt /var/www/robots.txt
+COPY configuration/gigadb-public/lockss.txt /var/www/lockss.txt
 
 COPY configuration/nginx-conf/sites/${GIGADB_ENV} /tmp/sites-available/
 COPY configuration/nginx-static /tmp/nginx-static/

--- a/tests/_support/Steps/ThirdPartySteps.php
+++ b/tests/_support/Steps/ThirdPartySteps.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Steps;
+
+/**
+ * Class CuratorSteps
+ * steps specific to user story for curators
+ *
+ * stubs copied from (after gherkin scenario steps are created):
+ * docker-compose run --rm test ./vendor/codeception/codeception/codecept g:snippets acceptance
+ */
+class ThirdPartySteps extends \Codeception\Actor
+{
+    protected $I;
+    protected $module;
+
+
+    public function __construct(\AcceptanceTester $I)
+    {
+        $this->I = $I;
+    }
+
+    /**
+     * @Given I have not signed in
+     */
+    public function iHaveNotSignedIn()
+    {
+        $this->I->amOnPage('site/logout');
+    }
+
+
+
+}

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -55,4 +55,6 @@ gherkin:
         - \Steps\WebsiteUserSteps
       developer:
         - \Steps\DeveloperSteps
+      "third party system":
+        - \Steps\ThirdPartySteps
 bootstrap: initdb.php

--- a/tests/acceptance/CLOCKSS.feature
+++ b/tests/acceptance/CLOCKSS.feature
@@ -1,0 +1,11 @@
+@ok-can-offline
+Feature: CLOCKSS permission
+  As a third party system
+  I want to be allowed to access GigaDB content
+  So that I index its content
+
+  @ok
+  Scenario: Can read permission
+    Given I have not signed in
+    When I am on "/lockss.txt"
+    Then I should see "CLOCKSS system has permission to ingest, preserve, and serve this open access Archival Unit."


### PR DESCRIPTION
# Pull request for issue: #2099

This is a pull request for the following functionalities:

Add a publicly accessible static file on the website called `lockss.txt` which contain permission statement from:
https://clockss.org/preserving-your-publications-in-clockss/

## How to test?

Navigate to:

http://gigadb.gigasciencejournal.com/lockss.txt

It should show the permission text.

After pushing this PR to gitlab pipeline for your AWS environment, check on AWS deployment,  that the file is readable and has the permission text.

# How have functionalities been implemented?

static file added at the root of the website.

## Any issues with implementation?

n/a

## Any changes to automated tests?

New acceptance scenario and a new user story user (Third party system)


## Any changes to documentation?

Added a troubleshooting note for correct Gitlab user role needed to download variables

## Any technical debt repayment?

Remove Firefox installl from the JS container, as it is no longer  used
and caused the container to fail on build due to change to Firefox download URL.

## Any improvements to CI/CD pipeline?

n/a

