### PR TITLE
Feat 2236 display pre print manuscript on dataset page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #2236: Display pre print manuscript on dataset page
+
 ## v4.4.13 - 2025-06-13 - 26083397b - 
 
 - Feat #199: Reorder home page sections

--- a/data/dev/manuscript.csv
+++ b/data/dev/manuscript.csv
@@ -8,4 +8,4 @@ id,identifier,pmid,dataset_id,is_pre_print
 163,10.1186/2047-217X-3-27,,8,false
 168,10.1126/science.1251385,,8,false
 219,10.1126/science.1253451,,8,false
-281,10.1186/s13742-015-0064-7,,200,false
+281,10.1186/s13742-015-0064-7,,200,true

--- a/ops/configuration/yii-conf/main.php.dist
+++ b/ops/configuration/yii-conf/main.php.dist
@@ -69,6 +69,10 @@ return CMap::mergeArray(array(
     ),
 
     'components'=>array(
+        'request' => [
+            'enableCsrfValidation' => true,
+            'enableCookieValidation' => true,
+        ],
         'format'=>array(
             'class'=>'application.extensions.CTypeFormatter'
         ),

--- a/protected/components/DatasetPageSettings.php
+++ b/protected/components/DatasetPageSettings.php
@@ -73,11 +73,15 @@ class DatasetPageSettings extends yii\base\BaseObject
             "page" => 10,
         ];
 
-        if (isset($cookies['file_setting'])) {
+        if ($cookies['file_setting']) {
             $fileSettings = json_decode($cookies['file_setting']->value, true);
+
+            if (!$fileSettings['setting'] || !$fileSettings['page']) {
+                throw new CException('An error occurred');
+            }
         }
 
-        return [ "columns" => $fileSettings['setting'], "pageSize" => $fileSettings['page'] ];
+        return ["columns" => (array) $fileSettings['setting'], "pageSize" => (int) $fileSettings['page'] ];
     }
 
     /**
@@ -90,14 +94,16 @@ class DatasetPageSettings extends yii\base\BaseObject
      */
     public function setFileSettings(array $columns, int $pageSize, CMap $cookies): array
     {
-        if (isset($cookies['file_setting'])) {
+        if ($cookies['file_setting']) {
             $cookies['file_setting']->value = json_encode([ "setting" => $columns, "page" => $pageSize]);
         } else {
-                $cookie = new CHttpCookie('file_setting', json_encode(array('setting' => $columns, 'page' => $pageSize)));
-                $cookie->expire = time() + (60 * 60 * 24 * 30);
-                $cookies['file_setting'] = $cookie;
+            $cookie = new CHttpCookie('file_setting', json_encode(array('setting' => $columns, 'page' => $pageSize)));
+            $cookie->expire = time() + (60 * 60 * 24 * 30);
+            $cookie->httpOnly = true;
+            $cookie->secure = true;
+            $cookies['file_setting'] = $cookie;
         }
-        return [ "columns" => $columns, "pageSize" => $pageSize ];
+        return ["columns" => $columns, "pageSize" => $pageSize];
     }
 
     /**
@@ -114,11 +120,11 @@ class DatasetPageSettings extends yii\base\BaseObject
             "page" => 10,
         ];
 
-        if (isset($cookies['sample_setting'])) {
+        if ($cookies['sample_setting']) {
             $sampleSettings = json_decode($cookies['sample_setting']->value, true);
         }
 
-        return [ "columns" => $sampleSettings['columns'], "pageSize" => $sampleSettings['page'] ];
+        return ["columns" => $sampleSettings['columns'], "pageSize" => $sampleSettings['page']];
     }
 
     /**
@@ -131,13 +137,15 @@ class DatasetPageSettings extends yii\base\BaseObject
      */
     public function setSampleSettings(array $columns, int $pageSize, CMap $cookies): array
     {
-        if (isset($cookies['sample_setting'])) {
+        if ($cookies['sample_setting']) {
             $cookies['sample_setting']->value = json_encode([ "columns" => $columns, "page" => $pageSize]);
         } else {
-                $cookie = new CHttpCookie('sample_setting', json_encode(array('columns' => $columns, 'page' => $pageSize)));
-                $cookie->expire = time() + (60 * 60 * 24 * 30);
-                $cookies['sample_setting'] = $cookie;
+            $cookie = new CHttpCookie('sample_setting', json_encode(array('columns' => $columns, 'page' => $pageSize)));
+            $cookie->expire = time() + (60 * 60 * 24 * 30);
+            $cookie->httpOnly = true;
+            $cookie->secure = true;
+            $cookies['sample_setting'] = $cookie;
         }
-        return [ "columns" => $columns, "pageSize" => $pageSize ];
+        return ["columns" => $columns, "pageSize" => $pageSize];
     }
 }

--- a/protected/components/FormattedDatasetConnections.php
+++ b/protected/components/FormattedDatasetConnections.php
@@ -87,14 +87,21 @@ class FormattedDatasetConnections extends DatasetComponents implements DatasetCo
     */
     public function getPublications(): array
     {
-        $formattedPublications = [];
         $publications = $this->_cachedDatasetConnections->getPublications();
+        $formattedPublicationsPeerReview = [];
+        $formattedPublicationsPrePrint = [];
         foreach ($publications as $publication) {
             $publication['citation'] = preg_replace("/(doi:)([0-9.]+\/.*)/", '<a href="https://doi.org/$2">$1$2</a>', $publication['citation']);
             $publication['pmurl'] = preg_replace("/^(http.*)$/", "(PubMed:<a href=\"$1\">" . $publication['pmid'] . "</a>)", $publication['pmurl']);
-            $formattedPublications[] = $publication;
+
+            if ($publication['is_pre_print']) {
+                $formattedPublicationsPrePrint[] = $publication;
+            } else {
+                $formattedPublicationsPeerReview[] = $publication;
+            }
         }
-        return $formattedPublications;
+
+        return [$formattedPublicationsPeerReview, $formattedPublicationsPrePrint];
     }
 
     /**

--- a/protected/components/StoredDatasetConnections.php
+++ b/protected/components/StoredDatasetConnections.php
@@ -88,8 +88,7 @@ class StoredDatasetConnections extends DatasetComponents implements DatasetConne
     */
     public function getPublications(): array
     {
-
-        $sql = "select id, identifier, pmid, dataset_id from manuscript where dataset_id = :id order by id";
+;        $sql = "select id, identifier, pmid, dataset_id, is_pre_print from manuscript where dataset_id = :id order by id";
         $command = $this->_db->createCommand($sql);
         $command->bindParam(":id", $this->_id, PDO::PARAM_INT);
         $rows = $command->queryAll();

--- a/protected/controllers/DatasetController.php
+++ b/protected/controllers/DatasetController.php
@@ -55,10 +55,10 @@ class DatasetController extends Controller
     {
         // Retrieving the data
         $model = Dataset::model()->find("identifier=?", array($id));
-        $dao = new DatasetDAO(["identifier" => $id]) ;
+        $srv = Yii::app()->fileUploadService->getFileUploadService(\Yii::$container->get('guzzleHttpClient'), $id);
+        $dao = $srv->dataset;
         $nextDataset =  $dao->getNextDataset() ?? $dao->getFirstDataset();
         $previousDataset =  $dao->getPreviousDataset() ?? $dao->getFirstDataset();
-        $srv = new FileUploadService(["webClient" => \Yii::$container->get('guzzleHttpClient')]);
 
         $datasetPageSettings = new DatasetPageSettings($model);
 
@@ -76,24 +76,29 @@ class DatasetController extends Controller
             $fileSettings = $datasetPageSettings->getFileSettings($cookies);
         }
 
-        if (isset($_POST['setting']) && $_POST['pageSize']) {
-            $fileSettings = $datasetPageSettings->setFileSettings($_POST['setting'], $_POST['pageSize'], $cookies);
+        $setting = Yii::$app->request->post('setting');
+        $pageSize = Yii::$app->request->post('pageSize');
+
+        if ($setting && $pageSize) {
+            $fileSettings = $datasetPageSettings->setFileSettings($setting, $pageSize, $cookies);
             $flag = "file";
         }
-
 
         //configuring samples table
         $sampleSettings = $datasetPageSettings->getSampleSettings($cookies);
 
-        if (isset($_POST['columns'])) {
-            $sampleSettings = $datasetPageSettings->setSampleSettings($_POST['columns'], $_POST['samplePageSize'], $cookies);
+        $columns = Yii::$app->request->post('columns');
+        $samplePageSize = Yii::$app->request->post('samplePageSize');
+        if (Yii::$app->request->post('columns')) {
+            $sampleSettings = $datasetPageSettings->setSampleSettings($columns, $samplePageSize, $cookies);
             $flag = "sample";
         }
 
         // Assembling page components and page settings
         $assemblyConfig = [];
         if ("invalid" !== $datasetPageSettings->getPageType()) {
-            if (preg_match("/dataset\/$id\/token/",$_SERVER['REQUEST_URI'])) {
+            $requestUri = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
+            if (preg_match("/dataset\/$id\/token/", $requestUri)) {
                 $assemblyConfig = ['skip_cache' => true] ;
             }
             $assembly = DatasetPageAssembly::assemble($model, Yii::app(), $srv, $assemblyConfig);
@@ -112,9 +117,9 @@ class DatasetController extends Controller
             $urlToRedirect = trim($assembly->getDataset()->getUrlToRedirectAttribute());
             $currentAbsoluteFullUrl = Yii::app()->request->getBaseUrl(true) . Yii::app()->request->url ;
 
-            if ($urlToRedirect && $currentAbsoluteFullUrl == $urlToRedirect) {
+            if ($urlToRedirect && $currentAbsoluteFullUrl === $urlToRedirect) {
                 $this->metaData['redirect'] = 'http://dx.doi.org/10.5524/' . $assembly->getDataset()->identifier ;
-                $this->render('interstitial', array(
+                return $this->render('interstitial', array(
                     'model' => $assembly->getDataset()
                 ));
             }
@@ -146,7 +151,7 @@ class DatasetController extends Controller
 
         // Different rendering based on page type (invalid, hidden, public)
         if ("invalid" === $datasetPageSettings->getPageType()) {
-            $this->render('invalid', array('model' => new Dataset('search'), 'keyword' => $id, 'general_search' => 1));
+            return $this->render('invalid', array('model' => new Dataset('search'), 'keyword' => $id, 'general_search' => 1));
         } elseif (in_array($datasetPageSettings->getPageType(), ["hidden","draft", "mockup"])) {
             // Page private ? Disable robot to index
             $this->metaData['private'] = true;
@@ -155,7 +160,7 @@ class DatasetController extends Controller
                 $mainRenderer($assembly, $datasetPageSettings, $previousDataset, $nextDataset, $fileSettings, $sampleSettings, $flag);
             } else {
                 Yii::log('Request is invalid for URI: '.$_SERVER['REQUEST_URI'],'error');
-                $this->render('invalid', array('model' => new Dataset('search'), 'keyword' => $id));
+                return $this->render('invalid', array('model' => new Dataset('search'), 'keyword' => $id));
             }
         } else { //page type is public
             // specify canonical URL due to samples and files pagination generating multiple URLs with the same main content

--- a/protected/views/dataset/view.php
+++ b/protected/views/dataset/view.php
@@ -187,18 +187,31 @@ $sampleDataProvider = $samples->getDataProvider();
                     </div>
                 </div>
                 <?php
-                $publications = $connections->getPublications();
-                if (!empty($publications)) { ?>
+                [$peerReviews, $prePrints] = $connections->getPublications();
+                if ($peerReviews) { ?>
                     <h3 class="h5"><strong><?= Yii::t('app', 'Read the peer-reviewed publication(s):') ?></strong></h3>
                     <ul class="list-unstyled citation-list">
-                        <? foreach ($publications as $publication) {
+                        <? foreach ($peerReviews as $peerReview) {
                           ?>
                           <li>
                           <?
-                            echo $publication['citation'] . $publication['pmurl'];
+                            echo $peerReview['citation'] . $peerReview['pmurl'];
                           ?>
                           </li>
                           <?
+                        }
+                        ?>
+                    </ul>
+                <?php } if ($prePrints) { ?>
+                    <h3 class='h5'><strong><?= Yii::t('app', 'Read the pre-print publication(s):') ?></strong></h3>
+                        <ul class="list-unstyled citation-list">
+                        <? foreach ($prePrints as $prePrint) { ?>
+                            <li>
+                            <?
+                                echo $prePrint['citation'] . $prePrint['pmurl'];
+                            ?>
+                            </li>
+                        <?
                         }
                         ?>
                     </ul>

--- a/tests/acceptance/DatasetView.feature
+++ b/tests/acceptance/DatasetView.feature
@@ -263,3 +263,8 @@ Feature: a user visit the dataset page
     When I am on "/dataset/100020"
     Then I should see "Liu X; Quan Z; Cheng S; Xu X; Pan S; Zeng P; Xie M; Yue Z; Zhan D; Li Y; Wang J; Zhao Z; Zhang G (2011)"
     And I should not see "Wang, J; Quan, Z; Zhao, Z; Cheng, S; Liu, X; Li, Y; Pan, S; Xie, M; Xu, X; Yue, Z; Zeng, P; Zhan, D; Zhang, G (2011)"
+
+  Scenario: Show pre print publications
+    Given I have not signed in
+    When I am on "/dataset/100142"
+    Then I should see "Read the pre-print publication(s):"

--- a/tests/acceptance/DatasetView.feature
+++ b/tests/acceptance/DatasetView.feature
@@ -20,7 +20,6 @@ Feature: a user visit the dataset page
   Scenario: pagination widget is shown when total number of file greater than the page size setting
     Given I have not signed in
     And I have set the page size setting to 5
-    When I am on "/dataset/100006"
     And I follow "Files"
     Then I should see "Next >"
     Then I should see "Go to page"

--- a/tests/unit/FormattedDatasetConnectionsTest.php
+++ b/tests/unit/FormattedDatasetConnectionsTest.php
@@ -116,6 +116,7 @@ class FormattedDatasetConnectionsTest extends CTestCase
                                             'dataset_id' => 1,
                                             'citation' => "full citation fetched remotely. doi:10.1186/gb-2012-13-10-r100",
                                             'pmurl' => "http://www.ncbi.nlm.nih.gov/pubmed/23075480",
+                                            'is_pre_print' => false
                                         ),
                                         array(
                                             'id' => 2,
@@ -124,11 +125,12 @@ class FormattedDatasetConnectionsTest extends CTestCase
                                             'dataset_id' => 1,
                                             'citation' => "Another full citation fetched remotely. doi:10.1038/nature10158",
                                             'pmurl' => null,
+                                            'is_pre_print' => false
                                         ),
                                     )
                                 );
 
-        $expected = array(
+        $expected = array(array(
                         array(
                             'id' => 1,
                             'identifier' => "10.1186/gb-2012-13-10-r100",
@@ -136,6 +138,7 @@ class FormattedDatasetConnectionsTest extends CTestCase
                             'dataset_id' => 1,
                             'citation' => 'full citation fetched remotely. <a href="https://doi.org/10.1186/gb-2012-13-10-r100">doi:10.1186/gb-2012-13-10-r100</a>',
                             'pmurl' => '(PubMed:<a href="http://www.ncbi.nlm.nih.gov/pubmed/23075480">23075480</a>)',
+                            'is_pre_print' => false
                         ),
                         array(
                             'id' => 2,
@@ -144,8 +147,9 @@ class FormattedDatasetConnectionsTest extends CTestCase
                             'dataset_id' => 1,
                             'citation' => 'Another full citation fetched remotely. <a href="https://doi.org/10.1038/nature10158">doi:10.1038/nature10158</a>',
                             'pmurl' => null,
+                            'is_pre_print' => false
                         ),
-                    );
+                    ), array());
         $daoUnderTest = new FormattedDatasetConnections($controller, $cachedDatasetConnections);
         $this->assertEquals($expected, $daoUnderTest->getPublications());
     }

--- a/tests/unit/StoredDatasetConnectionsTest.php
+++ b/tests/unit/StoredDatasetConnectionsTest.php
@@ -178,6 +178,7 @@ class StoredDatasetConnectionsTest extends CDbTestCase
                             'dataset_id' => 1,
                             'citation' => "full citation fetched remotely. doi:10.1186/gb-2012-13-10-r100",
                             'pmurl' => "http://www.ncbi.nlm.nih.gov/pubmed/23075480",
+                            'is_pre_print' => false
                         ),
                         array(
                             'id' => 2,
@@ -186,6 +187,7 @@ class StoredDatasetConnectionsTest extends CDbTestCase
                             'dataset_id' => 1,
                             'citation' => "Another full citation fetched remotely. doi:10.1038/nature10158",
                             'pmurl' => null,
+                            'is_pre_print' => false
                         ),
                         array(
                             'id' => 3,
@@ -194,6 +196,7 @@ class StoredDatasetConnectionsTest extends CDbTestCase
                             'pmid' => null,
                             'citation' => "The third citation fetched remotely. doi.org/10.6789/s13742-015",
                             'pmurl' => null,
+                            'is_pre_print' => false
                         ),
                     );
         $daoUnderTest = new StoredDatasetConnections(
@@ -227,6 +230,7 @@ class StoredDatasetConnectionsTest extends CDbTestCase
                             'dataset_id' => 1,
                             'citation' => null,
                             'pmurl' => "http://www.ncbi.nlm.nih.gov/pubmed/23075480",
+                            'is_pre_print' => false
                         ),
                         array(
                             'id' => 2,
@@ -235,6 +239,7 @@ class StoredDatasetConnectionsTest extends CDbTestCase
                             'dataset_id' => 1,
                             'citation' => null,
                             'pmurl' => null,
+                            'is_pre_print' => false
                         ),
                         array(
                             'id' => 3,
@@ -242,7 +247,8 @@ class StoredDatasetConnectionsTest extends CDbTestCase
                             'pmid' => null,
                             'dataset_id' => 1,
                             'citation' => "Citation text 2 here.",
-                            'pmurl' => null
+                            'pmurl' => null,
+                            'is_pre_print' => false
                         ),
                     );
         $daoUnderTest = new StoredDatasetConnections(
@@ -273,6 +279,7 @@ class StoredDatasetConnectionsTest extends CDbTestCase
                 'dataset_id' => 1,
                 'citation' => "Citation text 1 here.",
                 'pmurl' => null,
+                'is_pre_print' => false
             ),
             array(
                 'id' => 3,
@@ -280,7 +287,8 @@ class StoredDatasetConnectionsTest extends CDbTestCase
                 'pmid' => null,
                 'dataset_id' => 1,
                 'citation' => "Citation text 2 here.",
-                'pmurl' => null
+                'pmurl' => null,
+                'is_pre_print' => false
             ),
         );
 
@@ -311,6 +319,7 @@ class StoredDatasetConnectionsTest extends CDbTestCase
                 'dataset_id' => 1,
                 'citation' => "Citation text 1 here.",
                 'pmurl' => "http://www.ncbi.nlm.nih.gov/pubmed/23075480",
+                'is_pre_print' => false
             ),
             array(
                 'id' => 3,
@@ -318,7 +327,8 @@ class StoredDatasetConnectionsTest extends CDbTestCase
                 'pmid' => null,
                 'dataset_id' => 1,
                 'citation' => "Citation text 2 here.",
-                'pmurl' => null
+                'pmurl' => null,
+                'is_pre_print' => false
             ),
         );
 
@@ -349,6 +359,7 @@ class StoredDatasetConnectionsTest extends CDbTestCase
                 'dataset_id' => 1,
                 'citation' => "Citation text 1 here.",
                 'pmurl' => "http://www.ncbi.nlm.nih.gov/pubmed/23075480",
+                'is_pre_print' => false
             ),
             array(
                 'id' => 2,
@@ -356,7 +367,8 @@ class StoredDatasetConnectionsTest extends CDbTestCase
                 'pmid' => null,
                 'dataset_id' => 1,
                 'citation' => "Citation text 2 here.",
-                'pmurl' => null
+                'pmurl' => null,
+                'is_pre_print' => false
             ),
         );
         $daoUnderTest = new StoredDatasetConnections(


### PR DESCRIPTION
# Pull request for issue: #2236 

based on https://github.com/gigascience/gigadb-website/pull/2249

This is a pull request for the following functionalities:

display pre print manuscript on dataset page

## How to test?

Given I have a dataset with a pre-print manuscripts link
When I navigate to the dataset page
Then I see a section with heading "Read the Pre-print publication(s):"
and that section shows the pre-print manuscript link(s) associated with that dataset

## How have functionalities been implemented?

## Any issues with implementation?

## Any changes to automated tests?

tests updated and acceptance test added

## Any changes to documentation?

## Any technical debt repayment?

the view method in the controller should be rewritten and the logic should be placed in appropriate services

## Any improvements to CI/CD pipeline?
