### PR TITLE
fix 2180: add user in curation log when minting doi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #2180: Add user in curation log when minting the DOI
 - Feat #2066: Wrap edit file attribute form in a modal
 - Fix #2203: Update the curation log without requiring a page refresh when minting a DOI
 - Fix #1290: Update and save project url and name

--- a/ops/packaging/Beanstalkd-Dockerfile
+++ b/ops/packaging/Beanstalkd-Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.14
 
 RUN apk add --no-cache beanstalkd
 

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -445,7 +445,7 @@ class AdminDatasetController extends Controller
         $result['doi_response'] = $doiResponse->getBody()->getContents();
         $result['check_doi_status'] = $doiResponse->getStatusCode();
         $isPresent = in_array($result['check_doi_status'], [200, 204]);
-        $log .= sprintf(' - Check DOI: %s', $isPresent ? "OK" : "DOI doesn't exist");
+        $log .= sprintf(' | Check DOI: %s', $isPresent ? "OK" : "DOI doesn't exist");
 
         if ($isPresent || $result['check_doi_status'] === 404) {
             if (!$xml_data = $dataset->toXML()) {
@@ -469,7 +469,7 @@ class AdminDatasetController extends Controller
             $keyStatus = sprintf('%s_md_status', $result['check_doi_status'] === 200 ? 'update' : 'create');
             $result[$keyResponse] = $updateMdResponse->getBody()->getContents();
             $result[$keyStatus] = $updateMdResponse->getStatusCode();
-            $log .= sprintf(' - %s md response: %s', $result['check_doi_status'] === 200 ? 'update' : 'create', 201 === $result[$keyStatus] ? "OK" : $result[$keyResponse]);
+            $log .= sprintf(' | %s metadata response: %s', $result['check_doi_status'] === 200 ? 'update' : 'create', 201 === $result[$keyStatus] ? "OK" : $result[$keyResponse]);
 
             $logMessageXml = 201 === $result[$keyStatus] ? 'Sent DataCite XML' : 'Failed to send DataCite XML';
             CurationLog::createGeneralCurationLogEntry($dataset->id, $logMessageXml, $xml_data, $userName);
@@ -489,7 +489,7 @@ class AdminDatasetController extends Controller
 
                 $result['create_doi_response'] = $response->getBody()->getContents();
                 $result['create_doi_status'] = $response->getStatusCode();
-                $log .= sprintf(' - Create DOI: %s', $result['create_doi_status'] === 201 ? 'OK' : $result['create_doi_response']);
+                $log .= sprintf(' | Create DOI: %s', $result['create_doi_status'] === 201 ? 'OK' : $result['create_doi_response']);
             }
         }
 

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -397,6 +397,16 @@ class AdminDatasetController extends Controller
      */
     public function actionMint()
     {
+        $user = User::model()->findByPk(Yii::app()->user->id);
+
+        if (!$user) {
+            $result['error'] = 'An error occurred';
+            echo json_encode($result);
+            Yii::app()->end();
+        }
+
+        $userName = sprintf('%s %s', $user->first_name, $user->last_name);
+
         if (!$doi = Yii::$app->request->post('doi')) {
             $result['error'] = 'You need to provide a DOI';
             echo json_encode($result);
@@ -462,7 +472,7 @@ class AdminDatasetController extends Controller
             $log .= sprintf(' - %s md response: %s', $result['check_doi_status'] === 200 ? 'update' : 'create', 201 === $result[$keyStatus] ? "OK" : $result[$keyResponse]);
 
             $logMessageXml = 201 === $result[$keyStatus] ? 'Sent DataCite XML' : 'Failed to send DataCite XML';
-            CurationLog::createGeneralCurationLogEntry($dataset->id, $logMessageXml, $xml_data);
+            CurationLog::createGeneralCurationLogEntry($dataset->id, $logMessageXml, $xml_data, $userName);
 
             if (201 === $result[$keyStatus] && 404 === $result['check_doi_status']) {
                 $result['doi_data'] = 'doi=' . $mds_prefix . '/' . $doi . "\n" . 'url=http://gigadb.org/dataset/' . $doi;
@@ -484,7 +494,7 @@ class AdminDatasetController extends Controller
         }
 
         $curationLog = CurationLog::model()->searchByDatasetId($dataset->id);
-        CurationLog::createGeneralCurationLogEntry($dataset->id, $action, $log);
+        CurationLog::createGeneralCurationLogEntry($dataset->id, $action, $log, $userName);
 
         $result['html'] = $this->renderPartial('curationLog', array('dataset_id' => $dataset->id, 'model' => $curationLog), true);
         echo json_encode($result);

--- a/tests/acceptance/AdminDatasetCurationLog.feature
+++ b/tests/acceptance/AdminDatasetCurationLog.feature
@@ -13,7 +13,9 @@ Feature: curation log entry under the dataset form
     And I press the button "Mint DOI"
     And I wait "3" seconds
     And I should see "This DOI exists in DataCite already, so it has now been updated with the current values from GigaDB."
-    And I should see "Dataset 100006 - Check DOI: OK - update md response: OK"
+    Then I am on "/adminDataset/update/id/8"
+    And I wait "3" seconds
+    And I should see "Dataset 100006 | Check DOI: OK | update metadata response: OK"
     And I should see "<?xml"
     When I press the button "+"
     And I wait "3" seconds

--- a/tests/acceptance/AdminDatasetCurationLog.feature
+++ b/tests/acceptance/AdminDatasetCurationLog.feature
@@ -29,3 +29,13 @@ Feature: curation log entry under the dataset form
     And I wait "3" seconds
     And I should see "Failed to send DataCite XML"
     And I should see "<?xml"
+
+  @ok
+  Scenario: Minting Doi and adding curation log entry with created_by filled in with by the connected user's name
+    When I am on "/adminDataset/update/id/8"
+    And I press the button "Mint DOI"
+    And I wait "3" seconds
+    And I should see "This DOI exists in DataCite already, so it has now been updated with the current values from GigaDB."
+    Then I am on "/adminDataset/update/id/8"
+    And I wait "3" seconds
+    And I should see "Joe Bloggs"


### PR DESCRIPTION
# Pull request for issue: #2180 

 Created_by column in the log entry has been changed to name the user who clicked the mint doi button

## How to test?

go on dataset update page
click the "Mint DOI" button
look at the curation log entry

## How have functionalities been implemented?

## Any issues with implementation?

## Any changes to automated tests?

acceptance test added

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?
