### PR TITLE
fix:2203 update the curation log without requiring a page refresh when minting a DOI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #2203: Update the curation log without requiring a page refresh when minting a DOI
 - Fix #1290: Update and save project url and name
 - Fix #2187: Make FAQ buttons responsive
 - Fix #2116: Make authors ordered as shown in the DOI page in the readme file

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -483,7 +483,10 @@ class AdminDatasetController extends Controller
             }
         }
 
+        $curationLog = CurationLog::model()->searchByDatasetId($dataset->id);
         CurationLog::createGeneralCurationLogEntry($dataset->id, $action, $log);
+
+        $result['html'] = $this->renderPartial('curationLog', array('dataset_id' => $dataset->id, 'model' => $curationLog), true);
         echo json_encode($result);
         Yii::app()->end();
     }

--- a/protected/views/adminDataset/_form.php
+++ b/protected/views/adminDataset/_form.php
@@ -508,7 +508,7 @@ echo $form->hiddenField($model, "image_id");
             <?php if (isset($dataset_id)) {
             ?>
                 <hr />
-                <div class="form-block-6">
+                <div class="form-block-6" id="curationLogId">
                     <?php
                     echo $this->renderPartial("curationLog", array('dataset_id' => $dataset_id, 'model' => $curationlog));
                     ?>
@@ -856,7 +856,8 @@ function handleDoiStatus(output) {
     create_md_status,
     update_md_status,
     update_md_response,
-    error
+    error,
+    html,
   } = output
 
   if (check_doi_status === 200 && update_md_status === 201) {
@@ -879,6 +880,10 @@ function handleDoiStatus(output) {
 
   if (error) {
     $("#minting").addClass("alert alert-danger").html(error)
+  }
+
+  if (html) {
+      $('#curationLogId').html(html);
   }
 }
 

--- a/tests/acceptance/AdminDatasetCurationLog.feature
+++ b/tests/acceptance/AdminDatasetCurationLog.feature
@@ -13,8 +13,6 @@ Feature: curation log entry under the dataset form
     And I press the button "Mint DOI"
     And I wait "3" seconds
     And I should see "This DOI exists in DataCite already, so it has now been updated with the current values from GigaDB."
-    Then I am on "/adminDataset/update/id/8"
-    And I wait "3" seconds
     And I should see "Dataset 100006 - Check DOI: OK - update md response: OK"
     And I should see "<?xml"
     When I press the button "+"


### PR DESCRIPTION
# Pull request for issue: #2203 

This is a pull request for the following functionalities:

update the curation log without requiring a page refresh when minting a DOI

## How to test?

Given I click the Mint DOI button on the dataset admin page
When a new curation log entry is created
Then I should be able to see it without refreshing the page

## How have functionalities been implemented?

## Any issues with implementation?

## Any changes to automated tests?

test updated

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?
