### PR TITLE
Update default dataset view file settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-## v4.4.5 - 2025-02-24 - cfe6bc63c - 
+- Feat #2212: Update default dataset view file settings
+
+## v4.4.5 - 2025-02-24 - cfe6bc63c -
 
 - Fix #1119: Fix filename column width in dataset page
 - Feat #2138: Avoid deleting a type when deleting a dataset type

--- a/protected/components/DatasetPageSettings.php
+++ b/protected/components/DatasetPageSettings.php
@@ -13,7 +13,7 @@
 class DatasetPageSettings extends yii\base\BaseObject
 {
     /** @var constant to assign the default column names of files table to a constant */
-    const VIEW_DEFAULT_FILE_COLUMNS = ['name', 'description', 'type_id' , 'size', 'attribute', 'location'];
+    const VIEW_DEFAULT_FILE_COLUMNS = ['name', 'description', 'format_id', 'size', 'location'];
     const MOCKUP_COLUMNS = ['name','description', 'size', 'type_id', 'format_id', 'location', 'date_stamp','sample_id','attribute'] ;
 
     /** @var DatasetDAO $_dataset The dao class for getting dataset info*/
@@ -70,7 +70,7 @@ class DatasetPageSettings extends yii\base\BaseObject
         // default values
         $fileSettings = [
             "setting" => $defaultColumns,
-            "page" => 10,
+            "page" => 50,
         ];
 
         if (isset($cookies['file_setting'])) {

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -435,4 +435,12 @@ class AcceptanceTester extends \Codeception\Actor
     {
         $this->see($text, ['css' => "$table tr:nth-child($row) td:nth-child($column)"]);
     }
+
+    /**
+     * @Then I should see option :option selected in :select
+     */
+    public function iShouldSeeOptionSelected($option, $select)
+    {
+        $this->seeOptionIsSelected($select, $option);
+    }
 }

--- a/tests/acceptance/DatasetView.feature
+++ b/tests/acceptance/DatasetView.feature
@@ -228,3 +228,27 @@ Feature: a user visit the dataset page
     When I follow "[aria-label^='Size']"
     And I follow "[aria-label^='Size']"
     Then I should see "3.88 GB" in the table "#files_table" cell 1 6
+
+  @broken @issue-2212
+  # the default values in the test and local env are different from the ones used in live, i.e. protected/components/DatasetPageSettings.php:16, in such setup this cannot be tested effectively. For this reason, the test does not pass, although it represents the expected live behavior
+  Scenario: Files settings default checked values
+    Given I have not signed in
+    When I am on "/dataset/100035"
+    And I follow "Files"
+    And I click the table settings for "files_table_settings"
+    Then I should see "description" checkbox is checked
+    And I should see "sample_id" checkbox is not checked
+    And I should see "type_id" checkbox is not checked
+    And I should see "format_id" checkbox is checked
+    And I should see "size" checkbox is checked
+    And I should see "date_stamp" checkbox is not checked
+    And I should see "location" checkbox is checked
+    And I should see "attribute" checkbox is not checked
+
+  @ok @issue-2212
+  Scenario: Files settings default items per page is 50
+    Given I have not signed in
+    When I am on "/dataset/100035"
+    And I follow "Files"
+    And I click the table settings for "files_table_settings"
+    Then I should see option "50" selected in "#selectPageSizeFilesSetting"


### PR DESCRIPTION
# Pull request for issue: #2122

This is a pull request for the following functionalities:

* Update default active columns for file table in dataset page, according to the ticket description
* Update default number of items per page to 50

BEFORE
![image](https://github.com/user-attachments/assets/f2b197b9-d959-4efc-b49c-93825f652b17)

AFTER
![Screenshot from 2025-05-22 17-55-15](https://github.com/user-attachments/assets/c19bd269-4d74-460b-bea2-98aeb5e5012d)

![Screenshot from 2025-05-22 17-54-32](https://github.com/user-attachments/assets/1651011a-f26d-4372-8997-3c9e4365fabd)

## How to test?

If you go to any dataset page and open the file settings modal, the default option should be 50. However, the way the protected/components/DatasetPageSettings.php is configured, it used different default settings for live and dev, as can be seen in `protected/controllers/DatasetController.php:73`, so it is probably sufficient to confirm that the default for live is set correctly

```php
const VIEW_DEFAULT_FILE_COLUMNS = ['name', 'description', 'format_id', 'size', 'location'];
```

## How have functionalities been implemented?

- updated VIEW_DEFAULT_FILE_COLUMNS array
- Updated default items per page in `public function getFileSettings`
- Added acceptance tests to check the expected defaults

## Any issues with implementation?

Since dev uses a different default, the acceptance test added to check the expected defaults will not pass and so I tagged it as broken and added an explanation

## Any changes to automated tests?

See above