### PR TITLE
Using GigaDB nginx container as a reverse proxy to access GigaBlog as a subdirectory URL

### DIFF
--- a/ops/configuration/nginx-conf/sites/dev/gigadb.dev.http.conf
+++ b/ops/configuration/nginx-conf/sites/dev/gigadb.dev.http.conf
@@ -19,6 +19,26 @@ server {
          try_files $uri $uri/ /index.php$is_args$args;
     }
 
+    location /blog {
+        proxy_pass https://gigasciencejournal.wpcomstaging.com/;
+    }
+
+    location /blog/wp-content {
+        proxy_pass https://gigasciencejournal.wpcomstaging.com/wp-content;
+    }
+
+    location /blog/wp-includes {
+        proxy_pass https://gigasciencejournal.wpcomstaging.com/wp-includes;
+    }
+
+    location /blog/wp-login.php {
+        proxy_pass https://gigasciencejournal.wpcomstaging.com/login.php;
+    }
+
+    location /blog/wp-admin {
+       proxy_pass https://gigasciencejournal.wpcomstaging.com/wp-admin;
+    }
+
     location ~ \.php$ {
         try_files $uri /index.php =404;
         fastcgi_pass php-upstream;


### PR DESCRIPTION
# Pull request for issue: [gigablog#8](https://github.com/gigascience/gigablog/issues/8)

This is a pull request for the following functionalities:

* Using nginx container in `dev` environment as a reverse proxy for GigaBlog hosted on Wordpress to demonstrate how a blog subdomain URL (https://gigasciencejournal.wpcomstaging.com/) can be implemented as a subfolder URL.

## How to test?

1. Spin up your local GigaDB dev environment using `./up.sh`. 
2. Go to http://gigadb.gigasciencejournal.com/blog and you should see homepage for GigaBlog which originates from content hosted in Wordpress.

## How have functionalities been implemented?

The [proxy_pass](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass) directive has been used in `gigadb.dev.http.conf` to pass requests to https://gigasciencejournal.wpcomstaging.com.

Other people have had this problem before, e.g. see [here](https://jeffreyeverhart.com/2016/12/11/wordpress-nginx-proxy-server-subdomain-subdirectory/).

## Any issues with implementation?

If you click on a link to a specific GigaBlog post on the http://gigadb.gigasciencejournal.com/blog home page, the link is `https://gigasciencejournal.wpcomstaging.com/2024/10/23/oriental_stork_genome/`. What we actually want to see is a `http://gigadb.gigasciencejournal.com/blog/2024/10/23/oriental_stork_genome/`.

To do this, I think we need to update the WordPress Address URL and Site Address URL from `https://gigasciencejournal.wpcomstaging.com` to `http://gigadb.gigasciencejournal.com/blog`. However, I don't think this ability is provided with a WordPress hosted website.

A couple of ways were tested to change these two variables:
* Updating the WordPress Address URL and Site Address URL values in the `wp_options` table
* Uploading a `wp-config.php` file using SFTP.

None of the above methods made any difference to the blog post links.
