### PR TITLE
Feat 1533 form submission buttons appearance and behaviour to adapt to a dataset being public or private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #1533: Make dataset-admin form submission buttons appearance and behaviour to adapt to a dataset being public or private
+
 ## v4.4.16 - 2025-08-15 - 6e04c0b9e -
 
 - Fix #2428: AdminUserController should target AdminUserController when validating or rejecting a claim

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -140,8 +140,8 @@ class AdminDatasetController extends Controller
                     }
 
                     Yii::app()->user->setFlash('saveSuccess', 'saveSuccess');
-                    if ($dataset->upload_status=='AuthorReview') {
-                        $this->redirect('/adminDataset/private/identifier/'.$dataset->identifier);
+                    if ($dataset->upload_status==='AuthorReview') {
+                        $this->private($dataset);
                     }
                     $this->redirect(array('/dataset/'.$dataset->identifier));
                 }
@@ -186,8 +186,11 @@ class AdminDatasetController extends Controller
      * If update is successful, the browser will be redirected to the 'view' page.
      * @param integer $id the ID of the model to be updated
      */
-    public function actionUpdate($id)
+    public function actionUpdate(int $id)
     {
+        $isCreateOrResetPrivateUrl = Yii::$app->request->post('createReset');
+        $isOpenUrl = Yii::$app->request->post('openUrl');
+
         $hasPartialError = false;
         $model = $this->loadModel($id);
         $datasetPageSettings = new DatasetPageSettings($model);
@@ -285,18 +288,17 @@ class AdminDatasetController extends Controller
                  $this->redirect(array('/adminDataset/update/id/' . $model->id));
             }
 
-            Yii::app()->user->setFlash('updateSuccess', 'Updated successfully!');
-            switch ($datasetPageSettings->getPageType()) {
-                case "draft":
-                    $this->redirect('/adminDataset/admin/');
-                    break;
-                case "public":
-                    $this->redirect('/dataset/' . $model->identifier);
-                    break;
-                case "hidden":
-                    $this->redirect(array('/adminDataset/update/id/' . $model->id));
-                    break;
+            if ($isOpenUrl) {
+                return $this->redirect('/dataset/'.$model->identifier.'/token/'.$model->token);
             }
+            if ($isCreateOrResetPrivateUrl) {
+                return $this->private($model);
+            }
+            if ($model->getIsPublic()) {
+                return $this->redirect('/dataset/' . $model->identifier);
+            }
+            Yii::app()->user->setFlash('updateSuccess', 'Updated successfully!');
+            return $this->redirect(array('/adminDataset/update/id/' . $model->id));
 
         } else {
             Yii::app()->user->setFlash('updateError', 'Fail to update!');
@@ -305,6 +307,7 @@ class AdminDatasetController extends Controller
 
         $this->loadBaBbqPolyfills = true;
         $this->registerTooltipScript();
+
         $this->render('update', array(
             'model' => $model,
             'datasetPageSettings' => $datasetPageSettings,
@@ -313,35 +316,31 @@ class AdminDatasetController extends Controller
         ));
     }
 
-
     /**
      * One-off access to a private dataset
      *
      */
-    public function actionPrivate()
+    private function private(Dataset $model)
     {
-        $id = Yii::$app->request->get('identifier');
-        $model= Dataset::model()->find("identifier=?", array($id));
         $datasetPageSettings = new DatasetPageSettings($model);
         $pageType = $datasetPageSettings->getPageType();
 
         if (!in_array($pageType, ['invalid', 'public', 'hidden', 'draft', 'mockup'])) {
             throw new CHttpException(404, 'Page type not found');
         }
-
         if ("invalid" === $pageType) {
-            $this->redirect('/site/index');
-        } elseif ("public" === $pageType) {
-            $this->redirect('/dataset/'.$model->identifier);
-        } else {
-            $model->token = Yii::$app->security->generateRandomString(16);
-
-            if (!$model->save()) {
-                throw new CHttpException(500, 'Fail to update dataset token');
-            }
-
-            $this->redirect('/dataset/'.$model->identifier.'/token/'.$model->token);
+            return $this->redirect('/site/index');
         }
+        if ("public" === $pageType) {
+            return $this->redirect('/dataset/'.$model->identifier);
+        }
+        $model->token = Yii::$app->security->generateRandomString(16);
+        if (!$model->save()) {
+            throw new CHttpException(500, 'Fail to update dataset token');
+        }
+
+        return $this->redirect('/dataset/'.$model->identifier.'/token/'.$model->token);
+
     }
 
 

--- a/protected/models/Dataset.php
+++ b/protected/models/Dataset.php
@@ -412,7 +412,7 @@ class Dataset extends CActiveRecord
     }
 
     public function getIsPublic() {
-        return $this->upload_status == "Published";
+        return $this->upload_status === "Published";
     }
 
     public function getAllSamples() {

--- a/protected/views/adminDataset/_form.php
+++ b/protected/views/adminDataset/_form.php
@@ -536,37 +536,53 @@ echo $form->hiddenField($model, "image_id");
 
 <div class="col-xs-12 form-control-btns">
     <?php
-      $showCreateResetUrlBtn = in_array($datasetPageSettings->getPageType(), ["hidden", "draft", "mockup"]);
-
-    $showOpenPrivateUrlBtn = $showCreateResetUrlBtn && $model->token;
-
-      $showMockupBtn = Yii::app()->featureFlag->isEnabled("fuw") && "mockup" === $datasetPageSettings->getPageType();
-
-    if ($showCreateResetUrlBtn) {
-        ?>
-        <a id="mockup" class="btn background-btn-o" href="<?php echo Yii::app()->createUrl('/adminDataset/private/identifier/' . $model->identifier) ?>" title="This will save any changes made on this page AND create a new mockup page URL/token link" data-toggle="tooltip">Create/Reset Private URL</a>
-        <?php
+        $isNotPublic = in_array($datasetPageSettings->getPageType(), ["hidden", "draft", "mockup", "invalid"]);
+        $showMockupBtn = Yii::app()->featureFlag->isEnabled("fuw") && "mockup" === $datasetPageSettings->getPageType();
+        $text = $model->isNewRecord ? 'Create' : 'Save Changes';
+    if ($isNotPublic && $model->token) {
+        $text .= ' And Reset Private URL';
+    } elseif ($isNotPublic && !$model->token) {
+        $text .= ' And Create Private URL';
     }
-    if ($showMockupBtn) {
+
+    if ($isNotPublic) {
+        echo CHtml::submitButton(
+            $text,
+            array('name' => 'createReset', 'class' => 'btn background-btn submit-btn', 'title' => 'This will Save any changes made on this page and open the mockup view of the dataset page', 'data-toggle' => 'tooltip')
+        );
+    }
+      if ($showMockupBtn) {
         echo CHtml::link('Generate mockup for reviewers', '#', array(
-            'class'       => 'btn background-btn',
+          'class' => 'btn background-btn',
           'data-toggle' => "modal", 'data-target' => "#mockupCreation"
         ));
     }
     ?>
-    <a class="btn background-btn-o" href="<?= Yii::app()->createUrl('/adminDataset/admin') ?>"
-       title="Cancel any changes not saved on this page and return to the list of datasets" data-toggle="tooltip">Cancel
-        and go back</a>
-    <?php echo CHtml::submitButton(
-        $model->isNewRecord ? 'Create' : 'Save',
-        array('class' => 'btn background-btn submit-btn', 'id' => 'datasetFormSaveButton', 'title' => 'Save any changes made on this page and stay on this page', 'data-toggle' => 'tooltip')
-    );
-    if ($showOpenPrivateUrlBtn) {
+    <a class="btn background-btn-o" href="<?= Yii::app()->createUrl('/adminDataset/admin') ?>" title="Cancel any changes not saved on this page and return to the list of datasets" data-toggle="tooltip">Cancel Changes</a>
+    <?php
+
+    if (!$isNotPublic) {
         ?>
-        <a class="btn background-btn-o" href="<?php echo Yii::app()->createUrl('/dataset/' . $model->identifier . '/token/' . $model->token) ?>" title="This will Save any changes made on this page and open the mockup view of the dataset page" data-toggle="tooltip">Open Private URL</a>
-        <?php
+        <button id='datasetFormSaveButtonForPublished' class='btn background-btn' type = 'button' >
+            Save Changes And Open DOI
+        </button >
+    <?php
     }
-    ?>
+
+    if ($model->isNewRecord || ($isNotPublic && $model->token)) {
+        echo CHtml::submitButton(
+            $model->isNewRecord ? 'Create' : 'Save Changes',
+            array('class' => 'btn background-btn submit-btn', 'id' => 'datasetFormSaveButton', 'title' => 'Save any changes made on this page and stay on this page', 'data-toggle' => 'tooltip')
+        );
+    }
+
+    if ($isNotPublic && $model->token) {
+        echo CHtml::submitButton(
+            'Save Changes And Open Private URL',
+            array('name' => 'openUrl', 'class' => 'btn background-btn submit-btn', 'title' => 'This will Save any changes made on this page and open the mockup view of the dataset page', 'data-toggle' => 'tooltip')
+        );
+    }
+   ?>
 </div>
 
 <div class='modal fade admindataset-form' id='check_doi_modal' role='dialog' tabindex='-1' aria-modal='true'>
@@ -578,13 +594,11 @@ echo $form->hiddenField($model, "image_id");
             </div>
             <div class='modal-body'>
                 <div id='check-doi-error' class='alert alert-error clearfix' style='display: none;'></div>
-                <div class="pull-right mb-20">
-                    <a id='hideModalCheckDoi' class='btn background-btn-o'>Ok</a>
-                </div>
                 <div id='check-confirmation' class="clearfix"></div>
             </div>
+            <div class='modal-footer' id='dynamicModalFooter'>
+            </div>
         </div>
-
     </div>
 </div>
 
@@ -680,6 +694,7 @@ echo $form->hiddenField($model, "image_id");
                 dataType: 'json',
                 success: function (response) {
                     if (!([200, 204].includes(response.check_doi_status))) {
+                        $('#dynamicModalFooter').empty();
                         $('#check_doi_modal').modal('show')
                         myError.style.display = 'block'
                         let el = document.createElement('div')
@@ -697,6 +712,7 @@ echo $form->hiddenField($model, "image_id");
                     }
                 },
                 error: function (xhr, status, error) {
+                    $('#dynamicModalFooter').empty();
                     $('#check_doi_modal').modal('show');
 
                     myError.style.display = 'block'
@@ -708,33 +724,65 @@ echo $form->hiddenField($model, "image_id");
             });
         })
 
+        let isSubmitting = false;
+        //for published dataset
+        $('#datasetFormSaveButtonForPublished').click(function(e) {
+            if (isSubmitting) return;
+            e.preventDefault();
+
+            $('#check_doi_modal').modal('show')
+            $('#dynamicModalFooter').empty();
+            let myConfirmation = $('#check-confirmation')[0];
+            myConfirmation.innerHTML = 'Does DataCite DOI metadata have been updated?'
+            let el = document.createElement('div')
+            el.innerHTML = "Does DataCite DOI metadata have been updated?"
+
+            let buttonOk = $('<button/>', {
+                type: 'submit',
+                text: 'Yes',
+                id: 'datasetFormSaveButton',
+                class: 'btn background-btn submit-btn',
+                title: 'Save any changes made on this page and stay on this page',
+                'data-toggle': 'tooltip',
+            });
+
+            let btnNo = $('<button/>', {
+                type: 'submit',
+                text: 'No',
+                id: 'datasetFormSaveButton',
+                class: 'btn background-btn submit-btn',
+                title: 'Save any changes made on this page and stay on this page',
+                'data-toggle': 'tooltip',
+            });
+
+            let btnUpdateAuto = $('<button>')
+                .addClass('btn background-btn')
+                .text('No, please update it now')
+                .on('click', function(e) {
+                    e.preventDefault()
+                    $('#mint_doi_button').click()
+                    $('#check_doi_modal').modal('hide')
+                    $('#minting').html('minting under way, please wait');
+                });
+
+            let btnUpdateManually = $('<button>')
+                .addClass('btn btn-danger')
+                .text('No, let me do that')
+                .on('click', function(e) {
+                    e.preventDefault()
+                    $('#check_doi_modal').modal('hide')
+                });
+
+            $('#dynamicModalFooter').append(buttonOk);
+            $('#dynamicModalFooter').append(btnNo);
+            $('#dynamicModalFooter').append(btnUpdateAuto);
+            $('#dynamicModalFooter').append(btnUpdateManually);
+
+        })
+
         $('#hideModalCheckDoi').click(function (e) {
             $('#check_doi_modal').modal('hide')
         })
-
-        $('#mockup').on('click', function (event) {
-            event.preventDefault();
-
-            mockupUrl = $(this).attr('href');
-            form = $('#dataset-form');
-
-            $.ajax({
-                url: form.attr('action'),
-                method: 'POST',
-                data: form.serialize(),
-                success: function (response, textStatus, xhr) {
-                    if (200 === xhr.status) {
-                        window.location.href = mockupUrl;
-                    } else {
-                        $('#flashError').html('An error occurred while trying to save the dataset')
-                    }
-
-                },
-                error: function (error) {
-                    $('#flashError').html('An error occurred while trying to save the dataset')
-                }
-            })
-        });
     });
 
     function formatXML(xmlString) {
@@ -980,7 +1028,7 @@ Yii::app()->clientScript->registerScriptFile($jsUrl, CClientScript::POS_END);
     });
 
     $('#customizeEmailModal').on('hidden.bs.modal', function () {
-        $('#datasetFormSaveButton').focus(); // hardcoded button that triggers the modal to return focus
+        $('#datasetFormSaveButton').focus();
     });
 </script>
 
@@ -999,7 +1047,9 @@ Yii::app()->clientScript->registerScriptFile($jsUrl, CClientScript::POS_END);
         }
         let shouldBlock = false
         let datasetFormSaveButton = $('#datasetFormSaveButton')[0]
-        datasetFormSaveButton.disabled = false;
+        if (datasetFormSaveButton) {
+            datasetFormSaveButton.disabled = true;
+        }
 
         const {
             check_doi_status,
@@ -1041,9 +1091,13 @@ Yii::app()->clientScript->registerScriptFile($jsUrl, CClientScript::POS_END);
         if (!shouldBlock) {
             let myConfirmation = $('#check-confirmation')[0];
             myConfirmation.innerHTML = ''
-            datasetFormSaveButton.disabled = false
+
+            if (datasetFormSaveButton) {
+                datasetFormSaveButton.disabled = false;
+            }
 
             if (!xml) {
+                $('#dynamicModalFooter').empty();
                 $('#check_doi_modal').modal('show')
                 let el = document.createElement('div')
                 el.textContent = "Unable to generate XML for Datacite, please check"
@@ -1051,10 +1105,6 @@ Yii::app()->clientScript->registerScriptFile($jsUrl, CClientScript::POS_END);
 
                 myConfirmation.appendChild(el)
             }
-
-            datasetFormSaveButton.disabled = false
-        } else if ('Published' === $('#Dataset_upload_status').val()) {
-            datasetFormSaveButton.disabled = true
         }
 
         if (html) {

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -138,6 +138,14 @@ class AcceptanceTester extends \Codeception\Actor
     }
 
     /**
+     * @Then I should not see a submit button :value
+     */
+    public function iShouldNotSeeASubmitButton($value)
+    {
+        $this->cantSeeElement('input', ['value' => $value, 'type' => 'submit']);
+    }
+
+    /**
      * @Then I should see a disabled submit button :value
      */
     public function iShouldSeeADisabledSubmitButton($value)

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -32,6 +32,7 @@ Feature: form to update dataset details
     And I should see "Description"
     And I should see "Keywords"
     And I should see "URL to redirect"
+    And I should see a "Save Changes" button
     And I should see a button "Create New Log" with curation log link
     And I should not see "Publisher"
 
@@ -50,8 +51,9 @@ Feature: form to update dataset details
     When I am on "/adminDataset/update/id/2342"
     And I check the field "Dataset_Epigenomic"
     And I attach the file "bgi_logo_new.png" to the file input element "datasetImage"
-    And I press the button "Save"
-    And I wait 3 seconds
+    And I press the button "Save Changes And Open DOI"
+    And I wait "3" seconds
+    And I press the button "No"
     Then I am on "/dataset/100935"
     And I should see an image located in "/images/datasets/e3462258-a12a-5b1a-b45b-a94b95cc9442/bgi-logo-new.png"
 
@@ -116,38 +118,51 @@ Feature: form to update dataset details
     And I should see an image located in "/images/datasets/e166c2a0-3684-5209-bccd-c4b18ff87be9/bgi-logo-new.png"
 
   @ok @issue-1023
-  Scenario: To confirm the upload status of published dataset has changed to incomplete
-    When I am on "/adminDataset/update/id/5"
-    Then I should see "Incomplete"
-    And I should see "Create/Reset Private URL"
-    And I should not see "Open Private URL"
-
-  @ok @issue-1023
   Scenario: An incomplete dataset page cannot be visited publicly
     When I am on "/dataset/100039/"
     Then I should see "The DOI 100039 cannot be displayed"
 
   @ok @issue-1023
-  Scenario: Can create/reset private url
+  Scenario: Can create a private url for a non published dataset
     When I am on "/adminDataset/update/id/5"
-    And I press the button "Create/Reset Private URL"
-    And I wait "3" seconds
+    And I press the button "createReset"
+    And I wait "1" seconds
     Then I should see current url contains "/dataset/100039/token/"
     And I should see "Genomic data of the Puerto Rican Parrot (Amazona vittata) from a locally funded project."
 
   @ok @dataset-status
   Scenario: Can't see create/reset private url for a published dataset
     When I am on "/adminDataset/update/id/8"
-    Then I should not see "Create/Reset Private URL"
-    And I should not see "Open Private URL"
+    Then I should not see a submit button "Save Changes And Create Private URL"
+    And I should not see a submit button "Save Changes And Reset Private URL"
+    And I should not see a submit button "Save Changes And Open Private URL"
+    And I should see "Save Changes And Open DOI"
+    And I should see "Cancel Changes"
+
+    @ok
+  Scenario: It doesn't have an open private url button for a published dataset
+    When I am on "/adminDataset/update/id/63"
+    Then I should not see a submit button "Save Changes And Open Private URL"
+    And I should not see a submit button "Save Changes And Create Private URL"
+    And I should not see a submit button "Save Changes And Reset Private URL"
+    And I should see "Save Changes And Open DOI"
+    And I should see "Cancel Changes"
 
   @ok @issue-1023
-  Scenario: Open private url is working
-    When I am on "/adminDataset/update/id/5"
-    And I press the button "Create/Reset Private URL"
+  Scenario: Has an open private url button for a non published dataset with a token
+    When I am on "/adminDataset/update/id/668"
+    And I check the field "Dataset_Epigenomic"
+    And I press the button "openUrl"
     And I wait "1" seconds
-    Then I should see current url contains "/dataset/100039/token/"
-    And I should see "Genomic data of the Puerto Rican Parrot (Amazona vittata) from a locally funded project."
+    Then I should see current url contains "/dataset/200070/token/"
+    And I should see "supporting data for nothing in particular"
+
+    @ok
+  Scenario: It doesn't have an open private url button for a published dataset
+    When I am on "/adminDataset/update/id/63"
+    And I should not see a submit button "Save Changes And Open Private URL"
+    And I should see "Save Changes And Open DOI"
+    And I should see "Cancel Changes"
 
   @ok @issue-1023
   Scenario: Create AuthorReview dataset with token URL
@@ -181,8 +196,8 @@ Feature: form to update dataset details
     Then I am on "/adminDataset/update/id/2741"
     And I should see "AuthorReview"
     And I should see "123789"
-    And I should see "Create/Reset Private URL"
-    And I should see "Open Private URL"
+    And I should see a submit button "Save Changes And Reset Private URL"
+    And I should see a submit button "Save Changes And Open Private URL"
 
   @ok @issue-1023
   Scenario: Open Private URL from AuthorReview dataset
@@ -195,11 +210,11 @@ Feature: form to update dataset details
     And I fill in the field of "name" "Dataset[title]" with "test dataset"
     And I fill in the field of "name" "Dataset[identifier]" with "123789"
     And I fill in the field of "name" "Dataset[ftp_site]" with "ftp://test"
-    When I check the field "Dataset_Epigenomic"
+    And I check the field "Dataset_Epigenomic"
     And I press the button "Create"
     And I wait 3 seconds
     And I am on "/adminDataset/update/id/2741"
-    And I follow "Open Private URL"
+    And I press the button "openUrl"
     And I wait "1" seconds
     Then I should see current url contains "/dataset/123789/token/"
     And I should see "https://doi.org/10.5524/123789"
@@ -282,8 +297,9 @@ Feature: form to update dataset details
     And I fill in the field of "name" "Image[source]" with "test source"
     And I fill in the field of "name" "Image[license]" with "test license"
     And I fill in the field of "name" "Image[photographer]" with "test Joe"
-    And I press the button "Save"
+    And I press the button "Save Changes And Open DOI"
     And I wait 3 seconds
+    And I press the button "No"
     Then I am on "/adminDataset/update/id/8"
     And I should see an image field "source" with text "test source"
     And I should see an image field "license" with text "test license"
@@ -294,7 +310,10 @@ Feature: form to update dataset details
   Scenario: can save keywords on update
     When I am on "/adminDataset/update/id/8"
     And I fill in keywords fields of name keywords with "abcd, a four part keyword, my_keyword, my-keyword, my dodgy tag<script>alert('xss!');</script>"
-    And I press the button "Save"
+    And I press the button "Save Changes And Open DOI"
+    And I wait 3 seconds
+    And I press the button "No"
+    And I wait 3 seconds
     Then I am on "dataset/100006"
     And I should see "abcd"
     And I should see "a four part keyword"
@@ -329,10 +348,16 @@ Feature: form to update dataset details
     Given I am on "/adminDataset/update/id/8"
     And I click on keywords field
     And I fill in keywords fields of name keywords with "bam"
-    And I press the button "Save"
+    And I press the button "Save Changes And Open DOI"
+    And I wait 3 seconds
+    And I press the button "No"
+    And I wait 2 seconds
     When I am on "/adminDataset/update/id/8"
     And I click on delete keyword button
-    And I press the button "Save"
+    And I press the button "Save Changes And Open DOI"
+    And I wait 3 seconds
+    And I press the button "No"
+    And I wait 2 seconds
     Then I am on "dataset/100006"
     And I should not see "bam"
 
@@ -390,11 +415,36 @@ Feature: form to update dataset details
     Given I am on "/adminDataset/update/id/8"
     And I should see "Published"
     When I fill in the field of "name" "Dataset[dataset_size]" with "lorem ipsum"
-    And I press the button "Save"
+    And I press the button "Save Changes And Open DOI"
     And I wait 3 seconds
+    And I press the button "No"
+    And I wait 2 seconds
     Then I should be on "/adminDataset/update/id/8"
     And I should see "Fail to update!"
     And I should see "Dataset Size must be a number."
+
+  @ok
+  Scenario: Redirect to the mockup with the existing token when successfully updating private dataset
+    Given I am on "/adminDataset/update/id/668"
+    And I should see "Private"
+    When I fill in the field of "name" "Dataset[dataset_size]" with "1024"
+    When I check the field "Dataset_Epigenomic"
+    And I should see a submit button "Save Changes And Open Private URL"
+    And I press the button "openUrl"
+    Then I should see current url contains "/dataset/200070/token/"
+
+  @ok
+  Scenario: Redirect to the mockup with a new token when successfully updating private dataset
+    Given I am on "/adminDataset/update/id/668"
+    And I should see "Private"
+    And I check the field "Dataset_Epigenomic"
+    And I fill in the field of "name" "Dataset[dataset_size]" with "1024"
+    And I should see a submit button "Save Changes And Reset Private URL"
+    And I should see a submit button "Save Changes"
+    And I should see "Cancel Changes"
+    And I should not see a submit button "Save Changes And Create Private URL"
+    When I press the button "createReset"
+    Then I should see current url contains "/dataset/200070/token/"
 
   @ok @flashmessage
   Scenario: Display success message when updating private dataset
@@ -412,7 +462,7 @@ Feature: form to update dataset details
     Given I am on "/adminDataset/update/id/668"
     And I should see "Private"
     When I fill in the field of "name" "Dataset[dataset_size]" with "lorem ipsum"
-    And I press the button "Save"
+    And I press the button "Save Changes"
     And I wait 3 seconds
     Then I should be on "/adminDataset/update/id/668"
     And I should see "Fail to update!"
@@ -445,8 +495,14 @@ Feature: form to update dataset details
   Scenario: Check dataset page with Curation status can be viewed using private URL
     Given I am on "/adminDataset/update/id/5"
     And I select "Curation" from the field "Dataset_upload_status"
-    And I press the button "Save"
-    And I am on "/adminDataset/private/identifier/100039"
+    And I should not see a submit button "Save Changes And Reset Private URL"
+    And I should see a submit button "Save Changes And Create Private URL"
+    And I press the button "createReset"
+    And I wait "3" seconds
+    And I am on "/adminDataset/update/id/5"
+    And I should see a submit button "Save Changes And Reset Private URL"
+    And I should see a submit button "Save Changes"
+    And I press the button "openUrl"
     Then I should see current url contains "/dataset/100039/token/"
     And I should see "Genomic data of the Puerto Rican Parrot"
 
@@ -489,13 +545,13 @@ Feature: form to update dataset details
     And I should see a link "here" to "https://support.datacite.org/reference/mds#api-response-codes"
 
   @ok @dataset-status
-  Scenario Outline: Links to create mockup or to open mockup are always present for a non-published dataset
+  Scenario Outline: Links to create mockup or to open mockup are always present for a non-published dataset with a token
     Given I am on "/adminDataset/update/id/668"
     And I select <status> from the field "Dataset_upload_status"
-    And I press the button "Save"
+    And I press the button "Save Changes"
     And I am on "/adminDataset/update/id/668"
-    Then I should see a link "Create/Reset Private URL" to "/adminDataset/private/identifier/200070"
-    And I should see a link "Open Private URL" to "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
+    Then I should see a submit button "Save Changes And Reset Private URL"
+    And I should see a submit button "Save Changes And Open Private URL"
     Examples:
       | status                   |
       | "ImportFromEM"           |
@@ -511,26 +567,10 @@ Feature: form to update dataset details
       | "DataAvailableForReview" |
       | "DataPending"            |
 
-  @ok
-  Scenario: Links to create mockup is present for a submitted dataset
-    Given I am on "/adminDataset/update/id/5"
-    And I select "DataAvailableForReview" from the field "Dataset_upload_status"
-    And I press the button "Save"
-    And I wait 3 seconds
-    When I am on "/adminDataset/update/id/5"
-    And I select "Submitted" from the field "Dataset_upload_status"
-    And I press the button "Save"
-    When I am on "/adminDataset/update/id/5"
-    Then I should see "Create/Reset Private URL"
-    And I press the button "Create/Reset Private URL"
-    And I wait "3" seconds
-    Then I should see current url contains "/dataset/100039/token/"
-    And I should see "Genomic data of the Puerto Rican Parrot (Amazona vittata) from a locally funded project."
-
   @ok @issue-1812 @mockup
   Scenario: Navigating mockup page tables does not generate errors
     Given I am on "/adminDataset/update/id/5"
-    When I press the button "Create/Reset Private URL"
+    When I press the button "createReset"
     And I wait "1" seconds
     And I press the button "Files"
     And I press the button "Next >"
@@ -576,11 +616,16 @@ Feature: form to update dataset details
     Given I am on "/adminDataset/update/id/8"
     Then I should see "Workflow"
     Then I check "Dataset_Workflow" checkbox
-    And I press the button "Save"
+    And I press the button "Save Changes And Open DOI"
+    And I wait "1" seconds
+    And I press the button "No"
     When I am on "/adminDataset/update/id/8"
     Then I should see "Dataset_Workflow" checkbox is checked
     Then I uncheck "Dataset_Workflow" checkbox
-    And I press the button "Save"
+    And I press the button "Save Changes And Open DOI"
+    And I wait "1" seconds
+    And I press the button "No"
+    And I wait "5" seconds
     When I am on "/adminDataset/update/id/8"
     Then I should see "Workflow"
 
@@ -591,7 +636,9 @@ Feature: form to update dataset details
     Then I should see "Dataset_Genomic" checkbox is checked
     Then I check "Dataset_Workflow" checkbox
     Then I uncheck "Dataset_Genomic" checkbox
-    And I press the button "Save"
+    And I press the button "Save Changes And Open DOI"
+    And I wait "1" seconds
+    And I press the button "No"
     And I wait "5" seconds
     When I am on "/adminDataset/update/id/5"
     Then I should see "Dataset_Genomic" checkbox is checked
@@ -605,8 +652,9 @@ Feature: form to update dataset details
     And I should see "Dataset_Workflow" checkbox is unchecked
     When I check "Dataset_Workflow" checkbox
     Then I should see "Dataset_Workflow" checkbox is checked
-    When I press the button "Save"
-    And I wait "5" seconds
+    When I press the button "Save Changes And Open DOI"
+    And I wait "1" seconds
+    And I press the button "No"
     And I am on "/adminDataset/update/id/8"
     Then I should see "Dataset_Workflow" checkbox is checked
     Then I should see "Dataset_Genomic" checkbox is unchecked
@@ -642,3 +690,116 @@ Feature: form to update dataset details
     And I am on "/adminDataset/update/id/5"
     Then I can see the option "Published" selected for "Dataset_upload_status"
     And I should see "Status changed to Published"
+
+    @ok
+  Scenario: Check buttons for a non public dataset with no token
+    Given I am on "/adminDataset/update/id/5"
+    Then I should see a submit button "Save Changes And Create Private URL"
+    And I should not see a submit button "Save Changes And Reset Private URL"
+    And I should see "Cancel Changes"
+
+    @ok
+  Scenario: Save Changes And Create Private URL button create a url and save changes for a non public dataset with no token
+    Given I am on "/adminDataset/update/id/5"
+    And I fill in the field of "name" "Dataset[title]" with "test dataset"
+    And I should see a submit button "Save Changes And Create Private URL"
+    When I press the button "createReset"
+    And I wait "1" seconds
+    Then I should see current url contains "/dataset/100039/token/"
+    And I should see "test dataset"
+
+    @ok
+  Scenario: Check buttons for a non public dataset with a token
+    Given I am on "/adminDataset/update/id/668"
+    Then I should see a submit button "Save Changes And Reset Private URL"
+    And I should see a submit button "Save Changes"
+    And I should see a submit button "Save Changes And Open Private URL"
+    And I should see "Cancel Changes"
+
+    @ok
+  Scenario: Save Changes And Open Private URL button for a non public dataset with a token
+    Given I am on "/adminDataset/update/id/668"
+    And I check "Dataset_Workflow" checkbox
+    When I press the button "openUrl"
+    Then I should see current url contains "/dataset/200070/token/"
+    And I should see "Dataset type: Workflow"
+
+    @ok
+  Scenario: Save Changes button for a non public dataset with a token stay on update page
+    Given I am on "/adminDataset/update/id/668"
+    And I check "Dataset_Workflow" checkbox
+    When I press the button "Save Changes"
+    Then I should see "Updated successfully!"
+
+    @ok
+  Scenario: Cancel Changes button for a non public dataset with a token returns to admin page
+    Given I am on "/adminDataset/update/id/668"
+    When I press the button "Cancel Changes"
+    Then I should see current url contains "/adminDataset/admin"
+
+    @ok
+  Scenario: Check buttons for a public dataset
+    Given I am on "/adminDataset/update/id/8"
+    Then I should not see a submit button "Save Changes And Create Private URL"
+    And I should not see a submit button "Save Changes And Reset Private URL"
+    And I should not see a submit button "Save Changes And Open Private URL"
+    And I should see "Save Changes And Open DOI"
+    And I should see "Cancel Changes"
+
+    @ok
+  Scenario: Check that a model opens for a published dataset when click on "Save Changes And Open DOI" button
+    Given I am on "/adminDataset/update/id/8"
+    And I press the button "Save Changes And Open DOI"
+    And I wait "3" seconds
+    Then I should see "Does DataCite DOI metadata have been updated?"
+    And I should see "Yes"
+    And I should see "No"
+    And I should see "No, please update it now"
+    And I should see "No, let me do that"
+
+  Scenario: Check that updates are saved and I'm redirect to the relevant dataset doi page when I click "Yes" for a published dataset
+    Given I am on "/adminDataset/update/id/8"
+    And I should see "Dataset_Workflow" checkbox is unchecked
+    And I check "Dataset_Workflow" checkbox
+    And I press the button "Save Changes And Open DOI"
+    And I wait "3" seconds
+    And I press the button "Yes"
+    Then I should see current url contains "/dataset/100006"
+    And I should see "Dataset type: Genomic, Workflow"
+
+    @ok
+  Scenario: Check that updates are saved and I'm redirect to the relevant dataset doi page when I click "No" for a published dataset
+    Given I am on "/adminDataset/update/id/8"
+    And I should see "Dataset_Workflow" checkbox is unchecked
+    And I check "Dataset_Workflow" checkbox
+    And I press the button "Save Changes And Open DOI"
+    And I wait "3" seconds
+    And I press the button "No"
+    Then I should see current url contains "/dataset/100006"
+    And I should see "Dataset type: Genomic, Workflow"
+
+    @ok
+  Scenario: Check that the DOI has been minted  when I click "No, please update it now" for a published dataset
+    Given I am on "/adminDataset/update/id/8"
+    And I should not see "DOI Minting"
+    And I should not see "Sent DataCite XML"
+    And I press the button "Save Changes And Open DOI"
+    And I wait "3" seconds
+    And I press the button "No, please update it now"
+    And I wait "3" seconds
+    Then I should see current url contains "/adminDataset/update/id/8"
+    And I should see "DOI Minting"
+    And I should see "Sent DataCite XML"
+
+    @ok
+  Scenario: Check that I stay on update page when I click "No, let me do that" for a published dataset
+    Given I am on "/adminDataset/update/id/8"
+    And I should not see "DOI Minting"
+    And I should not see "Sent DataCite XML"
+    And I press the button "Save Changes And Open DOI"
+    And I wait "3" seconds
+    And I press the button "No, let me do that"
+    And I wait "3" seconds
+    Then I should see current url contains "/adminDataset/update/id/8"
+    And I should not see "DOI Minting"
+    And I should not see "Sent DataCite XML"


### PR DESCRIPTION
# Pull request for issue: #1533 and #2208

form submission buttons appearance and behaviour to adapt to a dataset being public or private

go on admin update dataset page and test public and non public datasets

!! PR https://github.com/gigascience/gigadb-website/pull/2166 need to be reviewed and merged before.

## How to test?

### a dataset that is not public & no token 

>Given I am on a dataset-admin form for a dataset that is not public
>AND the token URL has NOT already been set
>When I scroll to the bottom of the page 
>Then I can see a button marked with "Save Changes And Create Private URL"
> And a button marked "Cancel Changes"
(NB there is no save changes only button here)

>Given I am on a dataset-admin form for a dataset that is not public
>AND the token URL has NOT already been set
>When I click the button "Save Changes And Create Private URL" 
>Then  changes made to the dataset are saved to the database
>And it creates a new token for the private URL
>And I am redirected to the mockup with the just created token

>Given I am on a dataset-admin form for a dataset that is not public
>AND the token URL has NOT already been set
>When I click the button "Cancel Changes" button
>Then no changes are saved to the database
>And I am redirected back to the dataset list admin page


### a dataset that is not public With an existing token 

>Given I am on a dataset-admin form for a dataset that is not public
>AND the token URL has already been set
>When I scroll to the bottom of the page
>Then I can see the button marked with "Save Changes And Open Private URL"
>And I see the button "Save Changes"
>And I see the button "Cancel Changes"
>And I see the button "Save Changes And Reset Private URL"

>Given I am on a dataset-admin form for a dataset that is not public
>AND the token URL has already been set
>When I click the button "Save Changes And Open Private URL" 
>Then changes made to the dataset are saved to the database
>And it does not creates a new token for the private URL
>And I am redirected to the mockup with the existing token

>Given I am on a dataset-admin form for a dataset that is not public
>AND the token URL has already been set
>When I click the button "Save Changes And Reset Private URL" button 
>Then changes made to the dataset are saved to the database
>And a new token is set for the private URL
>And I am redirected to the mockup with the new token URL

>Given I am on a dataset-admin form for a dataset that is not public
>AND the token URL has already been set
>When I click the "Save Changes" button 
>Then changes made to the dataset are saved to the database
>And I remain on the same dataset admin page

>Given I am on a dataset-admin form for a dataset that is not public
>AND the token URL has already been set
>When I click the button "Cancel Changes" button 
>Then no changes are saved to the database
>And I am redirected back to the dataset list admin page


### a public dataset

>Given I am on a dataset-admin form for a dataset that is public
>When I scroll to the bottom of the page
>Then I don't see the button "Save Changes And Create Private URL"
>And I don't see the button "Save Changes And Reset Private URL"
>And I don't see the button "Save Changes And Open Private URL"
>And I see the button "Save Changes And Open DOI"
>And I see the button "Cancel Changes"

>When I click the button "Save Changes And Open DOI" button 
>Then any changes are saved to the database
>And I am asked to confirm if the DataCite DOI metadata has been updated?
>When I click yes the datacite doi has been updated then I am redirected to the relevant dataset DOI page.
>When I click no the datacite doi does not need updating then I am redirected to the relevant dataset doi page
> When I click "no, please update it now" then the doi is reminted at datacite (and curation log entry added)
>When I click "No let me do that" then I am redirected to the dataset admin and NO changes have been saved yet.

>When I click the button "Cancel Changes" button 
>Then no changes are saved to the database
>And I am redirected back to the dataset list admin page


## How have functionalities been implemented?

## Any issues with implementation?

## Any changes to automated tests?

acceptance tests updated+ tests added

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?
