### PR TITLE
Fix 1955 edit user

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ variables:
   NODE_VERSION: "20.11.0"
   YII_VERSION: "1.1.28"
   YII2_VERSION: "2.0.48"
-  POSTGRES_VERSION: "14.15"
+  POSTGRES_VERSION: "14.10"
   HOME_URL: "gigadb.gigasciencejournal.com"
   FILES_PUBLIC_URL: "http://gigadb.gigasciencejournal.com"
   PUBLIC_HTTP_PORT: "80"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1955: Edit user without being forced to enter a password + add a password regex
+
 ## v4.4.8 - 2025-04-08 - 01de0477b -
 
 - Fix #2033: Create a mockup for all upload statuses except published

--- a/protected/controllers/UserController.php
+++ b/protected/controllers/UserController.php
@@ -125,32 +125,28 @@ class UserController extends Controller {
     public function actionUpdate() {
         $user = $this->loadUser();
         $this->performAjaxValidation($user);
-        #if (!Yii::app()->user->checkAccess('updateOwnUser', array('user'=>$user))) {
-        #    Yii::log(__FUNCTION__."> Unauthorized", 'debug');
-        #    throw new CHttpException(403, 'You are not authorized to perform this action.');
-        #}
 
-
-
-
-        if (isset($_POST['User'])) {
-            $user->attributes = $_POST['User'] ;
-            $attrs = $_POST['User'];
-
-            $password = $user->password_new = $attrs['password'];
+        if ($attrs = Yii::$app->request->post('User')) {
+            $user->email = $user->username = strtolower(trim($attrs['email']));
+            $user->first_name = trim($attrs['first_name']);
+            $user->last_name = trim($attrs['last_name']);
+            $user->password_new = $attrs['password'];
             $user->password_repeat = $attrs['password_repeat'];
+            $user->role = $attrs['role'];
+            $user->affiliation = $attrs['affiliation'];
+            $user->preferred_link = $attrs['preferred_link'];
+            $user->newsletter = $attrs['newsletter'];
+            $user->terms = $attrs['terms'];
+
 
             if (!Yii::app()->user->checkAccess('admin')) {
                 $user->role = 'user';
             }
 
             if ($user->validate('update')) {
-                if ($password != '') {
-                    $user->encryptPassword();
-                }
+                $user->encryptPassword();
 
                 if ($user->save(false)) {
-
                     Yii::app()->user->setFlash('notice', 'Updated');
                     $this->redirect(array('user/show/id/'.$user->id));
                 }
@@ -163,6 +159,7 @@ class UserController extends Controller {
                 Yii::log(__FUNCTION__."> validation failed", 'warning');
             }
         }
+
         $user->password = $user->password_repeat = '';
         $this->render('update', array('model'=>$user));
 
@@ -404,15 +401,20 @@ EO_MAIL;
      * If the data model is not found, an HTTP exception will be raised.
      * @param integer the primary key value. Defaults to null, meaning using the 'id' GET variable
      */
-    private function loadUser($id=null) {
-        if ($this->_user===null) {
-            if ($id!==null || isset($_GET['id'])) {
-                $this->_user=User::model()->findbyPk($id!==null ? $id : $_GET['id']) ;
-            }
-            if ($this->_user===null)
-                throw new CHttpException(500,'The requested user does not exist.') ;
+    private function loadUser($id = null) {
+        if ($this->_user instanceof User) {
+            return $this->_user;
         }
-        return $this->_user ;
+
+        if ($id || Yii::$app->request->get('id')) {
+            $this->_user = User::model()->findbyPk($id ? (int) $id : (int) $_GET['id']) ;
+        }
+
+        if (!$this->_user) {
+            throw new CHttpException(500,'The requested user does not exist.') ;
+        }
+
+        return $this->_user;
     }
 
 

--- a/protected/controllers/UserController.php
+++ b/protected/controllers/UserController.php
@@ -143,12 +143,14 @@ class UserController extends Controller {
                 $user->role = 'user';
             }
 
-            if ($user->validate('update')) {
+            $user->scenario = 'update';
+            if ($user->validate()) {
+                $user->password = $user->password_new;
                 $user->encryptPassword();
 
-                if ($user->save(false)) {
+                if ($user->save()) {
                     Yii::app()->user->setFlash('notice', 'Updated');
-                    $this->redirect(array('user/show/id/'.$user->id));
+                    $this->redirect(array('user/view/id/'.$user->id));
                 }
                 else {
                     Yii::log(__FUNCTION__."> Update failed", 'warning');

--- a/protected/controllers/UserController.php
+++ b/protected/controllers/UserController.php
@@ -335,17 +335,17 @@ class UserController extends Controller {
         $user = User::model()->findByattributes(array('id'=> Yii::app()->user->id));
         $model->newsletter = $user->newsletter;
 
-        if(isset($_POST['ajax']) && $_POST['ajax']==='ChangePassword-form')
+        if (Yii::$app->request->post('ajax') && 'ChangePassword-form' === Yii::$app->request->post('ajax'))
         {
             echo CActiveForm::validate($model);
             Yii::app()->end();
         }
 
-        if(isset($_POST['ChangePasswordForm']))
+        if ($changePasswordFormAttr = Yii::$app->request->post('ChangePasswordForm'))
         {
-            $model->attributes=$_POST['ChangePasswordForm'];
-            $model->newsletter=$_POST['ChangePasswordForm']['newsletter'];
-            if($model->validate() && $model->changePass())
+            $model->attributes = $changePasswordFormAttr;
+            $model->newsletter = $changePasswordFormAttr['newsletter'];
+            if ($model->validate() && $model->changePass())
                 $this->redirect('/user/view_profile');
         }
         $model->password = $model->confirmPassword = '';

--- a/protected/models/ChangePasswordForm.php
+++ b/protected/models/ChangePasswordForm.php
@@ -5,8 +5,8 @@ class ChangePasswordForm extends CFormModel
 	public $password;
 	public $confirmPassword;
 	public $user_id;
-        public $terms;
-        public $newsletter;
+    public $terms;
+    public $newsletter;
 
 	/**
 	 * Declares the validation rules.
@@ -18,8 +18,9 @@ class ChangePasswordForm extends CFormModel
 		return array(
 			// username and password are required
 			array('password, confirmPassword, user_id, terms', 'required'),
-                        array('password', 'compare', 'compareAttribute'=>'confirmPassword'),
-                        array('terms','compare', 'compareValue' => TRUE,'message'=>'Tick here to confirm you have read and understood our Terms of use and Privacy policy.'),
+            array('password', 'match', 'pattern' => User::PASSWORD_REGEX, 'message' => 'Make sure your password contains at least 8 characters with 1 uppercase character, 1 number and 1 special character.'),
+            array('password', 'compare', 'compareAttribute'=>'confirmPassword'),
+            array('terms','compare', 'compareValue' => TRUE,'message'=>'Tick here to confirm you have read and understood our Terms of use and Privacy policy.'),
                     
 		);
 	}
@@ -37,16 +38,18 @@ class ChangePasswordForm extends CFormModel
 
     public function changePass(){
         $user = User::model()->findByPk($this->user_id);
-        if(isset($user)){
+        if ($user){
             $user->password = $this->password;
             $user->password_repeat = $this->confirmPassword;
             $user->newsletter = $this->newsletter;
+            $user->terms = $this->terms;
             $user->encryptPassword();
 
-            if($user->save(false)) {
+            if ($user->save()) {
                 return true;
             }
         }
+
         return false;
     }
 }

--- a/protected/models/User.php
+++ b/protected/models/User.php
@@ -92,8 +92,6 @@ class User extends CActiveRecord {
 
             return;
         }
-
-        $this->password = $this->password_new;
     }
 
 

--- a/protected/models/User.php
+++ b/protected/models/User.php
@@ -23,6 +23,8 @@ class User extends CActiveRecord {
             'DDBJ' => 'DDBJ'
     );
 
+    public const PASSWORD_REGEX = '/^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,}$/';
+
     /**
      * Returns the static model of the specified AR class.
      * @return MyActiveRecord the static model class
@@ -48,15 +50,12 @@ class User extends CActiveRecord {
             array('email', 'required'),
             array('email', 'email'),
             array('email', 'unique'),
-
-            #array('password','length','max'=>128),
-            array('password', 'required', 'on'=>'insert'),
-            array('password', 'compare', 'compareAttribute'=>'password_repeat', 'on'=>'insert'),
-            array('password', 'checkPassword', 'on'=>'update'),
-            array('password', 'safe','on'=>'insert'),
-            array('password_repeat','required'),
+            array('password', 'checkPassword'), // need to be checked first
+            array('password', 'required', 'on' => 'insert'),
+            array('password', 'match', 'pattern' => self::PASSWORD_REGEX, 'message' => 'Make sure your password contains at least 8 characters with 1 uppercase character, 1 number and 1 special character.', 'on' => 'insert'),
+            array('password', 'compare', 'compareAttribute'=>'password_repeat', 'on' => 'insert'),
+            array('password','length','max' => 128),
             array('first_name, last_name','length','max'=>60),
-
             array('first_name','required'),
             array('last_name','required'),
             array('affiliation','required'),
@@ -65,28 +64,36 @@ class User extends CActiveRecord {
             array('terms','compare', 'on'=>'insert', 'compareValue' => TRUE,'message'=>'Tick here to confirm you have read and understood our Terms of use and Privacy policy.'),
             array('role','safe'),
             array('preferred_link', 'safe'),
-            array('verifyCode', 'validateCaptcha'),
+            array('verifyCode', 'validateCaptcha', 'on'=>'insert'),
         );
     }
 
     public function checkPassword($attribute, $params) {
+        if ($this->scenario === "insert") {
+            return;
+        }
+
         $password = $this->password_new;
         $password_repeat = $this->password_repeat;
 
-        if ($password != '') {
-            $password_repeat = $this->password_repeat;
-
-            if ($password != $password_repeat) {
-                $this->addError($attribute,"Password and confirm don't match");
-                return false;
-            }
-            else {
-                Yii::log(__FUNCTION__."> match", 'debug');
-            }
-
-            $this->password = $this->password_new;
+        if (!$password) {
+            return;
         }
-        return true;
+
+        if (!preg_match(self::PASSWORD_REGEX, $password)) {
+            $this->addError($attribute, "Make sure your password contains at least 8 characters with 1 uppercase character,  1 number and 1 special character.");
+
+            return;
+
+        }
+
+        if ($password !== $password_repeat) {
+            $this->addError($attribute,"Passwords must match");
+
+            return;
+        }
+
+        $this->password = $this->password_new;
     }
 
 
@@ -114,7 +121,6 @@ class User extends CActiveRecord {
             'username' => 'Username',
             'terms'=> 'Terms and Conditions',
             'email' => Yii::t('app' , 'Email'),
-            'terms'=> 'Terms and Conditions',
             'first_name' => Yii::t('app' , 'First Name'),
             'last_name' => Yii::t('app' , 'Last Name'),
             'password' => Yii::t('app' , 'Password'),

--- a/protected/views/user/_form.php
+++ b/protected/views/user/_form.php
@@ -151,7 +151,7 @@
 						'inputWrapperOptions' => 'col-xs-9',
 						'attributeName' => 'password',
 						'inputOptions' => [
-							'required' => 'required',
+							'required' => 'update' !== $scenario ? 'required' : false,
 						],
 					]);
 					$this->widget('application.components.controls.PasswordField', [
@@ -163,7 +163,7 @@
 						'inputWrapperOptions' => 'col-xs-9',
 						'attributeName' => 'password_repeat',
 						'inputOptions' => [
-							'required' => 'required',
+							'required' => 'update' !== $scenario ? 'required' : false,
 						],
 					]);
 					?>

--- a/tests/acceptance/ChangePassword.feature
+++ b/tests/acceptance/ChangePassword.feature
@@ -17,32 +17,21 @@ Feature: Change password
     And I should see a submit button "Save"
 
   @ok
-  Scenario: Filling in form to provide new password
+  Scenario: Filling out the form to provide a new password, but the password does not meet the regex requirements
     Given I sign in as a user
     When I am on "/user/changePassword"
     And I fill in the field of "id" "ChangePasswordForm_password" with "123456787"
     And I fill in the field of "id" "ChangePasswordForm_confirmPassword" with "123456787"
     And I check the field "ChangePasswordForm_terms"
     And I press the button "Save"
-    Then I am on "user/view_profile"
-    And I should see "Your profile page"
-    And I should see "user@gigadb.org"
-    And I should see "John"
-    And I should see "Smith"
+    Then I should see "Make sure your password contains at least 8 characters with 1 uppercase character, 1 number and 1 special character."
 
   @ok
-  Scenario: Filling in form to provide user@gigadb.org with original password
-    Given I am on "/site/login"
-    And I fill in the field of "name" "LoginForm[username]" with "user@gigadb.org"
-    And I fill in the field of "name" "LoginForm[password]" with "gigadb"
-    And I press the button "Login"
+  Scenario: Filling out the form to provide a new password, and the password does meet the regex requirements
+    Given I sign in as a user
     When I am on "/user/changePassword"
-    And I fill in the field of "id" "ChangePasswordForm_password" with "gigadb"
-    And I fill in the field of "id" "ChangePasswordForm_confirmPassword" with "gigadb"
+    And I fill in the field of "id" "ChangePasswordForm_password" with "Admintest123?"
+    And I fill in the field of "id" "ChangePasswordForm_confirmPassword" with "Admintest123?"
     And I check the field "ChangePasswordForm_terms"
     And I press the button "Save"
-    Then I am on "user/view_profile"
-    And I should see "Your profile page"
-    And I should see "user@gigadb.org"
-    And I should see "John"
-    And I should see "Smith"
+    Then I should see "Your profile page"

--- a/tests/acceptance/EditUser.feature
+++ b/tests/acceptance/EditUser.feature
@@ -13,7 +13,7 @@ Feature: EditUser
     And I fill in the field of "id" "User_first_name" with "modified"
     And I check the field "User_terms"
     And I press the button "Save"
-    Then I should see "View User 8"
+    Then I should see "View User #8"
     And I should see "modified"
 
   @ok
@@ -23,7 +23,7 @@ Feature: EditUser
     And I fill in the field of "id" "User_password_repeat" with "Azertyu2@"
     And I check the field "User_terms"
     And I press the button "Save"
-    Then I should not see "View User 8"
+    Then I should not see "View User #8"
 
   @ok
   Scenario: Ensure I can't edit a user without matching password regex
@@ -32,7 +32,7 @@ Feature: EditUser
     And I fill in the field of "id" "User_password_repeat" with "123"
     And I check the field "User_terms"
     And I press the button "Save"
-    Then I should not see "View User 8"
+    Then I should not see "View User #8"
 
   @ok
   Scenario: Ensure I can edit a user with matching password
@@ -41,4 +41,4 @@ Feature: EditUser
     And I fill in the field of "id" "User_password_repeat" with "Azertyu1@"
     And I check the field "User_terms"
     And I press the button "Save"
-    Then I should see "View User 8"
+    Then I should see "View User #8"

--- a/tests/acceptance/EditUser.feature
+++ b/tests/acceptance/EditUser.feature
@@ -1,0 +1,44 @@
+@ok-needs-secrets
+Feature: EditUser
+  As a curator
+  I want a form to edit user details
+  So that I can edit a user to GigaDB database
+
+  Background:
+    Given I have signed in as admin
+
+  @ok
+  Scenario: Ensure I can edit a user without changing the password
+    Given I am on "/user/update/id/8"
+    And I fill in the field of "id" "User_first_name" with "modified"
+    And I check the field "User_terms"
+    And I press the button "Save"
+    Then I should see "View User 8"
+    And I should see "modified"
+
+  @ok
+  Scenario: Ensure I can't edit a user without matching password
+    Given I am on "/user/update/id/8"
+    And I fill in the field of "id" "User_password" with "Azertyu1@"
+    And I fill in the field of "id" "User_password_repeat" with "Azertyu2@"
+    And I check the field "User_terms"
+    And I press the button "Save"
+    Then I should not see "View User 8"
+
+  @ok
+  Scenario: Ensure I can't edit a user without matching password regex
+    Given I am on "/user/update/id/8"
+    And I fill in the field of "id" "User_password" with "123"
+    And I fill in the field of "id" "User_password_repeat" with "123"
+    And I check the field "User_terms"
+    And I press the button "Save"
+    Then I should not see "View User 8"
+
+  @ok
+  Scenario: Ensure I can edit a user with matching password
+    Given I am on "/user/update/id/8"
+    And I fill in the field of "id" "User_password" with "Azertyu1@"
+    And I fill in the field of "id" "User_password_repeat" with "Azertyu1@"
+    And I check the field "User_terms"
+    And I press the button "Save"
+    Then I should see "View User 8"

--- a/tests/acceptance/NewUser.feature
+++ b/tests/acceptance/NewUser.feature
@@ -29,7 +29,7 @@ Feature: NewUser
     And I should see a submit button "Register"
 
   @ok
-  Scenario: Filling in the form to create new user
+  Scenario: Filling in the form to create new user and it fails
     Given I am on "/user/create"
     And there is no user with email "martianmanhunter@mailinator.com"
     When I fill in the field of "id" "User_email" with "martianmanhunter@mailinator.com"
@@ -37,6 +37,22 @@ Feature: NewUser
     And I fill in the field of "id" "User_last_name" with "J'onzz"
     And I fill in the field of "id" "User_password" with "123456787"
     And I fill in the field of "id" "User_password_repeat" with "123456787"
+    And I fill in the field of "id" "User_affiliation" with "GigaScience"
+    And I select "NCBI" from the field "User_preferred_link"
+    And I check the field "User_terms"
+    And I fill in the field of "id" "User_verifyCode" with "shazam"
+    And I press the button "Register"
+    Then I should not see "Welcome!"
+
+  @ok
+  Scenario: Filling in the form to create new user
+    Given I am on "/user/create"
+    And there is no user with email "martianmanhunter@mailinator.com"
+    When I fill in the field of "id" "User_email" with "martianmanhunter@mailinator.com"
+    And I fill in the field of "id" "User_first_name" with "J'onn"
+    And I fill in the field of "id" "User_last_name" with "J'onzz"
+    And I fill in the field of "id" "User_password" with "Azertyu1@"
+    And I fill in the field of "id" "User_password_repeat" with "Azertyu1@"
     And I fill in the field of "id" "User_affiliation" with "GigaScience"
     And I select "NCBI" from the field "User_preferred_link"
     And I check the field "User_terms"

--- a/tests/functional/EmailCest.php
+++ b/tests/functional/EmailCest.php
@@ -79,8 +79,8 @@ class EmailCest
         $I->fillField(['id' => 'User_email'], 'swordmaster@mailinator.com');
         $I->fillField(['id' => 'User_first_name'], 'Duuncan');
         $I->fillField(['id' => 'User_last_name'], 'Idaaho');
-        $I->fillField(['id' => 'User_password'], 'foobar');
-        $I->fillField(['id' => 'User_password_repeat'], 'foobar');
+        $I->fillField(['id' => 'User_password'], 'Foobar123?');
+        $I->fillField(['id' => 'User_password_repeat'], 'Foobar123?');
         $I->fillField(['id' => 'User_affiliation'], 'Atriedes');
         $I->selectOption('form select[id=User_preferred_link]', 'NCBI');
         $I->checkOption('#User_newsletter');
@@ -115,8 +115,8 @@ class EmailCest
         $I->fillField(['id' => 'User_email'], 'warmaster@mailinator.com');
         $I->fillField(['id' => 'User_first_name'], 'Gurney');
         $I->fillField(['id' => 'User_last_name'], 'Halleck');
-        $I->fillField(['id' => 'User_password'], 'foobar');
-        $I->fillField(['id' => 'User_password_repeat'], 'foobar');
+        $I->fillField(['id' => 'User_password'], 'Foobar123?');
+        $I->fillField(['id' => 'User_password_repeat'], 'Foobar123?');
         $I->fillField(['id' => 'User_affiliation'], 'Atriedes');
         $I->selectOption('form select[id=User_preferred_link]', 'NCBI');
         $I->checkOption('#User_newsletter');

--- a/tests/unit/UserTest.php
+++ b/tests/unit/UserTest.php
@@ -43,4 +43,59 @@ class UserTest extends \CDbTestCase
         $this->assertTrue(strlen($password) >= 8);
         $this->assertRegExp('/^[a-z0-9]+$/', $password);
     }
+
+    function testPasswordRequired()
+    {
+        $user= new \User();
+        $user->validate();
+        $errors = $user->getErrors();
+
+        $this->assertArrayHasKey("password", $errors);
+        $this->assertContains('Password cannot be blank', $errors['password'][0]);
+    }
+
+    function testPasswordMustMatchRegex()
+    {
+        $user = new \User();
+        $user->password = "foo";
+        $user->validate();
+        $errors = $user->getErrors();
+
+        $this->assertArrayHasKey('password', $errors);
+        $this->assertContains('Make sure your password contains at least 8 characters with 1 uppercase character, 1 number and 1 special character.', $errors['password'][0]);
+    }
+
+    function testPasswordMustBeExactlyRepeated()
+    {
+        $user = new \User();
+        $user->password = 'Azertyu1@';
+        $user->validate();
+        $errors = $user->getErrors();
+
+        $this->assertArrayHasKey('password', $errors);
+        $this->assertContains('Password must be repeated exactly', $errors['password'][0]);
+    }
+
+    function testEmptyPassword()
+    {
+        $user = new \User();
+        $user->password = '   ';
+        $user->password_repeat = '   ';
+        $user->validate();
+        $errors = $user->getErrors();
+
+        $this->assertArrayHasKey('password', $errors);
+        $this->assertContains('Password cannot be blank', $errors['password'][0]);
+    }
+
+    function testValidPassword()
+    {
+        $user = new \User();
+        $user->password = 'Azertyu1@';
+        $user->password_repeat = 'Azertyu1@';
+        $user->validate();
+        $errors = $user->getErrors();
+
+        $this->assertArrayNotHasKey('password', $errors);
+    }
 }


### PR DESCRIPTION
# Pull request for issue: #1955 

This is a pull request for the following functionalities:
add a regex for password
password is optional when I want to edit an user
captcha not required for update

## How to test?

Given I am on the user admin form for a user
When I change its details
And I click Save
Then the details is saved to the database
And I am not asked to fill a captcha
Given I am on the user admin form for a user
When I change its details
And I click Save
Then the details is saved to the database
And I am not forced to provide a password for that user

## How have functionalities been implemented?

## Any issues with implementation?

## Any changes to automated tests?

test added

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?
