### PR TITLE
Balance size of dataset table columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-## v4.4.5 - 2025-02-24 - cfe6bc63c - 
+- Fix #2219: Set datasetfile table column widths explicitly
+
+## v4.4.5 - 2025-02-24 - cfe6bc63c -
 
 - Fix #1119: Fix filename column width in dataset page
 - Feat #2138: Avoid deleting a type when deleting a dataset type

--- a/less/modules/datatables.less
+++ b/less/modules/datatables.less
@@ -31,6 +31,40 @@ table.dataTable thead {
 
 .dataset-files-table {
   .filename-column {
-    width: 20ch;
+    width: 12%;
+  }
+
+  .description-column {
+    width: 30%;
+    min-width: 20ch;
+  }
+
+  .sample-id-column {
+    width: 10%;
+  }
+
+  .data-type-column {
+    width: 10%;
+  }
+
+  .file-format-column {
+    width: 10%;
+  }
+
+  .size-column {
+    width: 10%;
+  }
+
+  .release-date-column {
+    width: 10%;
+  }
+
+  .attributes-column {
+    width: 15%;
+  }
+
+  .download-column {
+    width: 60px;
+    max-width: 75px;
   }
 }

--- a/protected/views/dataset/view.php
+++ b/protected/views/dataset/view.php
@@ -399,14 +399,14 @@ $sampleDataProvider = $samples->getDataProvider();
                                     <thead>
                                         <tr>
                                             <th class="filename-column" title="The name of the file. Click header to sort by A-Z/Z-A.">File Name</th>
-                                            <th title="Short description of file contents. Click header to sort by A-Z/Z-A.">Description</th>
-                                            <th title="Name or ID of sample used to generate this file.">Sample ID</th>
-                                            <th title="The type of data in the file, see [help](http://gigadb.org/site/help#vocabulary) page for definitions of individual data types.  Click header to sort by A-Z/Z-A.">Data Type</th>
-                                            <th title="The format of the file, see [help](http://gigadb.org/site/help#vocabulary) page for definitions of individual file formats. Click header to sort by A-Z/Z-A.">File Format</th>
-                                            <th title="The size on disk of the file. Click header to sort by A-Z/Z-A.">Size</th>
-                                            <th title="Date of release of the file, see the history log for details of any changes made after initial release date. Click header to sort by A-Z/Z-A.">Release Date</th>
-                                            <th title="Additional information about the file presented as Key:Value pairs.">File Attributes</th>
-                                            <th title="The direct link to the files server location.">Download</th>
+                                            <th class="description-column" title="Short description of file contents. Click header to sort by A-Z/Z-A.">Description</th>
+                                            <th class="sample-id-column" title="Name or ID of sample used to generate this file.">Sample ID</th>
+                                            <th class="data-type-column" title="The type of data in the file, see [help](http://gigadb.org/site/help#vocabulary) page for definitions of individual data types.  Click header to sort by A-Z/Z-A.">Data Type</th>
+                                            <th class="file-format-column" title="The format of the file, see [help](http://gigadb.org/site/help#vocabulary) page for definitions of individual file formats. Click header to sort by A-Z/Z-A.">File Format</th>
+                                            <th class="size-column" title="The size on disk of the file. Click header to sort by A-Z/Z-A.">Size</th>
+                                            <th class="release-date-column" title="Date of release of the file, see the history log for details of any changes made after initial release date. Click header to sort by A-Z/Z-A.">Release Date</th>
+                                            <th class="attributes-column" title="Additional information about the file presented as Key:Value pairs.">File Attributes</th>
+                                            <th class="download-column" title="The direct link to the files server location.">Download</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -427,7 +427,7 @@ $sampleDataProvider = $samples->getDataProvider();
                                                 <td><?= $file['format'] ?></td>
                                                 <td><?= $file['sizeUnit'] ?></td>
                                                 <td><?= $file['date_stamp'] ?></td>
-                                                <td><?= $file['attrDesc'] ?></td>
+                                                <td class="text-break-word"><?= $file['attrDesc'] ?></td>
                                                 <td class="button-column">
                                                     <div class="icon-wrapper">
                                                         <a class="js-download-count fa fa-download fa-lg icon icon-download" href="<?= $file['location'] ?>" aria-label="Download <?= $file["name"] ?>"></a>
@@ -939,6 +939,7 @@ $sampleDataProvider = $samples->getDataProvider();
           console.log("Error, return to " + _min);
           return _min;
         }
+        return _min;
       }
 
       function goToFilesPage() {
@@ -988,8 +989,8 @@ $sampleDataProvider = $samples->getDataProvider();
       }
 
       $(document).ready(function() {
-        handleInitPagination()
-        handlePaginationCssClasses()
+        handleInitPagination();
+        handlePaginationCssClasses();
       });
 
     </script>


### PR DESCRIPTION
# Pull request for issue: #2219

Explicitly set relative size of dataset table columns to give more weight to the description column

BEFORE
![image](https://github.com/user-attachments/assets/7639d0fa-7a32-489e-9842-d9d9af942d90)

AFTER
![image](https://github.com/user-attachments/assets/4b96f9ad-093d-4f1a-a87b-0d8e198675fb)


## How to test?

Navigate to any dataset page, e.g. http://gigadb.gigasciencejournal.com/dataset/100094 and verify table layout is as desired

## How have functionalities been implemented?

Explicitly added % widths to table columns so that description has always a larger relative width

## Any issues with implementation?

--

## Any changes to automated tests?

--
