### PR TITLE
Improves admin dataset table UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #363: Improves admin dataset table UX
+
 ## v4.4.7 - 2025-03-26 - 4c548f037 -
 
 - Fix #2241: Restore Sketchfab visualisations alongside 3D models files visualisations

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -174,10 +174,12 @@ class AdminDatasetController extends Controller
             $model->setAttributes($_GET['Dataset']);
         }
 
+        $dataProvider = $model->search();
+
         $this->loadBaBbqPolyfills = true;
         $this->render('admin', array(
             'model'=>$model,
-            'dataProvider'=>$model->search(),
+            'dataProvider'=>$dataProvider,
         ));
     }
 

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -174,12 +174,10 @@ class AdminDatasetController extends Controller
             $model->setAttributes($_GET['Dataset']);
         }
 
-        $dataProvider = $model->search();
-
         $this->loadBaBbqPolyfills = true;
         $this->render('admin', array(
             'model'=>$model,
-            'dataProvider'=>$dataProvider,
+            'dataProvider'=>$model->search(),
         ));
     }
 

--- a/protected/models/Dataset.php
+++ b/protected/models/Dataset.php
@@ -98,7 +98,7 @@ class Dataset extends CActiveRecord
             array('description, publication_date, modification_date, image_id, fairnuse, types', 'safe'),
             // The following rule is used by search().
             // Please remove those attributes that should not be searched.
-            array('id, manuscript_id, submitter_id, image_id, identifier, title, description, publisher, dataset_size, ftp_site, upload_status, excelfile, excelfile_md5, publication_date, modification_date', 'safe', 'on'=>'search'),
+            array('id, manuscript_id, submitter_id, image_id, identifier, title, description, publisher, dataset_size, ftp_site, upload_status, excelfile, excelfile_md5, publication_date, modification_date, curator_id', 'safe', 'on'=>'search'),
 #            array('projectIDs , sampleIDs , authorIDs , datasetTypeIDs' , 'safe'),
         );
     }
@@ -250,9 +250,26 @@ class Dataset extends CActiveRecord
         $criteria->compare('LOWER(excelfile_md5)',strtolower($this->excelfile_md5),true);
         $criteria->compare('publication_date',$this->publication_date);
         $criteria->compare('modification_date',$this->modification_date);
+        // $criteria->compare('manuscript_id', $this->manuscript_id);
+        $criteria->compare('upload_status', $this->upload_status);
+
+        if (!empty($this->curator_id)) {
+            $criteria->addCondition("exists (
+                select 1 from gigadb_user u
+                where u.id = t.curator_id
+                and lower(concat(coalesce(u.first_name, ''), ' ', coalesce(u.last_name, ''))) like :curator_name
+            )");
+            $criteria->params[':curator_name'] = '%' . strtolower($this->curator_id) . '%';
+        }
+
 
         return new CActiveDataProvider($this, array(
             'criteria'=>$criteria,
+            'sort' => array(
+                'defaultOrder' => array(
+                    'id' => CSort::SORT_DESC
+                ),
+            ),
         ));
     }
 

--- a/protected/models/Dataset.php
+++ b/protected/models/Dataset.php
@@ -250,7 +250,6 @@ class Dataset extends CActiveRecord
         $criteria->compare('LOWER(excelfile_md5)',strtolower($this->excelfile_md5),true);
         $criteria->compare('publication_date',$this->publication_date);
         $criteria->compare('modification_date',$this->modification_date);
-        // $criteria->compare('manuscript_id', $this->manuscript_id);
         $criteria->compare('upload_status', $this->upload_status);
 
         if (!empty($this->curator_id)) {

--- a/protected/views/adminDataset/admin.php
+++ b/protected/views/adminDataset/admin.php
@@ -77,86 +77,86 @@ $('.search-form form').submit(function(){
 	</p>
 
 	<?php $this->widget('CustomGridView', array(
-		'id'=>'dataset-grid',
-    'afterAjaxUpdate' => 'afterAjaxUpdate',
-		'dataProvider'=>$dataProvider,
-		'itemsCssClass'=>"table table-bordered table-fixed dataset-table",
+		'id' => 'dataset-grid',
+        'afterAjaxUpdate' => 'afterAjaxUpdate',
+		'dataProvider' => $dataProvider,
+		'itemsCssClass' => "table table-bordered table-fixed dataset-table",
 		'rowCssClassExpression' => '"dataset-".$data["identifier"]',
-		'filter'=>$model,
-		'columns'=>array(
+		'filter' => $model,
+		'columns' => array(
 			'id',
 			'identifier',
-			'manuscript_id',
-      array(
-        'name' => 'title',
-        'type' => 'raw',
-        'value' => 'Yii::app()->controller->widget("CHtmlPurifier")->purify($data->title)',
-        ),
-			// 'publisher',
-			// 'dataset_size',
-			// 'ftp_site',
-			// 'upload_status',
-			// 'excelfile',
-			// 'excelfile_md5',
-			'publication_date',
-			// array('name'=> 'curator_id', 'value'=>'$data->getCuratorName()'),
-			'modification_date',
 			array(
-				'class'=>'CDataColumn',
-				'header' => "Upload Status",
-				'headerHtmlOptions'=>array('style'=>'width: 150px'),
-				'value'  => '$data->upload_status'
-			),
-			array(
-				'class'=>'CButtonColumn',
-				'header' => "Actions",
-				'headerHtmlOptions'=>array('style'=>'width: 120px'),
-				'template' => '{view}{update}{dropbox}{delete}',
-				'buttons' => array(
-					'view' => array(
-						'imageUrl' => false,
-						'url' => 'Yii::app()->createUrl("dataset/view" , array("id" => $data->identifier))',
-						'label' => '',
-						'options' => array(
-							"title" => "View Dataset",
-							"class" => "fa fa-eye fa-lg icon icon-view",
-							"aria-label" => "View Dataset"
-						),
-					),
-					'update' => array(
-						'imageUrl' => false,
-						'label' => '',
-						'options' => array(
-							"title" => "Update Dataset",
-							"class" => "fa fa-pencil fa-lg icon icon-update",
-							"aria-label" => "Update Dataset"
-						),
-					),
+                'name' => 'manuscript_id',
+                'filter' => false,
+            ),
+            array(
+                'name' => 'title',
+                'type' => 'raw',
+                'value' => 'Yii::app()->controller->widget("CHtmlPurifier")->purify($data->title)',
+            ),
+            'publication_date',
+            array(
+                'name' => 'curator_id',
+                'header' => "Curator",
+                'value' => '$data->getCuratorName()',
+            ),
+            array(
+                'name' => 'upload_status',
+                'header' => "Upload Status",
+                'headerHtmlOptions' => array('style' => 'width: 150px'),
+                'value' => '$data->upload_status',
+            ),
+            array(
+                'class' => 'CButtonColumn',
+                'header' => "Actions",
+                'headerHtmlOptions' => array('style'=>'width: 120px'),
+                'template' => '{view}{update}{dropbox}{delete}',
+                'buttons' => array(
+                    'view' => array(
+                        'imageUrl' => false,
+                        'url' => 'Yii::app()->createUrl("dataset/view" , array("id" => $data->identifier))',
+                        'label' => '',
+                        'options' => array(
+                            "title" => "View Dataset",
+                            "class" => "fa fa-eye fa-lg icon icon-view",
+                            "aria-label" => "View Dataset"
+                        ),
+                    ),
+                    'update' => array(
+                        'imageUrl' => false,
+                        'label' => '',
+                        'options' => array(
+                            "title" => "Update Dataset",
+                            "class" => "fa fa-pencil fa-lg icon icon-update",
+                            "aria-label" => "Update Dataset"
+                        ),
+                    ),
 
-					'delete' => array(
-						'imageUrl' => false,
-						'label' => '',
-						'options' => array(
-							"title" => "Delete Dataset",
-							"class" => "fa fa-trash fa-lg icon icon-delete",
-							"aria-label" => "Delete Dataset"
-						),
-					),
+                    'delete' => array(
+                        'imageUrl' => false,
+                        'label' => '',
+                        'options' => array(
+                            "title" => "Delete Dataset",
+                            "class" => "fa fa-trash fa-lg icon icon-delete",
+                            "aria-label" => "Delete Dataset"
+                        ),
+                    ),
 
-					'dropbox' => array(
-						'imageUrl' => false,
-						'url' => 'Yii::app()->createUrl("adminDataset/assignFTPBox" , array("id" => $data->identifier))',
-						'label' => '',
-						'visible' => '"AssigningFTPbox" === $data->upload_status',
-						'options' => array(
-							'title' => 'New Dropbox for this dataset',
-							"class" => "fa fa-inbox fa-lg icon icon-dropbox",
-							"aria-label" => "New Dropbox for this dataset"
-						),
-					)
+                    'dropbox' => array(
+                        'imageUrl' => false,
+                        'url' => 'Yii::app()->createUrl("adminDataset/assignFTPBox" , array("id" => $data->identifier))',
+                        'label' => '',
+                        'visible' => '"AssigningFTPbox" === $data->upload_status',
+                        'options' => array(
+                            'title' => 'New Dropbox for this dataset',
+                            "class" => "fa fa-inbox fa-lg icon icon-dropbox",
+                            "aria-label" => "New Dropbox for this dataset"
+                        ),
+                    )
 
-				),
-			),
+                ),
+            ),
 		),
 	)); ?>
 

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -435,4 +435,20 @@ class AcceptanceTester extends \Codeception\Actor
     {
         $this->see($text, ['css' => "$table tr:nth-child($row) td:nth-child($column)"]);
     }
+
+    /**
+     * @Then I should see :cssSelector with text :text
+     */
+    public function iShouldSeeCssSelectorWithText($cssSelector, $text)
+    {
+        $this->see($text, ['css' => $cssSelector]);
+    }
+
+    /**
+     * @Then I should not see :cssSelector with text :text
+     */
+    public function iShouldNotSeeCssSelectorWithText($cssSelector, $text)
+    {
+        $this->dontSee($text, ['css' => $cssSelector]);
+    }
 }

--- a/tests/acceptance/AdminDataset.feature
+++ b/tests/acceptance/AdminDataset.feature
@@ -1,0 +1,49 @@
+@ok-can-offline
+Feature: Dataset dashboard
+  As a curator
+  I want the list of datasets to show in a useful way
+  So that I can easily see those datasets relevant to me
+
+  Background:
+    Given I have signed in as admin
+    And I am on "/adminDataset/admin"
+
+  @ok
+  Scenario: Default sorting by ID in descending order
+    Then I should see the table is sorted by column "ID" in the "desc" order
+
+  @ok
+  Scenario: No modification date column
+    Then I should not see "th" with text "Modification date"
+
+  @ok
+  Scenario: Curator column presence
+    Then I should see "th" with text "Curator"
+
+  @ok
+  Scenario: Upload Status column sorting ascending
+    When I follow "Upload Status"
+    And I wait "1" seconds
+    Then I should see the table is sorted by column "Upload Status" in the "asc" order
+
+  @ok
+  Scenario: Curator column sorting ascending
+    When I follow "Curator"
+    And I wait "1" seconds
+    Then I should see the table is sorted by column "Curator" in the "asc" order
+
+  @ok
+  Scenario: Filter by Curator
+    When I fill in the field of "name" "Dataset[curator_id]" with "Chris A"
+    And I press return on the element "(//input)[6]"
+    And I wait "1" seconds
+    Then I should see "tbody td" with text "Chris A"
+    And I should not see "tbody td" with text "C H"
+
+  @ok
+  Scenario: Filter by Upload Status
+    When I fill in the field of "name" "Dataset[upload_status]" with "Published"
+    And I press return on the element "(//input)[7]"
+    And I wait "1" seconds
+    Then I should see "tbody td" with text "Published"
+    And I should not see "tbody td" with text "Unpublished"

--- a/tests/acceptance/AdminDataset.feature
+++ b/tests/acceptance/AdminDataset.feature
@@ -1,4 +1,3 @@
-@ok-can-offline
 Feature: Dataset dashboard
   As a curator
   I want the list of datasets to show in a useful way


### PR DESCRIPTION
# Pull request for issue: #363

This PR improves the curator experience in http://gigadb.gigasciencejournal.com/adminDataset/admin

From the http://gigadb.gigasciencejournal.com/adminDataset/admin page the curator can manage the datasets. This PR changes what table columns are visible, adds search filter functionality to "curator" and "upload status" columns, and sets default sorting order to descending ID

![Screenshot from 2025-05-22 16-21-53](https://github.com/user-attachments/assets/2597289e-2ae4-48f0-8b62-954be759787b)


## How to test?

`docker-compose run --rm codecept run --no-redirect acceptance tests/acceptance/AdminDataset.feature -vv` should pass

## How have functionalities been implemented?

- `protected/views/adminDataset/admin.php`
  - formatted code for consistency
  - added requested data columns and removed unwanted ones
- `protected/models/Dataset.php`
  - added curator_id to the searchable fields
  - made upload status searchable
  - made curator searchable by curator fullname
  - setup default table sorting on page refresh to be desc by id, so that last datasets show up at the top
- `tests/acceptance/AdminDataset.feature`: added acceptance tests for new features

## Any issues with implementation?

--

## Any changes to automated tests?

- `tests/acceptance/AdminDataset.feature` new tests here
- `tests/_support/AcceptanceTester.php` added generic helpers to check text presence in css selector

