### PR TITLE
fix: 1616 new nomenclature for upload_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #1616: Add a curation log entry when updating upload_status
+- Fix #1616: New nomenclature for upload_status - AssigningFTPbox should be replaced by CuratorInitialReview
+- Fix #1616: New nomenclature for upload_status - Provided Data should be used when Data AvailableForReview is used
+- Fix #1616: New nomenclature for upload_status - Submitted should be replaced by DataAvailableForReview
+- Fix #1616: New nomenclature for upload_status - Submitted should be replaced by DataAvailableForReview
+- Fix #1616: New nomenclature for upload_status - dataPending should be replaced by dataPreparation
+
 ## v4.4.16 - 2025-08-15 - 6e04c0b9e -
 
 - Fix #2428: AdminUserController should target AdminUserController when validating or rejecting a claim

--- a/files/templates/DataAvailableForReview.twig
+++ b/files/templates/DataAvailableForReview.twig
@@ -1,2 +1,3 @@
-The dataset with DOI {{ identifier }} has had its upload status
-changed to "DataAvailableForReview".
+
+The editors have change the upload status for the dataset with DOI {{ identifier }}.
+They set it up to "DataAvailableForReview"

--- a/files/templates/DataPreparation.twig
+++ b/files/templates/DataPreparation.twig
@@ -2,4 +2,4 @@
 Dear author,
 
 The curators have change the upload status for the dataset with DOI {{ identifier }}.
-It is now set to "DataPending" which indicates that some files are missing.
+It is now set to "DataPreparation" which indicates that some files are missing.

--- a/files/templates/Submitted.twig
+++ b/files/templates/Submitted.twig
@@ -1,3 +1,0 @@
-
-The editors have change the upload status for the dataset with DOI {{ identifier }}.
-They set it up to "Submitted"

--- a/files/templates/UserProvidedData.twig
+++ b/files/templates/UserProvidedData.twig
@@ -1,0 +1,2 @@
+The dataset with DOI {{ identifier }} has had its upload status
+changed to "UserProvidedData".

--- a/files/templates/emailInstructions.twig
+++ b/files/templates/emailInstructions.twig
@@ -30,7 +30,7 @@ Once you have finished the uploading of the files and filling in the associated 
 you can click "Complete and return to Your Uploaded Datasets page" to confirm your files submission. 
 This will change the status from "{{ status }}" to "DataAvalaibleForReview" to allow review of the submission and its dataset by our curators.
 
-If the review shows that files are missing or metadata is incomplete/has error, the curators will mark the dataset as "DataPending" which will allow you to access the file upload wizard again from your user profile in order to amend your submission.
+If the review shows that files are missing or metadata is incomplete/has error, the curators will mark the dataset as "DataPreparation" which will allow you to access the file upload wizard again from your user profile in order to amend your submission.
 
 
 Any question, don't hesitate to contact us at info@gigasciencejournal.com

--- a/fuw/app/common/tests/_support/Step/Acceptance/CuratorSteps.php
+++ b/fuw/app/common/tests/_support/Step/Acceptance/CuratorSteps.php
@@ -269,7 +269,7 @@ class CuratorSteps #extends \common\tests\AcceptanceTester
             $fileUploadSrv, 
             Yii::$app->params['dataset_upload']
         );
-        $datasetUpload->setStatusToDataAvailableForReview("changed from test scenario");
+        $datasetUpload->setStatusToUserProvidedData("changed from test scenario");
      }
 
     /**

--- a/fuw/app/common/tests/acceptance/file-upload-1-curator-dropbox-setup.feature
+++ b/fuw/app/common/tests/acceptance/file-upload-1-curator-dropbox-setup.feature
@@ -8,7 +8,7 @@ Background:
 	Given there is "user" "Joy" "Fox"
 	And there is "admin" "Ben" "Hur"
 	And The user "Ben" "Hur" is registered as authorised user in the API
-	And a dataset with DOI "000005" owned by user "Joy" "Fox" has status "AssigningFTPbox"
+	And a dataset with DOI "000005" owned by user "Joy" "Fox" has status "CuratorInitialReview"
 	And filedrop account for DOI "000005" doesn't exist
 
 @ok
@@ -17,7 +17,7 @@ Scenario: Accessing admin page's list of datasets to setup drop box for a datase
 	And I go to "/site/admin"
 	When I press "Datasets"
 	Then the response sould contain "000005"
-	And the response sould contain "AssigningFTPbox"
+	And the response sould contain "CuratorInitialReview"
 	And I should see a "New Dropbox for this dataset" button
 
 @ok
@@ -86,7 +86,7 @@ Scenario: Popup composer for customizing and sending email instructions
 # Scenario: Creating the drop box and emailing the author custom instructions
 # 	Given I sign in as an admin
 # 	And a dataset has been entered with temporary DOI "000005"
-# 	And the uploaded dataset has status "AssigningFTPbox"
+# 	And the uploaded dataset has status "CuratorInitialReview"
 # 	And I am on "/site/admin"
 # 	And I have pressed "Assign Drop box to dataset 000005"
 # 	When I fill in "Message to the author" with "custom instructions"
@@ -97,7 +97,7 @@ Scenario: Popup composer for customizing and sending email instructions
 # Scenario: Creating the drop box and emailing a different author
 # 	Given I sign in as an admin
 # 	And a dataset has been entered with temporary DOI "000005"
-# 	And the uploaded dataset has status "AssigningFTPbox"
+# 	And the uploaded dataset has status "CuratorInitialReview"
 # 	And I am on "/site/admin"
 # 	And I have pressed "Assign Drop box to dataset 000005"
 # 	When I fill in "Author name" with "Terry Bone"
@@ -108,7 +108,7 @@ Scenario: Popup composer for customizing and sending email instructions
 # Scenario: Emailing instructions without creating a drop box
 # 	Given I sign in as an admin
 # 	And a dataset has been entered with temporary DOI "000005"
-# 	And the uploaded dataset has status "AssigningFTPbox"
+# 	And the uploaded dataset has status "CuratorInitialReview"
 # 	And I am on "/site/admin"
 # 	And I have pressed "Assign Drop box to dataset 000005"
 # 	When I fill in "Author name" with "Terry Bone"
@@ -120,7 +120,7 @@ Scenario: Popup composer for customizing and sending email instructions
 # Scenario: Status is changed after the drop box is created and email sent
 # 	Given I sign in as an admin
 # 	And a dataset has been entered with temporary DOI "000005"
-# 	And the uploaded dataset has status "AssigningFTPbox"
+# 	And the uploaded dataset has status "CuratorInitialReview"
 # 	And the creation of a drop box to dataset "000005" has been initiated
 # 	When I wait "5" minutes
 # 	And I go to "/site/admin"
@@ -132,7 +132,7 @@ Scenario: Popup composer for customizing and sending email instructions
 # Scenario: The drop box access details and the author name and email saved in curation log comment
 # 	Given I sign in as an admin
 # 	And a dataset has been entered with temporary DOI "000005"
-# 	And the uploaded dataset has status "AssigningFTPbox"
+# 	And the uploaded dataset has status "CuratorInitialReview"
 # 	And the creation of a drop box to dataset "000005" has been initiated
 # 	And the status of the dataset has changed to "UserUploadingData"
 # 	When I go to "/adminDataset/admin"

--- a/fuw/app/common/tests/acceptance/file-upload-2-author-upload.feature
+++ b/fuw/app/common/tests/acceptance/file-upload-2-author-upload.feature
@@ -19,8 +19,8 @@ Scenario: Upload files button when dataset has appropriate status (UserUploading
 	And I should see a "Upload Files" link
 
 @ok
-Scenario: Upload files button when dataset has appropriate status (DataPending)
-	Given a dataset with DOI "000007" owned by user "Artie" "Dodger" has status "DataPending"
+Scenario: Upload files button when dataset has appropriate status (DataPreparation)
+	Given a dataset with DOI "000007" owned by user "Artie" "Dodger" has status "DataPreparation"
 	And I sign in as the user "Artie" "Dodger"
 	And I wait "2" seconds
 	When I go to "/user/view_profile#submitted"

--- a/fuw/app/common/tests/acceptance/file-upload-2-author-upload.feature
+++ b/fuw/app/common/tests/acceptance/file-upload-2-author-upload.feature
@@ -31,7 +31,7 @@ Scenario: Upload files button when dataset has appropriate status (DataPreparati
 @ok
 Scenario: No Upload files button when dataset hasn't got to the appropriate status yet
 	Given there is "user" "Chloe" "Decker"
-	And a dataset with DOI "100008" owned by user "Chloe" "Decker" has status "AssigningFTPbox"
+	And a dataset with DOI "100008" owned by user "Chloe" "Decker" has status "CuratorInitialReview"
 	And I sign in as the user "Chloe" "Decker"
 	And I wait "2" seconds
 	When I go to "/user/view_profile#submitted"

--- a/fuw/app/common/tests/acceptance/file-upload-3-author-meta-data-form.feature
+++ b/fuw/app/common/tests/acceptance/file-upload-3-author-meta-data-form.feature
@@ -66,7 +66,7 @@ Scenario: Saving metadata
 	When I press "Complete and return to Your Uploaded Datasets page"
 	Then I should be on "/user/view_profile#submitted"
 	And I should see "File uploading complete"
-	And I should see "DataAvailableForReview"
+	And I should see "UserProvidedData"
 
 @ok
 Scenario: Removing uploads
@@ -90,7 +90,7 @@ Scenario: Removing uploads
 	Then I should be on "/user/view_profile#submitted"
 	And I should see "File uploading complete"
 	And I should see "1 File(s) successfully deleted"
-	And I should see "DataAvailableForReview"
+	And I should see "UserProvidedData"
 
 
 @ok
@@ -147,7 +147,7 @@ Scenario: Initial MD5 checksum for upload files shows up as tooltip
 # 	Then I should see a "Save Files Metadata" inactive button
 # 	And I should see a "Complete and return to Your Uploaded Datasets page" inactive button
 
-# Scenario: Completion: status set to DataAvailableForReview, email sent to editors, author taken to Your Uploaded Dataset page
+# Scenario: Completion: status set to UserProvidedData, email sent to editors, author taken to Your Uploaded Dataset page
 # 	Given I sign in as a user
 # 	And I have uploaded a set of files to the drop box for dataset "000005"
 # 	And I am on "/uploader/meta"
@@ -155,7 +155,7 @@ Scenario: Initial MD5 checksum for upload files shows up as tooltip
 # 	And I press "Complete and return to Your Uploaded Datasets page"
 # 	Then the response should contain "Your Uploaded Datasets"
 # 	And the response sould contain "10.5524/000005"
-# 	And the response sould contain "DataAvailableForReview"
+# 	And the response sould contain "UserProvidedData"
 # 	And an email notification is sent to "editorial@gigasciencejournal.com"
 # 	And I should be on "/user/view_profile#submitted"
 

--- a/fuw/app/common/tests/acceptance/file-upload-4-author-meta-data-tagging.feature
+++ b/fuw/app/common/tests/acceptance/file-upload-4-author-meta-data-tagging.feature
@@ -111,7 +111,7 @@ Scenario: Saving file metadata with attributes and samples
 	And I should see "1 attribute(s) added for upload TheProof.csv"
 	And I should see "2 sample(s) added for upload CC0_pixel.jpg"
 	And I should not see "1 sample(s) added for upload TheProof.csv"
-	And I should see "DataAvailableForReview"
+	And I should see "UserProvidedData"
 
 # Scenario: there is a button to add attributes in the file metadata page when all mandatory fields are filled in
 # 	Given I sign in as a user

--- a/fuw/app/common/tests/acceptance/file-upload-4-curator-metadata-form.feature
+++ b/fuw/app/common/tests/acceptance/file-upload-4-curator-metadata-form.feature
@@ -1,6 +1,6 @@
 Feature:
 	As a Curator
-	I want the retrieve the context of a dataset status change to "DataAvailableForReview"
+	I want the retrieve the context of a dataset status change to "UserProvidedData"
 	So that I can audit or troubleshoot the dataset files and metadata upload process
 
 Background:
@@ -11,7 +11,7 @@ Background:
 	And filedrop account for DOI "000007" does exist
 
 @ok
-Scenario: after status is changed to DataAvailableForReview, add entry in curation log
+Scenario: after status is changed to UserProvidedData, add entry in curation log
 	Given I sign in as the user "Artie" "Dodger"
 	And The user "Artie" "Dodger" is registered as authorised user in the API
 	And I am on "/user/view_profile#submitted"
@@ -30,8 +30,8 @@ Scenario: after status is changed to DataAvailableForReview, add entry in curati
 	When I press "Complete and return to Your Uploaded Datasets page"
 	Then I should be on "/user/view_profile#submitted"
 	And I should see "File uploading complete"
-	And I should see "DataAvailableForReview"
+	And I should see "UserProvidedData"
 	Given I sign in as an admin
 	When I go to "/adminDataset/admin"
 	And I press "Update Dataset" for dataset "000007"
-	Then I should see "Status changed to DataAvailableForReview"
+	Then I should see "Status changed to UserProvidedData"

--- a/fuw/app/common/tests/acceptance/file-upload-4.5-curator-editorial-acceptance.feature
+++ b/fuw/app/common/tests/acceptance/file-upload-4.5-curator-editorial-acceptance.feature
@@ -8,7 +8,7 @@ Background:
 	Given there is "user" "Artie" "Dodger"
 	And there is "admin" "Ben" "Hur"
 	And The user "Ben" "Hur" is registered as authorised user in the API	
-	And a dataset with DOI "000007" owned by user "Artie" "Dodger" has status "DataAvailableForReview"
+	And a dataset with DOI "000007" owned by user "Artie" "Dodger" has status "UserProvidedData"
 	And filedrop account for DOI "000007" does exist
 
 @ok
@@ -22,12 +22,12 @@ Scenario: Editor set the status to "Rejected" causing a curation log entry
 	Then I should see "Status changed to Rejected"
 
 @ok
-Scenario: Editor set the status to "Submitted" causing a curation log entry and an email notification
+Scenario: Editor set the status to "DataAvailableForReview" causing a curation log entry and an email notification
 	Given I sign in as an admin
 	When I go to "/adminDataset/admin"
 	And I press "Update Dataset" for dataset "000007"
-	And change the status to "Submitted"
+	And change the status to "DataAvailableForReview"
 	And I go to "/adminDataset/admin"
 	And I press "Update Dataset" for dataset "000007"
-	Then I should see "Status changed to Submitted"
+	Then I should see "Status changed to DataAvailableForReview"
 	And An email is sent to "Curators"

--- a/fuw/app/common/tests/acceptance/file-upload-5-curator-share-drop-box-mockup-link.feature
+++ b/fuw/app/common/tests/acceptance/file-upload-5-curator-share-drop-box-mockup-link.feature
@@ -2,38 +2,38 @@
 Feature:
 	As a Curator
 	I want to create a private mockup of dataset linked to the privately uploaded files
-	So that I can share access to privately uploaded files of a submitted dataset with select curators
+	So that I can share access to privately uploaded files of a DataAvailableForReview dataset with select curators
 
 Background:
 	Given there is "user" "Artie" "Dodger"
 	And there is "admin" "Ben" "Hur"
 	And The user "Ben" "Hur" is registered as authorised user in the API	
-	And a dataset with DOI "000007" owned by user "Artie" "Dodger" has status "DataAvailableForReview"
+	And a dataset with DOI "000007" owned by user "Artie" "Dodger" has status "UserProvidedData"
 	And filedrop account for DOI "000007" does exist
 
 @ok
-Scenario: There is a button to generate mockup when status is Submitted
+Scenario: There is a button to generate mockup when status is DataAvailableForReview
 	Given I sign in as an admin
 	And I go to "/adminDataset/admin"
 	And I press "Update Dataset" for dataset "000007"
-	And change the status to "Submitted"
+	And change the status to "DataAvailableForReview"
 	When I go to "/adminDataset/admin"
 	And I press "Update Dataset" for dataset "000007"
 	Then I should see a "Generate mockup for reviewers" link
 
 @ok
-Scenario: There is not a button to generate mockup when status is not Submitted
+Scenario: There is not a button to generate mockup when status is not DataAvailableForReview
 	Given I sign in as an admin
 	When I go to "/adminDataset/admin"
 	And I press "Update Dataset" for dataset "000007"
 	Then I should not see a "Generate mockup for reviewers" link
 
 @ok
-Scenario: Generating a mockup when status is Submitted
+Scenario: Generating a mockup when status is DataAvailableForReview
 	Given I sign in as an admin
 	And I go to "/adminDataset/admin"
 	And I press "Update Dataset" for dataset "000007"
-	And change the status to "Submitted"
+	And change the status to "DataAvailableForReview"
 	When I go to "/adminDataset/admin"
 	And I press "Update Dataset" for dataset "000007"
 	And I press "Generate mockup for reviewers"

--- a/fuw/app/common/tests/acceptance/file-upload-6-reviewer-access-drop-box-files.feature
+++ b/fuw/app/common/tests/acceptance/file-upload-6-reviewer-access-drop-box-files.feature
@@ -6,7 +6,7 @@ Feature:
 
 Background:
 	Given there is "user" "Artie" "Dodger"
-	And a dataset with DOI "000007" owned by user "Artie" "Dodger" has status "Submitted"
+	And a dataset with DOI "000007" owned by user "Artie" "Dodger" has status "DataAvailableForReview"
 	And filedrop account for DOI "000007" does exist
 
 @ok

--- a/fuw/app/common/tests/acceptance/file-upload-6.5-curator-sanity-check.feature
+++ b/fuw/app/common/tests/acceptance/file-upload-6.5-curator-sanity-check.feature
@@ -8,19 +8,19 @@ Background:
 	Given there is "user" "Artie" "Dodger"
 	And there is "admin" "Ben" "Hur"
 	And The user "Ben" "Hur" is registered as authorised user in the API	
-	And a dataset with DOI "000007" owned by user "Artie" "Dodger" has status "Submitted"
+	And a dataset with DOI "000007" owned by user "Artie" "Dodger" has status "DataAvailableForReview"
 	And filedrop account for DOI "000007" does exist
 
 
 @ok
-Scenario: Curator set the status to "DataPending" if something is missing, causing a curation log entry, and email notification
+Scenario: Curator set the status to "DataPreparation" if something is missing, causing a curation log entry, and email notification
 	Given I sign in as an admin
 	When I go to "/adminDataset/admin"
 	And I press "Update Dataset" for dataset "000007"
-	And change the status to "DataPending"
+	And change the status to "DataPreparation"
 	And I go to "/adminDataset/admin"
 	And I press "Update Dataset" for dataset "000007"
-	Then I should see "Status changed to DataPending"
+	Then I should see "Status changed to DataPreparation"
 	And I am on "/adminDataset/admin"
 	And An email is sent to "artie_dodger@gigadb.org"
 

--- a/protected/commands/SmokeTestCommand.php
+++ b/protected/commands/SmokeTestCommand.php
@@ -30,7 +30,7 @@ values(999999,'gigadb-smoke-test-user@rijam.sent.as','5a4f75053077a32e681f81daa8
 		Yii::app()->db->createCommand($sql)->execute();
 
     	// Create a test dataset
-    	$sql = "insert into dataset(id, submitter_id, image_id, identifier, title, dataset_size, ftp_site, upload_status) values(999999,999999,999999, '000007','smoke test',342564,'ftp://','AssigningFTPbox')";
+    	$sql = "insert into dataset(id, submitter_id, image_id, identifier, title, dataset_size, ftp_site, upload_status) values(999999,999999,999999, '000007','smoke test',342564,'ftp://','CuratorInitialReview')";
     	Yii::app()->db->createCommand($sql)->execute();
 
     	return 0;
@@ -39,7 +39,7 @@ values(999999,'gigadb-smoke-test-user@rijam.sent.as','5a4f75053077a32e681f81daa8
 
 	public function actionResetData($args) {
 	    echo "Reset the test data".PHP_EOL;
-	    $sql = "update dataset set upload_status='AssigningFTPbox' where id=999999";
+	    $sql = "update dataset set upload_status='CuratorInitialReview' where id=999999";
         Yii::app()->db->createCommand($sql)->execute();
         $sql = "delete from file_attributes where file_id in (select id from file where dataset_id=999999)";
         Yii::app()->db->createCommand($sql)->execute();

--- a/protected/components/DatasetPageSettings.php
+++ b/protected/components/DatasetPageSettings.php
@@ -33,7 +33,7 @@ class DatasetPageSettings extends yii\base\BaseObject
         parent::__construct();
         $this->_dao = $dao;
         $this->_model = $model;
-        if ($this->_model && !$this->_model->isNewRecord && in_array($this->_model->upload_status, ["ImportFromEM","UserUploadingData","DataAvailableForReview", "DataPending", "Curation", "AuthorReview"])) {
+        if ($this->_model && !$this->_model->isNewRecord && in_array($this->_model->upload_status, ["ImportFromEM", "UserUploadingData", "UserProvidedData", "DataPreparation", "Curation", "AuthorReview"])) {
             $this->_pageType = "draft";
         } elseif (
             $this->_model && !$this->_model->isNewRecord && "Published" !== $this->_model->upload_status

--- a/protected/components/DatasetUpload.php
+++ b/protected/components/DatasetUpload.php
@@ -73,14 +73,14 @@ class DatasetUpload extends yii\base\BaseObject
     }
 
     /**
-     * method to set Dataset Upload status to DataAvailableForReview and notify reviewers
+     * method to set Dataset Upload status to UserProvidedData and notify reviewers
      *
      * @param string $content email content of notification
      * @return bool wether or not operation is successful
      */
-    public function setStatusToDataAvailableForReview(string $content): bool
+    public function setStatusToUserProvidedData(string $content): bool
     {
-        $statusChanged = $this->_datasetDAO->transitionStatus("UserUploadingData", "DataAvailableForReview") || $this->_datasetDAO->transitionStatus("DataPending", "DataAvailableForReview");
+        $statusChanged = $this->_datasetDAO->transitionStatus("UserUploadingData", "UserProvidedData") || $this->_datasetDAO->transitionStatus("DataPreparation", "UserProvidedData");
         if ($statusChanged) {
             $emailSent = $this->_fileUploadSrv->emailSend(
                 $this->_config["sender"],
@@ -88,7 +88,7 @@ class DatasetUpload extends yii\base\BaseObject
                 "Data available for review",
                 $content
             );
-            CurationLog::createlog("DataAvailableForReview", $this->_datasetDAO->getId());
+            CurationLog::createlog("UserProvidedData", $this->_datasetDAO->getId());
             return $statusChanged && $emailSent;
         }
         return false;
@@ -101,9 +101,9 @@ class DatasetUpload extends yii\base\BaseObject
      *
      * @return bool whether operation is successful
      */
-    public function setStatusToSubmitted(string $previousStatus = null): bool
+    public function setStatusToDataAvailableForReview(string $previousStatus = null): bool
     {
-        return $this->_datasetDAO->transitionStatus("DataAvailableForReview", "Submitted", null, $previousStatus);
+        return $this->_datasetDAO->transitionStatus("UserProvidedData", "DataAvailableForReview", null, $previousStatus);
     }
 
     /**
@@ -113,9 +113,9 @@ class DatasetUpload extends yii\base\BaseObject
      *
      * @return bool whether operation is successful
      */
-    public function setStatusToDataPending(string $previousStatus = null): bool
+    public function setStatusToDataPreparation(string $previousStatus = null): bool
     {
-        return $this->_datasetDAO->transitionStatus("Submitted", "DataPending", null, $previousStatus);
+        return $this->_datasetDAO->transitionStatus("DataAvailableForReview", "DataPreparation", null, $previousStatus);
     }
 
     public function sendNotificationEmailBody(string $content, string $uploadStatus, string $authorEmail = null): bool

--- a/protected/components/FiledropService.php
+++ b/protected/components/FiledropService.php
@@ -79,8 +79,8 @@ class FiledropService extends yii\base\Component
         }
         // 'postID=:postID', array(':postID'=>10)
         $dataset = Dataset::model()->find('identifier=:doi', [":doi" => $this->identifier]) ;
-        if (!isset($dataset) || "AssigningFTPbox" !== $dataset->upload_status) {
-            Yii::log("Upload status required for DOI {$this->identifier}: AssigningFTPbox", "error");
+        if (!isset($dataset) || "CuratorInitialReview" !== $dataset->upload_status) {
+            Yii::log("Upload status required for DOI {$this->identifier}: CuratorInitialReview", "error");
             Yii::log("Gotten: {$dataset->upload_status}", "error");
             return null;
         }
@@ -98,7 +98,7 @@ class FiledropService extends yii\base\Component
                                     'connect_timeout' => 5,
                                 ]);
             if (201 === $response->getStatusCode()) {
-                $this->dataset->transitionStatus("AssigningFTPbox", "UserUploadingData", $this->instructions);
+                $this->dataset->transitionStatus("CuratorInitialReview", "UserUploadingData", $this->instructions);
                 return json_decode($response->getBody(), true);
             }
         } catch (RequestException $e) {

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -573,11 +573,11 @@ class AdminDatasetController extends Controller
     private function checkAndSetTransition(DatasetUpload $datasetUpload, Dataset $model, string $newStatus): bool
     {
         switch ($newStatus) {
-            case 'Submitted':
-                return $datasetUpload->setStatusToSubmitted($model->upload_status);
+            case 'DataAvailableForReview':
+                return $datasetUpload->setStatusToDataAvailableForReview($model->upload_status);
 
-            case 'DataPending':
-                return $datasetUpload->setStatusToDataPending($model->upload_status);
+            case 'DataPreparation':
+                return $datasetUpload->setStatusToDataPreparation($model->upload_status);
 
             default:
                 return true;

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -255,7 +255,14 @@ class AdminDatasetController extends Controller
 
             if ($uploadStatus && $uploadStatus !== $previousUploadStatus) {
                 Yii::log('Status changed to '.$uploadStatus, 'info');
-                $this->renderNotificationsAccordingToStatus($datasetUpload, $model);
+                $user = User::model()->findByPk(Yii::app()->user->id);
+
+                if (!$user) {
+                    throw new CHttpException(404, 'User not found.');
+                }
+
+                $userName = sprintf('%s %s', $user->first_name, $user->last_name);
+                $this->renderNotificationsAccordingToStatus($datasetUpload, $model, $previousUploadStatus, $userName);
             }
 
             // semantic keywords update, using remove all and re-create approach
@@ -584,8 +591,12 @@ class AdminDatasetController extends Controller
         }
     }
 
-    private function renderNotificationsAccordingToStatus(DatasetUpload $datasetUpload, Dataset $model)
-    {
+    private function renderNotificationsAccordingToStatus(
+        DatasetUpload $datasetUpload,
+        Dataset $model,
+        string $previousUplaodStatus,
+        string $user
+    ) {
         switch ($model->upload_status) {
             case 'Submitted':
                 $contentToSend = $datasetUpload->renderNotificationEmailBody('Submitted');
@@ -608,7 +619,12 @@ class AdminDatasetController extends Controller
         }
 
         if ($statusIsSet) {
-            CurationLog::createlog($model->upload_status, $model->id);
+            CurationLog::createGeneralCurationLogEntry(
+                $model->id,
+                sprintf('Status changed from %s to %s ', $previousUplaodStatus, $model->upload_status),
+                null,
+                $user
+            );
         }
     }
 

--- a/protected/controllers/AuthorisedDatasetController.php
+++ b/protected/controllers/AuthorisedDatasetController.php
@@ -48,7 +48,7 @@ class AuthorisedDatasetController extends Controller
     {
         $doi = $filterChain->controller->getActionParams()['id'] ?? false ;
         $dataset = Dataset::model()->findByAttributes(["identifier" => $doi]) ?? false ;
-        if ($dataset && in_array($dataset->upload_status, ['UserUploadingData','DataPending'])) {
+        if ($dataset && in_array($dataset->upload_status, ['UserUploadingData', 'DataPreparation'])) {
             $filterChain->run(); // continue with executing further filters and the action
         }
         else {

--- a/protected/controllers/authorisedDataset/FilesAnnotateAction.php
+++ b/protected/controllers/authorisedDataset/FilesAnnotateAction.php
@@ -121,9 +121,9 @@ class FilesAnnotateAction extends CAction
 
         if (Yii::$app->request->isPost && $allUploadsSaved && $allAttributesSaved) {
 
-                $statusChangedAndNotified = $datasetUpload->setStatusToDataAvailableForReview(
+                $statusChangedAndNotified = $datasetUpload->setStatusToUserProvidedData(
                     $datasetUpload->renderNotificationEmailBody(
-                        "DataAvailableForReview"
+                        "UserProvidedData"
                     )
                 );
                 if($statusChangedAndNotified) {

--- a/protected/migrations/fix_nomenclature/m240805_014722_upload_status_update.php
+++ b/protected/migrations/fix_nomenclature/m240805_014722_upload_status_update.php
@@ -1,0 +1,18 @@
+<?php
+
+class m240805_014722_upload_statusUpdate extends CDbMigration
+{
+	public function safeUp()
+	{
+        $this->update('dataset', array('upload_status' => 'DataPreparation'), "upload_status = 'DataPending'");
+        $this->update('dataset', array('upload_status' => 'UserProvidedData'), "upload_status = 'DataAvailableForReview'");
+        $this->update('dataset', array('upload_status' => 'DataAvailableForReview'), "upload_status = 'Submitted'");
+	}
+
+	public function safeDown()
+	{
+        $this->update('dataset', array('upload_status' => 'DataPending'), "upload_status = 'DataPreparation'");
+        $this->update('dataset', array('upload_status' => 'DataAvailableForReview'), "upload_status = 'UserProvidedData'");
+        $this->update('dataset', array('upload_status' => 'Submitted'), "upload_status = 'DataAvailableForReview'");
+	}
+}

--- a/protected/migrations/fix_nomenclature/m240805_014722_upload_status_update.php
+++ b/protected/migrations/fix_nomenclature/m240805_014722_upload_status_update.php
@@ -7,6 +7,7 @@ class m240805_014722_upload_statusUpdate extends CDbMigration
         $this->update('dataset', array('upload_status' => 'DataPreparation'), "upload_status = 'DataPending'");
         $this->update('dataset', array('upload_status' => 'UserProvidedData'), "upload_status = 'DataAvailableForReview'");
         $this->update('dataset', array('upload_status' => 'DataAvailableForReview'), "upload_status = 'Submitted'");
+        $this->update('dataset', array('upload_status' => 'CuratorInitialReview'), "upload_status = 'AssigningFTPbox'");
 	}
 
 	public function safeDown()
@@ -14,5 +15,6 @@ class m240805_014722_upload_statusUpdate extends CDbMigration
         $this->update('dataset', array('upload_status' => 'DataPending'), "upload_status = 'DataPreparation'");
         $this->update('dataset', array('upload_status' => 'DataAvailableForReview'), "upload_status = 'UserProvidedData'");
         $this->update('dataset', array('upload_status' => 'Submitted'), "upload_status = 'DataAvailableForReview'");
+        $this->update('dataset', array('upload_status' => 'AssigningFTPbox'), "upload_status = 'CuratorInitialReview'");
 	}
 }

--- a/protected/models/CurationLog.php
+++ b/protected/models/CurationLog.php
@@ -141,11 +141,13 @@ class CurationLog extends CActiveRecord
         return $curationlog->save();
     }
 
-    public static function createGeneralCurationLogEntry(int $id, string $action, string $content, $author = 'system'): bool
+    public static function createGeneralCurationLogEntry(int $id, string $action, string $content = null, $author = 'system'): bool
     {
         $curationLog = self::makeNewInstanceForCurationLogBy($id, $author);
         $curationLog->action = $action;
-        $curationLog->comments = $content;
+        if ($content) {
+            $curationLog->comments = $content;
+        }
 
         return $curationLog->save();
     }

--- a/protected/models/Dataset.php
+++ b/protected/models/Dataset.php
@@ -29,22 +29,22 @@ class Dataset extends CActiveRecord
     public $types;
 
     public const ORIGINAL_UPLOAD_STATUS_LIST = [
-        'ImportFromEM'=>'ImportFromEM',
-        'UserStartedIncomplete'=>'UserStartedIncomplete',
-        'Rejected'=>'Rejected',
-        'Not required'=>'Not required',
-        'Submitted'=>'Submitted',
-        'Curation'=>'Curation',
-        'AuthorReview'=>'AuthorReview',
-        'Private'=>'Private',
-        'Published' =>'Published',
+        'ImportFromEM'           => 'ImportFromEM',
+        'UserStartedIncomplete'  => 'UserStartedIncomplete',
+        'Rejected'               => 'Rejected',
+        'Not required'           => 'Not required',
+        'DataAvailableForReview' => 'DataAvailableForReview',
+        'Curation'               => 'Curation',
+        'AuthorReview'           => 'AuthorReview',
+        'Private'                => 'Private',
+        'Published'              => 'Published',
     ];
 
     public const FUW_UPLOAD_STATUS_LIST = [
-        'AssigningFTPbox'=>'AssigningFTPbox',
-        'UserUploadingData'=>'UserUploadingData',
-        'DataAvailableForReview'=>'DataAvailableForReview',
-        'DataPending'=>'DataPending',
+        'AssigningFTPbox'        => 'AssigningFTPbox',
+        'UserUploadingData'      => 'UserUploadingData',
+        'UserProvidedData'       => 'UserProvidedData',
+        'DataPreparation'        => 'DataPreparation',
     ];
 
     /*

--- a/protected/models/Dataset.php
+++ b/protected/models/Dataset.php
@@ -41,7 +41,7 @@ class Dataset extends CActiveRecord
     ];
 
     public const FUW_UPLOAD_STATUS_LIST = [
-        'AssigningFTPbox'        => 'AssigningFTPbox',
+        'CuratorInitialReview'   => 'CuratorInitialReview',
         'UserUploadingData'      => 'UserUploadingData',
         'UserProvidedData'       => 'UserProvidedData',
         'DataPreparation'        => 'DataPreparation',

--- a/protected/tests/functional/AdminDatasetAssignFTPBoxActionTest.php
+++ b/protected/tests/functional/AdminDatasetAssignFTPBoxActionTest.php
@@ -42,7 +42,7 @@ class AdminDatasetAssignFTPBoxActionTest extends FunctionalTesting
         try {
             $this->setUpUsers($this->dbh_gigadb, "Erin","Dot","admin","erin_dot@gigadb.org");
             $this->setUpUserIdentity($this->dbh_fuw, "erin_dot@gigadb.org");
-            $this->setUpDatasetUploadStatus($this->dbh_gigadb, "100005","AssigningFTPbox");
+            $this->setUpDatasetUploadStatus($this->dbh_gigadb, "100005","CuratorInitialReview");
             $this->changeUserRole($this->dbh_gigadb, "user","admin@gigadb.org");
             $this->url = "http://gigadb.dev/adminDataset/assignFTPBox/id/100005" ;
         }

--- a/protected/tests/functional/AdminDatasetUpdateActionTest.php
+++ b/protected/tests/functional/AdminDatasetUpdateActionTest.php
@@ -70,7 +70,7 @@ class AdminDatasetUpdateActionTest extends FunctionalTesting
         $testDOI = "100142";
         $curationEntry = "Status changed to Rejected";
         // set upload status to the  UserUploadingData
-        $this->setUpDatasetUploadStatus($this->dbh_gigadb, "$testDOI","DataAvailableForReview");
+        $this->setUpDatasetUploadStatus($this->dbh_gigadb, "$testDOI", "UserProvidedData");
         // ensure there is a filedrop_account
         $filedropAccountId = $this->makeFiledropAccountRecord($this->dbh_fuw,"$testDOI", $curationEntry);
         //admin user logs in
@@ -88,12 +88,12 @@ class AdminDatasetUpdateActionTest extends FunctionalTesting
 
     }
 
-    public function testSetUploadToSubmitted() {
+    public function testSetUploadToDataAvailableForReview() {
 
         $testDOI = "100142";
-        $curationEntry = "Status changed to Submitted";
+        $curationEntry = "Status changed to DataAvailableForReview";
         // set upload status to the  UserUploadingData
-        $this->setUpDatasetUploadStatus($this->dbh_gigadb, "$testDOI","DataAvailableForReview");
+        $this->setUpDatasetUploadStatus($this->dbh_gigadb, "$testDOI","UserProvidedData");
         // ensure there is a filedrop_account
         $filedropAccountId = $this->makeFiledropAccountRecord($this->dbh_fuw,"$testDOI", $curationEntry);
         //admin user logs in
@@ -103,12 +103,10 @@ class AdminDatasetUpdateActionTest extends FunctionalTesting
             "Admin");
         
         $this->session->visit($this->url);
-        $this->session->getPage()->selectFieldOption("Dataset_upload_status", "Submitted");
+        $this->session->getPage()->selectFieldOption("Dataset_upload_status", "DataAvailableForReview");
         $this->session->getPage()->pressButton("Save");
         $this->session->visit($this->url);
         $this->assertTrue($this->session->getPage()->hasContent($curationEntry));
-        
-
     }
 }
 

--- a/protected/tests/functional/FiledropServiceTest.php
+++ b/protected/tests/functional/FiledropServiceTest.php
@@ -116,7 +116,7 @@ class FiledropServiceTest extends FunctionalTesting
             ]);
 
         // set the right status on the dataset
-        Dataset::model()->updateAll(["upload_status" => "AssigningFTPbox"], "identifier = :doi", [":doi" => $this->doi]);
+        Dataset::model()->updateAll(["upload_status" => "CuratorInitialReview"], "identifier = :doi", [":doi" => $this->doi]);
 
         // invoke the Filedrop Service
         $response = $filedropSrv->createAccount();
@@ -180,7 +180,7 @@ class FiledropServiceTest extends FunctionalTesting
             ]);
 
         // set the right status on the dataset
-        Dataset::model()->updateAll(["upload_status" => "AssigningFTPbox"], "identifier = :doi", [":doi" => $this->doi]);
+        Dataset::model()->updateAll(["upload_status" => "CuratorInitialReview"], "identifier = :doi", [":doi" => $this->doi]);
 
         // invoke the Filedrop Service
         $response = $filedropSrv->createAccount();

--- a/protected/tests/unit/DatasetDAOTest.php
+++ b/protected/tests/unit/DatasetDAOTest.php
@@ -92,15 +92,15 @@ class DatasetDAOTest extends CDbTestCase {
         $datasetDAO = new DatasetDAO();
 
         $datasetDAO->setIdentifier('100243');
-        $success = $datasetDAO->transitionStatus('Published', 'AssigningFTPbox', 'foobar');
+        $success = $datasetDAO->transitionStatus('Published', 'CuratorInitialReview', 'foobar');
 
         $datasetDAO->setIdentifier('100249');
-        $failure = $datasetDAO->transitionStatus('Pending', 'AssigningFTPBox', 'foobar');
+        $failure = $datasetDAO->transitionStatus('Pending', 'CuratorInitialReview', 'foobar');
 
         $this->assertTrue($success);
         $this->assertFalse($failure);
         $changedDataset = Dataset::model()->findByAttributes(['identifier' => '100243']);
-        $this->assertEquals('AssigningFTPbox', $changedDataset->upload_status);
+        $this->assertEquals('CuratorInitialReview', $changedDataset->upload_status);
 
     }
 

--- a/protected/tests/unit/DatasetPageSettingsTest.php
+++ b/protected/tests/unit/DatasetPageSettingsTest.php
@@ -54,7 +54,7 @@ class DatasetPageSettingsTest extends CDbTestCase
 	public function testGetPageTypeDraft()
 	{
 		$model = Dataset::model()->findByPk(1);
-		$model->upload_status = "DataPending";
+		$model->upload_status = "DataPreparation";
 		$sut = new DatasetPageSettings($model);
 
 		$pageType = $sut->getPageType();

--- a/protected/tests/unit/DatasetUploadTest.php
+++ b/protected/tests/unit/DatasetUploadTest.php
@@ -15,7 +15,7 @@ class DatasetUploadTest extends CDbTestCase
         'datasets'=>'Dataset',
     );
 
-	public function testSetStatusToDataAvailableForReview()
+	public function testSetStatusToUserProvidedData()
 	{
 		$config = [
 			"sender" => "admin@gigadb.org",
@@ -30,7 +30,7 @@ class DatasetUploadTest extends CDbTestCase
 
         $mockDatasetDAO->expects($this->once())
                  ->method('transitionStatus')
-                 ->with("UserUploadingData", "DataAvailableForReview")
+                 ->with("UserUploadingData", "UserProvidedData")
                  ->willReturn(true);
 
         $mockDatasetDAO->expects($this->once())
@@ -50,11 +50,11 @@ class DatasetUploadTest extends CDbTestCase
 
 		$datasetFileUpload = new DatasetUpload($mockDatasetDAO, $mockFileUploadSrv, $config);
 		$nbItemsInCurationLog = CurationLog::Model()->count();
-		$result = $datasetFileUpload->setStatusToDataAvailableForReview($content);
+		$result = $datasetFileUpload->setStatusToUserProvidedData($content);
 		$this->assertEquals($nbItemsInCurationLog+1, CurationLog::Model()->count());
 	}
 
-	public function testSetStatusToSubmitted()
+	public function testSetStatusToDataAvailableForReview()
 	{
 		$config = [
 			"sender" => "admin@gigadb.org",
@@ -69,13 +69,13 @@ class DatasetUploadTest extends CDbTestCase
 
         $mockDatasetDAO->expects($this->once())
                  ->method('transitionStatus')
-                 ->with("DataAvailableForReview", "Submitted")
-                 ->willReturn(true);
+                 ->with("UserProvidedData", "DataAvailableForReview")
+                 ->willReturn(true);    
 
 
 		$datasetFileUpload = new DatasetUpload($mockDatasetDAO, $mockFileUploadSrv, $config);
 		$nbItemsInCurationLog = CurationLog::Model()->count();
-		$result = $datasetFileUpload->setStatusToSubmitted($content);
+		$result = $datasetFileUpload->setStatusToDataAvailableForReview($content);
 		$this->assertTrue($result);
 	}
 
@@ -95,7 +95,7 @@ class DatasetUploadTest extends CDbTestCase
                  ->willReturn("003000");
 
 		$datasetFileUpload = new DatasetUpload($mockDatasetDAO, $mockFileUploadSrv, $config);
-		$renderedContent = $datasetFileUpload->renderNotificationEmailBody("DataAvailableForReview");
+		$renderedContent = $datasetFileUpload->renderNotificationEmailBody("UserProvidedData");
 		$this->assertTrue(1 == preg_match('/dataset with DOI 003000/', $renderedContent));
 	}
 

--- a/protected/views/adminDataset/_form.php
+++ b/protected/views/adminDataset/_form.php
@@ -919,11 +919,11 @@ echo $form->hiddenField($model, "image_id");
 -->
 
 <script>
-    let defaultDataPendingEmailBody = '';
+    let defaultDataPreparationEmailBody = '';
 
     async function fetchEmailTemplate() {
         try {
-            const res = await fetch('/files/templates/DataPending.twig')
+            const res = await fetch('/files/templates/DataPreparation.twig')
             if (res.ok) {
                 return res.text();
             }
@@ -935,9 +935,9 @@ echo $form->hiddenField($model, "image_id");
     }
 
     $(document).ready(async function () {
-        defaultDataPendingEmailBody = await fetchEmailTemplate()
-        if (defaultDataPendingEmailBody) {
-            $("#Dataset_emailBody").val(defaultDataPendingEmailBody);
+        defaultDataPreparationEmailBody = await fetchEmailTemplate()
+        if (defaultDataPreparationEmailBody) {
+            $("#Dataset_emailBody").val(defaultDataPreparationEmailBody);
         }
     })
 
@@ -948,12 +948,12 @@ echo $form->hiddenField($model, "image_id");
             const initialUploadStatus = uploadStatusInput.attr('data-initial-value');
             const currentUploadStatus = uploadStatusInput.val();
             const submitSourceId = $(':focus').attr('id');
-            const didSelectDataPending = initialUploadStatus !== currentUploadStatus && currentUploadStatus === 'DataPending';
+            const didSelectDataPreparation = initialUploadStatus !== currentUploadStatus && currentUploadStatus === 'DataPreparation';
             const didSubmitFromModal = submitSourceId === 'customizeEmailModalSubmitBtn' ||
                 // NOTE need to include this case for Safari compatibility
                 submitSourceId === 'customizeEmailModal';
 
-            if (didSelectDataPending && !didSubmitFromModal) {
+            if (didSelectDataPreparation && !didSubmitFromModal) {
                 $('#customizeEmailModal').modal({
                     backdrop: 'static',
                     keyboard: false,
@@ -964,7 +964,7 @@ echo $form->hiddenField($model, "image_id");
     })
 
     function setDefaultEmailBody() {
-        $("#Dataset_emailBody").val(defaultDataPendingEmailBody);
+        $("#Dataset_emailBody").val(defaultDataPreparationEmailBody);
     }
 
 </script>

--- a/protected/views/adminDataset/admin.php
+++ b/protected/views/adminDataset/admin.php
@@ -148,7 +148,7 @@ $('.search-form form').submit(function(){
 						'imageUrl' => false,
 						'url' => 'Yii::app()->createUrl("adminDataset/assignFTPBox" , array("id" => $data->identifier))',
 						'label' => '',
-						'visible' => '"AssigningFTPbox" === $data->upload_status',
+						'visible' => '"CuratorInitialReview" === $data->upload_status',
 						'options' => array(
 							'title' => 'New Dropbox for this dataset',
 							"class" => "fa fa-inbox fa-lg icon icon-dropbox",

--- a/protected/views/user/uploadedDatasets.php
+++ b/protected/views/user/uploadedDatasets.php
@@ -91,7 +91,7 @@
                                                     <a class="update btn btn-transparent tooltip-trigger" data-toggle="tooltip" title="Update the metadata of the dataset" href=<? echo "/datasetSubmission/datasetManagement/id/" . $data[$i]->id ?>>Update<br />dataset</a>
                                                     <button class="js-delete-dataset btn btn-transparent" data-toggle="tooltip" title="Delete the dataset and all its files" did="<?=$data[$i]->id?>">
                                             Delete<br />dataset</button>
-                                                    <?php if ($data[$i]->upload_status === "UserUploadingData" || $data[$i]->upload_status === "DataPending") {
+                                                    <?php if ($data[$i]->upload_status === "UserUploadingData" || $data[$i]->upload_status === "DataPreparation") {
                                                     ?>
                                                     <a class="upload btn btn-transparent" href="/authorisedDataset/uploadFiles/id/<?php echo $data[$i]->identifier; ?>" data-toggle="tooltip" title="Upload files to the dataset, delete the existing files or edit their metadata">Upload<br />Files</a>
                                                     <?php

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -644,3 +644,11 @@ Feature: form to update dataset details
     And I am on "/adminDataset/update/id/5"
     Then I can see the option "Published" selected for "Dataset_upload_status"
     And I should see "Status changed to Published"
+
+  @ok
+  Scenario: Check curation log is created after updating the upload status
+    Given I am on "/adminDataset/update/id/5"
+    And I select "AuthorReview" from the field "Dataset_upload_status"
+    And I press the button "Save"
+    And I am on "/adminDataset/update/id/5"
+    Then I should see "Status changed from Incomplete to AuthorReview"

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -432,14 +432,15 @@ Feature: form to update dataset details
       | "UserStartedIncomplete"  |
       | "Rejected"               |
       | "Not required"           |
-      | "Submitted"              |
+      | "DataAvailableForReview" |
       | "Curation"               |
       | "AuthorReview"           |
       | "Private"                |
       | "AssigningFTPbox"        |
       | "UserUploadingData"      |
       | "DataAvailableForReview" |
-      | "DataPending"            |
+      | "UserProvidedData"       |
+      | "DataPreparation"        |
 
   @ok @dataset-status
   Scenario: Check dataset page with Curation status can be viewed using private URL
@@ -509,7 +510,8 @@ Feature: form to update dataset details
       | "AssigningFTPbox"        |
       | "UserUploadingData"      |
       | "DataAvailableForReview" |
-      | "DataPending"            |
+      | "UserProvidedData"       |
+      | "DataPreparation"        |
 
   @ok
   Scenario: Links to create mockup is present for a submitted dataset

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -436,7 +436,7 @@ Feature: form to update dataset details
       | "Curation"               |
       | "AuthorReview"           |
       | "Private"                |
-      | "AssigningFTPbox"        |
+      | "CuratorInitialReview"        |
       | "UserUploadingData"      |
       | "DataAvailableForReview" |
       | "UserProvidedData"       |
@@ -507,7 +507,7 @@ Feature: form to update dataset details
       | "Curation"               |
       | "AuthorReview"           |
       | "Private"                |
-      | "AssigningFTPbox"        |
+      | "CuratorInitialReview"   |
       | "UserUploadingData"      |
       | "DataAvailableForReview" |
       | "UserProvidedData"       |


### PR DESCRIPTION
# Pull request for issue: #1616

## How to test?

Add a curation log entry when updating upload_status
New nomenclature for upload_status - AssigningFTPbox should be replaced by CuratorInitialReview
New nomenclature for upload_status - Provided Data should be used when Data AvailableForReview is used
New nomenclature for upload_status - Submitted should be replaced by DataAvailableForReview
 New nomenclature for upload_status - Submitted should be replaced by DataAvailableForReview
New nomenclature for upload_status - dataPending should be replaced by dataPreparation

## How have functionalities been implemented?

## Any issues with implementation?

## Any changes to automated tests?

tests updated

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?