### PR TITLE
Add search filters to samples table on a dataset page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ nbproject/project.properties
 tests/fixtures/affiliate_users_credentials
 sql/temp_command.sql
 sql/before-run.pgdmp
+sql/gigadb_gigascience-upstream-gigadb-website_live_*.backup
 test_users.txt
 .php_cs.cache
 phpcs.xml
@@ -115,3 +116,11 @@ params-local.php
 
 # release related artefacts
 VERSION
+
+# Cursor
+.cursor
+.cursorignore
+.cursorindexingignore
+
+# local context for LLMs
+memory-bank

--- a/less/modules/datatables.less
+++ b/less/modules/datatables.less
@@ -17,6 +17,11 @@ table.dataTable thead {
       content: "▼";
     }
   }
+  .table-filters-row {
+    .form-control {
+      width: 100%;
+    }
+  }
 }
 
 #files, #sample {

--- a/protected/components/DatasetPageAssembly.php
+++ b/protected/components/DatasetPageAssembly.php
@@ -344,8 +344,11 @@ class DatasetPageAssembly extends yii\base\Component
      * @param int $pageSize item per page settings
      * @return DatasetPageAssembly
      */
-    public function setDatasetSamples(int $pageSize): DatasetPageAssembly
+    public function setDatasetSamples(int $pageSize, ?array $filters = []): DatasetPageAssembly
     {
+        // TODO handle filters
+        // Yii::log("Filters: " . print_r($filters, true), 'info');
+
         switch($this->_skip_cache) {
             case true:
                 $dataSource = new StoredDatasetSamples(

--- a/protected/controllers/DatasetController.php
+++ b/protected/controllers/DatasetController.php
@@ -53,6 +53,22 @@ class DatasetController extends Controller
 
     public function actionView($id)
     {
+        if (Yii::app()->request->getParam('samples_filter')) {
+            $filters = [];
+            $filterFields = ['sample_id', 'common_name', 'scientific_name', 'attribute', 'taxonomic_id', 'genbank_name'];
+
+            foreach ($filterFields as $field) {
+                $value = Yii::app()->request->getParam($field);
+                if ($value !== null && $value !== '') {
+                    $filters[$field] = $value;
+                }
+            }
+
+            $sampleFilters = $filters;
+        } else {
+            $sampleFilters = [];
+        }
+
         // Retrieving the data
         $model = Dataset::model()->find("identifier=?", array($id));
         $dao = new DatasetDAO(["identifier" => $id]) ;
@@ -103,7 +119,7 @@ class DatasetController extends Controller
                 ->setDatasetConnections()
                 ->setDatasetExternalLinks()
                 ->setDatasetFiles($fileSettings["pageSize"], "stored")
-                ->setDatasetSamples($sampleSettings["pageSize"])
+                ->setDatasetSamples($sampleSettings["pageSize"], $sampleFilters)
                 ->setSearchForm();
 
             // Rendering section

--- a/protected/views/dataset/_sample_panel.php
+++ b/protected/views/dataset/_sample_panel.php
@@ -37,22 +37,58 @@
             </tr>
             <tr class="table-filters-row">
                 <th>
-                    <input data-filter="sample_id" type="text" class="form-control" aria-label="Filter by Sample ID" />
+                    <input
+                        data-filter="sample_id"
+                        type="text"
+                        class="form-control"
+                        aria-label="Filter by Sample ID"
+                        value="<?php echo CHtml::encode(Yii::app()->request->getParam('sample_id', '')); ?>"
+                    />
                 </th>
                 <th>
-                    <input data-filter="common_name" type="text" class="form-control" aria-label="Filter by Common Name" />
+                    <input
+                        data-filter="common_name"
+                        type="text"
+                        class="form-control"
+                        aria-label="Filter by Common Name"
+                        value="<?php echo CHtml::encode(Yii::app()->request->getParam('common_name', '')); ?>"
+                    />
                 </th>
                 <th>
-                    <input data-filter="scientific_name" type="text" class="form-control" aria-label="Filter by Scientific Name" />
+                    <input
+                        data-filter="scientific_name"
+                        type="text"
+                        class="form-control"
+                        aria-label="Filter by Scientific Name"
+                        value="<?php echo CHtml::encode(Yii::app()->request->getParam('scientific_name', '')); ?>"
+                    />
                 </th>
                 <th>
-                    <input data-filter="attribute" type="text" class="form-control" aria-label="Filter by Sample Attributes" />
+                    <input
+                        data-filter="attribute"
+                        type="text"
+                        class="form-control"
+                        aria-label="Filter by Sample Attributes"
+                        value="<?php echo CHtml::encode(Yii::app()->request->getParam('attribute', '')); ?>"
+                    />
                 </th>
                 <th>
-                    <input data-filter="taxonomic_id" type="text" class="form-control" aria-label="Filter by Taxonomic ID" />
+                    <input
+                        data-filter="taxonomic_id"
+                        type="text"
+                        class="form-control"
+                        aria-label="Filter by Taxonomic ID"
+                        value="<?php echo CHtml::encode(Yii::app()->request->getParam('taxonomic_id', '')); ?>"
+                    />
                 </th>
                 <th>
-                    <input data-filter="genbank_name" type="text" class="form-control" aria-label="Filter by Genbank Name" />
+                    <input
+                        data-filter="genbank_name"
+                        type="text"
+                        class="form-control"
+                        aria-label="Filter by Genbank Name"
+                        value="<?php echo CHtml::encode(Yii::app()->request->getParam('genbank_name', '')); ?>"
+                    />
                 </th>
             </tr>
         </thead>
@@ -102,11 +138,14 @@
 ?>
 
 <script>
+    const filterKeys = ['sample_id', 'common_name', 'scientific_name', 'attribute', 'taxonomic_id', 'genbank_name'];
+
     // filter helpers
     function handleFilter() {
         console.log('Enter key pressed on filter input');
         const filterState = getFilterState();
         console.log('Current filter state:', filterState);
+        submitFilters();
     }
 
     function getFilterState() {
@@ -148,10 +187,44 @@
         setFilterState({});
     }
 
+    function submitFilters() {
+        const filterState = getFilterState();
+
+        let url = new URL(window.location.href);
+        url.searchParams.set('samples_filter', 'true');
+
+        Object.entries(filterState).forEach(([key, value]) => {
+            if (value) {
+                url.searchParams.set(key, value);
+            } else {
+                url.searchParams.delete(key);
+            }
+        });
+
+        // submit a GET request to the controller with the filter params (page refresh)
+        window.location.href = url.toString();
+    }
+
+    function initializeFilters() {
+        // the initial values are initialized directly in the inputs, here we only remove the query params to clean up the url, this means that a page refresh resets the filters
+        const url = new URL(window.location.href);
+
+        // this needs to be done in two separate steps
+        const keysToRemove = [...url.searchParams.keys()].filter(key =>
+            [...filterKeys, 'samples_filter'].includes(key)
+        );
+        keysToRemove.forEach(key => {
+            url.searchParams.delete(key);
+        });
+
+        window.history.replaceState({}, '', url.toString());
+    }
+
     // init table
     $(document).ready(function() {
+        initializeFilters();
         $('#samples_table').DataTable({
-            "initComplete": function () {
+            initComplete: function () {
                 $("#samples_table").wrap("<div class='dataset-datatables-wrapper'></div>");
 
                 // Add event listeners for filter inputs
@@ -165,15 +238,15 @@
                     handleFilter();
                 });
             },
-            "paging": false,
-            "ordering": true,
+            paging: false,
+            ordering: true,
             orderCellsTop: true,
-            "info": false,
-            "searching": false,
-            "lengthChange": false,
-            "pageLength": <?php echo $sampleDataProvider->getPagination()->getPageSize() ?>,
-            "pagingType": "simple_numbers",
-            "columns": [{
+            info: false,
+            searching: false,
+            lengthChange: false,
+            pageLength: <?php echo $sampleDataProvider->getPagination()->getPageSize() ?>,
+            pagingType: "simple_numbers",
+            columns: [{
                     "visible": <?php echo in_array('name', $columns) ? 'true' : 'false' ?>
                 },
                 {
@@ -197,12 +270,12 @@
 
         // pagination
         function onPageChange() {
-        const params = {
-            maxPage: <?php echo $sampleDataProvider->getPagination()->getPageCount() ?>,
-            targetPageNumber: document.getElementById('samplesPageInput').value,
-            pathPart: 'Samples_page'
-        }
-        goToPage(params);
+            const params = {
+                maxPage: <?php echo $sampleDataProvider->getPagination()->getPageCount() ?>,
+                targetPageNumber: document.getElementById('samplesPageInput').value,
+                pathPart: 'Samples_page'
+            }
+            goToPage(params);
         }
 
         function onPageInputKeyPress(event) {

--- a/protected/views/dataset/_sample_panel.php
+++ b/protected/views/dataset/_sample_panel.php
@@ -1,0 +1,185 @@
+<?php
+
+    /**
+     * @var $sampleDataProvider
+     * @var $model
+     * @var $columns
+     */
+
+    $samplesPerPage = $sampleDataProvider->getItemCount();
+    $totalNbSamples = $sampleDataProvider->getTotalItemCount();
+
+    if (count($model->samples) > 0) {
+    ?>
+
+<div role="tabpanel" class="tab-pane active" id="sample">
+    <p class="pull-left">
+    Click on a table column to sort the results.
+    </p>
+    <div class="btns-row btns-row-end">
+        <button id="clear_samples_filters" class="btn btn-default" type="button">
+            <span class="glyphicon glyphicon-remove"></span> Clear All Filters
+        </button>
+        <a id="samples_table_settings" class="btn btn-default" data-toggle="modal" data-target="#samples_settings" href="#">
+            <span class="glyphicon glyphicon-adjust"></span>Table Settings
+        </a>
+    </div>
+    <div class="clearfix"></div>
+    <table id="samples_table" class="table table-striped table-bordered" style="width:100%">
+        <thead>
+            <tr class="table-headers-row">
+                <th scope="col" title="User-specified name or identifier of the sample object. Note: a DNA sample and an RNA sample from the same donor are classed as two separate samples." style="width: 100px;">Sample ID</th>
+                <th scope="col" title="A well recognized commonly used name of the species, usually this is a synonym held in the NCBI taxonomy for the tax ID provided.">Common Name</th>
+                <th scope="col" title="The scientific binomial name of the species, usually this is in direct accordance with the NCBI taxonomy ID provided.">Scientific Name</th>
+                <th scope="col" title="This is a list of Key:Value pairs, where the Keys are from our Attributes list, and the Value is the specific value for the sample. See our metadata guide for the Attributes list with definitions of all available attributes.">Sample Attributes</th>
+                <th scope="col" title="Species taxonomy ID of the sampled species, we currently use the NCBI taxonomy as the source of this identifier.">Taxonomic ID</th>
+                <th scope="col" title="The preferred display name used by NCBI taxonomy for the tax ID provided">Genbank Name</th>
+            </tr>
+            <tr class="table-filters-row">
+                <th>
+                    <input type="text" class="form-control" aria-label="Filter by Sample ID" />
+                </th>
+                <th>
+                    <input type="text" class="form-control" aria-label="Filter by Common Name" />
+                </th>
+                <th>
+                    <input type="text" class="form-control" aria-label="Filter by Scientific Name" />
+                </th>
+                <th>
+                    <input type="text" class="form-control" aria-label="Filter by Sample Attributes" />
+                </th>
+                <th>
+                    <input type="text" class="form-control" aria-label="Filter by Taxonomic ID" />
+                </th>
+                <th>
+                    <input type="text" class="form-control" aria-label="Filter by Genbank Name" />
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php $sample_models = $sampleDataProvider->getData();
+
+                foreach ($sample_models as $sample) {?>
+                <tr>
+                    <td><?php echo $sample['linkName'] ?></td>
+                    <td><?php echo $sample['common_name'] ?></td>
+                    <td><?php echo $sample['scientific_name'] ?></td>
+                    <td><?php echo $sample['displayAttr'] ?></td>
+                    <td><?php echo $sample['taxonomy_link'] ?></td>
+                    <td><?php echo $sample['genbank_name'] ?></td>
+                </tr>
+            <?php }?>
+
+        </tbody>
+    </table>
+    <div class="table-footer">
+        <?php
+            if ($samplesPerPage != $totalNbSamples) {
+                ?>
+        <div class="pagination-wrapper">
+        <?
+            $this->widget('SiteLinkPager', array(
+                'id' => 'samples-pager',
+                'pages' => $sampleDataProvider->getPagination(),
+            ));
+        ?>
+        <div class="page-selector">
+        <button class="btn background-btn-o" id="samplesPageButton" onclick="onPageChange()">Go to page</button>
+        <input type="number" id="samplesPageInput" class="page_box" onkeypress="onPageInputKeyPress(event)" min="1" max="<?php echo $sampleDataProvider->getPagination()->getPageCount() ?>" aria-label="Enter page number">
+        <span class="page-selector-label"> of           <?php echo $sampleDataProvider->getPagination()->getPageCount() ?></span>
+        </div>
+        </div>
+        <?php
+            }
+            ?>
+        <div class="pull-right">
+            <div class="summary">Displaying <?php echo $samplesPerPage ?> samples of <?php echo $totalNbSamples ?></div>
+        </div>
+    </div>
+</div>
+<?php
+    }
+?>
+
+<script>
+    function handleFilter() {
+        console.log('Enter key pressed on filter input');
+        const filterState = getFilterState();
+        console.log('Current filter state:', filterState);
+    }
+
+    function getFilterState() {
+        const filterState = {};
+        $('.table-filters-row input').each(function() {
+            const input = $(this);
+            const filterType = input.attr('aria-label').replace('Filter by ', '').toLowerCase()
+                .replace(/\s+/g, '');
+            filterState[filterType] = input.val();
+        });
+        return filterState;
+    }
+
+    function onPageChange() {
+        const params = {
+            maxPage: <?php echo $sampleDataProvider->getPagination()->getPageCount() ?>,
+            targetPageNumber: document.getElementById('samplesPageInput').value,
+            pathPart: 'Samples_page'
+        }
+        goToPage(params);
+    }
+
+    function onPageInputKeyPress(event) {
+        const isEnter =  event.which === 13 || event.keyCode === 13 || event.key === "Enter"
+        if (isEnter) {
+            onPageChange();
+        }
+    }
+
+    $(document).ready(function() {
+        $('#samples_table').DataTable({
+            "initComplete": function () {
+                $("#samples_table").wrap("<div class='dataset-datatables-wrapper'></div>");
+
+                // Add event listeners for filter inputs
+                $('.table-filters-row input').on('keypress', function(e) {
+                    if (e.which === 13 || e.keyCode === 13) {
+                        handleFilter();
+                    }
+                });
+
+                $('.table-filters-row input').on('blur', function() {
+                    handleFilter();
+                });
+            },
+            "paging": false,
+            "ordering": true,
+            orderCellsTop: true,
+            "info": false,
+            "searching": false,
+            "lengthChange": false,
+            "pageLength": <?php echo $sampleDataProvider->getPagination()->getPageSize() ?>,
+            "pagingType": "simple_numbers",
+            "columns": [{
+                    "visible": <?php echo in_array('name', $columns) ? 'true' : 'false' ?>
+                },
+                {
+                    "visible": <?php echo in_array('common_name', $columns) ? 'true' : 'false' ?>
+                },
+                {
+                    "visible": <?php echo in_array('scientific_name', $columns) ? 'true' : 'false' ?>
+                },
+                {
+                    "visible": <?php echo in_array('attribute', $columns) ? 'true' : 'false' ?>
+                },
+                {
+                    "visible": <?php echo in_array('taxonomic_id', $columns) ? 'true' : 'false' ?>
+                },
+                {
+                    "visible": <?php echo in_array('genbank_name', $columns) ? 'true' : 'false' ?>
+                },
+            ]
+        });
+
+
+    });
+</script>

--- a/protected/views/dataset/_sample_panel.php
+++ b/protected/views/dataset/_sample_panel.php
@@ -17,7 +17,7 @@
     Click on a table column to sort the results.
     </p>
     <div class="btns-row btns-row-end">
-        <button id="clear_samples_filters" class="btn btn-default" type="button">
+        <button id="clear_samples_filters" class="btn btn-default" type="button" onClick="clearFilters()">
             <span class="glyphicon glyphicon-remove"></span> Clear All Filters
         </button>
         <a id="samples_table_settings" class="btn btn-default" data-toggle="modal" data-target="#samples_settings" href="#">
@@ -37,22 +37,22 @@
             </tr>
             <tr class="table-filters-row">
                 <th>
-                    <input type="text" class="form-control" aria-label="Filter by Sample ID" />
+                    <input id="sample_id_filter" type="text" class="form-control" aria-label="Filter by Sample ID" />
                 </th>
                 <th>
-                    <input type="text" class="form-control" aria-label="Filter by Common Name" />
+                    <input id="common_name_filter" type="text" class="form-control" aria-label="Filter by Common Name" />
                 </th>
                 <th>
-                    <input type="text" class="form-control" aria-label="Filter by Scientific Name" />
+                    <input id="scientific_name_filter" type="text" class="form-control" aria-label="Filter by Scientific Name" />
                 </th>
                 <th>
-                    <input type="text" class="form-control" aria-label="Filter by Sample Attributes" />
+                    <input id="attribute_filter" type="text" class="form-control" aria-label="Filter by Sample Attributes" />
                 </th>
                 <th>
-                    <input type="text" class="form-control" aria-label="Filter by Taxonomic ID" />
+                    <input id="taxonomic_id_filter" type="text" class="form-control" aria-label="Filter by Taxonomic ID" />
                 </th>
                 <th>
-                    <input type="text" class="form-control" aria-label="Filter by Genbank Name" />
+                    <input id="genbank_name_filter" type="text" class="form-control" aria-label="Filter by Genbank Name" />
                 </th>
             </tr>
         </thead>
@@ -102,6 +102,7 @@
 ?>
 
 <script>
+    // filters
     function handleFilter() {
         console.log('Enter key pressed on filter input');
         const filterState = getFilterState();
@@ -112,29 +113,28 @@
         const filterState = {};
         $('.table-filters-row input').each(function() {
             const input = $(this);
-            const filterType = input.attr('aria-label').replace('Filter by ', '').toLowerCase()
-                .replace(/\s+/g, '');
+            const filterType = input.attr('id').replace('filter-', '');
             filterState[filterType] = input.val();
         });
         return filterState;
     }
 
-    function onPageChange() {
-        const params = {
-            maxPage: <?php echo $sampleDataProvider->getPagination()->getPageCount() ?>,
-            targetPageNumber: document.getElementById('samplesPageInput').value,
-            pathPart: 'Samples_page'
-        }
-        goToPage(params);
+    function setFilterState(newFilterState) {
+        $('.table-filters-row input').each(function() {
+            const input = $(this);
+            const filterType = input.attr('id');
+            const value = newFilterState[filterType] || '';
+            input.val(value);
+        });
+        console.log('Filter state set:', getFilterState());
     }
 
-    function onPageInputKeyPress(event) {
-        const isEnter =  event.which === 13 || event.keyCode === 13 || event.key === "Enter"
-        if (isEnter) {
-            onPageChange();
-        }
+    function clearFilters() {
+        console.log('Clearing filters');
+        setFilterState({});
     }
 
+    // init table
     $(document).ready(function() {
         $('#samples_table').DataTable({
             "initComplete": function () {
@@ -142,11 +142,11 @@
 
                 // Add event listeners for filter inputs
                 $('.table-filters-row input').on('keypress', function(e) {
-                    if (e.which === 13 || e.keyCode === 13) {
+                    const isEnter =  e.which === 13 || e.keyCode === 13 || e.key === "Enter"
+                    if (isEnter) {
                         handleFilter();
                     }
                 });
-
                 $('.table-filters-row input').on('blur', function() {
                     handleFilter();
                 });
@@ -181,5 +181,21 @@
         });
 
 
+        // pagination
+        function onPageChange() {
+        const params = {
+            maxPage: <?php echo $sampleDataProvider->getPagination()->getPageCount() ?>,
+            targetPageNumber: document.getElementById('samplesPageInput').value,
+            pathPart: 'Samples_page'
+        }
+        goToPage(params);
+        }
+
+        function onPageInputKeyPress(event) {
+            const isEnter =  event.which === 13 || event.keyCode === 13 || event.key === "Enter"
+            if (isEnter) {
+                onPageChange();
+            }
+        }
     });
 </script>

--- a/protected/views/dataset/_sample_panel.php
+++ b/protected/views/dataset/_sample_panel.php
@@ -37,22 +37,22 @@
             </tr>
             <tr class="table-filters-row">
                 <th>
-                    <input id="sample_id_filter" type="text" class="form-control" aria-label="Filter by Sample ID" />
+                    <input data-filter="sample_id" type="text" class="form-control" aria-label="Filter by Sample ID" />
                 </th>
                 <th>
-                    <input id="common_name_filter" type="text" class="form-control" aria-label="Filter by Common Name" />
+                    <input data-filter="common_name" type="text" class="form-control" aria-label="Filter by Common Name" />
                 </th>
                 <th>
-                    <input id="scientific_name_filter" type="text" class="form-control" aria-label="Filter by Scientific Name" />
+                    <input data-filter="scientific_name" type="text" class="form-control" aria-label="Filter by Scientific Name" />
                 </th>
                 <th>
-                    <input id="attribute_filter" type="text" class="form-control" aria-label="Filter by Sample Attributes" />
+                    <input data-filter="attribute" type="text" class="form-control" aria-label="Filter by Sample Attributes" />
                 </th>
                 <th>
-                    <input id="taxonomic_id_filter" type="text" class="form-control" aria-label="Filter by Taxonomic ID" />
+                    <input data-filter="taxonomic_id" type="text" class="form-control" aria-label="Filter by Taxonomic ID" />
                 </th>
                 <th>
-                    <input id="genbank_name_filter" type="text" class="form-control" aria-label="Filter by Genbank Name" />
+                    <input data-filter="genbank_name" type="text" class="form-control" aria-label="Filter by Genbank Name" />
                 </th>
             </tr>
         </thead>
@@ -102,7 +102,7 @@
 ?>
 
 <script>
-    // filters
+    // filter helpers
     function handleFilter() {
         console.log('Enter key pressed on filter input');
         const filterState = getFilterState();
@@ -113,16 +113,30 @@
         const filterState = {};
         $('.table-filters-row input').each(function() {
             const input = $(this);
-            const filterType = input.attr('id').replace('filter-', '');
+            const filterType = input.attr('data-filter');
             filterState[filterType] = input.val();
         });
         return filterState;
     }
 
+    /**
+     * Set filter input values programmatically
+     * @param {Object} newFilterState - The new filter state to set
+     * @example
+     * setFilterState({
+     *     sample_id: '123',
+     *     common_name: 'Dog',
+     *     scientific_name: 'Canis lupus familiaris',
+     *     attribute: 'color:brown',
+     *     taxonomic_id: '9606',
+     *     genbank_name: 'NC_000001.10'
+     * });
+     * if a property is not provided, it is set to an empty string
+     */
     function setFilterState(newFilterState) {
         $('.table-filters-row input').each(function() {
             const input = $(this);
-            const filterType = input.attr('id');
+            const filterType = input.attr('data-filter');
             const value = newFilterState[filterType] || '';
             input.val(value);
         });

--- a/protected/views/dataset/view.php
+++ b/protected/views/dataset/view.php
@@ -702,6 +702,21 @@ $sampleDataProvider = $samples->getDataProvider();
                 $('#samples_table').DataTable({
                     "initComplete": function () {
                         $("#samples_table").wrap("<div class='dataset-datatables-wrapper'></div>");
+
+                        function handleFilter() {
+                            console.log('Enter key pressed on filter input');
+                        }
+
+                        // Add event listeners for filter inputs
+                        $('.table-filters-row input').on('keypress', function(e) {
+                            if (e.which === 13 || e.keyCode === 13) {
+                                handleFilter();
+                            }
+                        });
+
+                        $('.table-filters-row input').on('blur', function() {
+                            handleFilter();
+                        });
                     },
                     "paging": false,
                     "ordering": true,

--- a/protected/views/dataset/view.php
+++ b/protected/views/dataset/view.php
@@ -323,13 +323,33 @@ $sampleDataProvider = $samples->getDataProvider();
                             <a id="samples_table_settings" class="btn btn-default pull-right" data-toggle="modal" data-target="#samples_settings" href="#"><span class="glyphicon glyphicon-adjust"></span>Table Settings</a>
                             <table id="samples_table" class="table table-striped table-bordered" style="width:100%">
                                 <thead>
-                                    <tr>
-                                        <th title="User-specified name or identifier of the sample object. Note: a DNA sample and an RNA sample from the same donor are classed as two separate samples.">Sample ID</th>
-                                        <th title="A well recognized commonly used name of the species, usually this is a synonym held in the NCBI taxonomy for the tax ID provided.">Common Name</th>
-                                        <th title="The scientific binomial name of the species, usually this is in direct accordance with the NCBI taxonomy ID provided.">Scientific Name</th>
-                                        <th title="This is a list of Key:Value pairs, where the Keys are from our Attributes list, and the Value is the specific value for the sample. See our metadata guide for the Attributes list with definitions of all available attributes.">Sample Attributes</th>
-                                        <th title="Species taxonomy ID of the sampled species, we currently use the NCBI taxonomy as the source of this identifier.">Taxonomic ID</th>
-                                        <th title="The preferred display name used by NCBI taxonomy for the tax ID provided">Genbank Name</th>
+                                    <tr class="table-headers-row">
+                                        <th scope="col" title="User-specified name or identifier of the sample object. Note: a DNA sample and an RNA sample from the same donor are classed as two separate samples." style="width: 100px;">Sample ID</th>
+                                        <th scope="col" title="A well recognized commonly used name of the species, usually this is a synonym held in the NCBI taxonomy for the tax ID provided.">Common Name</th>
+                                        <th scope="col" title="The scientific binomial name of the species, usually this is in direct accordance with the NCBI taxonomy ID provided.">Scientific Name</th>
+                                        <th scope="col" title="This is a list of Key:Value pairs, where the Keys are from our Attributes list, and the Value is the specific value for the sample. See our metadata guide for the Attributes list with definitions of all available attributes.">Sample Attributes</th>
+                                        <th scope="col" title="Species taxonomy ID of the sampled species, we currently use the NCBI taxonomy as the source of this identifier.">Taxonomic ID</th>
+                                        <th scope="col" title="The preferred display name used by NCBI taxonomy for the tax ID provided">Genbank Name</th>
+                                    </tr>
+                                    <tr class="table-filters-row">
+                                        <th>
+                                            <input type="text" class="form-control" aria-label="Filter by Sample ID" />
+                                        </th>
+                                        <th>
+                                            <input type="text" class="form-control" aria-label="Filter by Common Name" />
+                                        </th>
+                                        <th>
+                                            <input type="text" class="form-control" aria-label="Filter by Scientific Name" />
+                                        </th>
+                                        <th>
+                                            <input type="text" class="form-control" aria-label="Filter by Sample Attributes" />
+                                        </th>
+                                        <th>
+                                            <input type="text" class="form-control" aria-label="Filter by Taxonomic ID" />
+                                        </th>
+                                        <th>
+                                            <input type="text" class="form-control" aria-label="Filter by Genbank Name" />
+                                        </th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -672,8 +692,12 @@ $sampleDataProvider = $samples->getDataProvider();
                 }
 
                 $('#samples_table').DataTable({
+                    "initComplete": function () {
+                        $("#samples_table").wrap("<div class='dataset-datatables-wrapper'></div>");
+                    },
                     "paging": false,
                     "ordering": true,
+                    orderCellsTop: true,
                     "info": false,
                     "searching": false,
                     "lengthChange": false,

--- a/protected/views/dataset/view.php
+++ b/protected/views/dataset/view.php
@@ -834,13 +834,10 @@ $sampleDataProvider = $samples->getDataProvider();
         }
 
         if (_userInput >= _min && _userInput <= _max) {
-          console.log("Valid page number!");
           return _userInput;
         } else if (_userInput > _max) {
-          console.log("Error, return to " + _max);
           return _max;
         } else if (_userInput < _min) {
-          console.log("Error, return to " + _min);
           return _min;
         }
       }

--- a/protected/views/dataset/view.php
+++ b/protected/views/dataset/view.php
@@ -310,100 +310,14 @@ $sampleDataProvider = $samples->getDataProvider();
                 <div class="tab-content dataset-tab-content">
                 <?php
                     if ($sampleDataProvider->getTotalItemCount() > 0) {
-                        $samplesPerPage = $sampleDataProvider->getItemCount();
-                        $totalNbSamples = $sampleDataProvider->getTotalItemCount();
 
                         if (count($model->samples) > 0) {
-                    ?>
-                        <div role="tabpanel" class="tab-pane active" id="sample">
-
-                            <p class="pull-left">
-                              Click on a table column to sort the results.
-                            </p>
-                            <div class="btns-row btns-row-end">
-                                <button id="clear_samples_filters" class="btn btn-default" type="button">
-                                    <span class="glyphicon glyphicon-remove"></span> Clear All Filters
-                                </button>
-                                <a id="samples_table_settings" class="btn btn-default" data-toggle="modal" data-target="#samples_settings" href="#">
-                                    <span class="glyphicon glyphicon-adjust"></span>Table Settings
-                                </a>
-                            </div>
-                            <div class="clearfix"></div>
-                            <table id="samples_table" class="table table-striped table-bordered" style="width:100%">
-                                <thead>
-                                    <tr class="table-headers-row">
-                                        <th scope="col" title="User-specified name or identifier of the sample object. Note: a DNA sample and an RNA sample from the same donor are classed as two separate samples." style="width: 100px;">Sample ID</th>
-                                        <th scope="col" title="A well recognized commonly used name of the species, usually this is a synonym held in the NCBI taxonomy for the tax ID provided.">Common Name</th>
-                                        <th scope="col" title="The scientific binomial name of the species, usually this is in direct accordance with the NCBI taxonomy ID provided.">Scientific Name</th>
-                                        <th scope="col" title="This is a list of Key:Value pairs, where the Keys are from our Attributes list, and the Value is the specific value for the sample. See our metadata guide for the Attributes list with definitions of all available attributes.">Sample Attributes</th>
-                                        <th scope="col" title="Species taxonomy ID of the sampled species, we currently use the NCBI taxonomy as the source of this identifier.">Taxonomic ID</th>
-                                        <th scope="col" title="The preferred display name used by NCBI taxonomy for the tax ID provided">Genbank Name</th>
-                                    </tr>
-                                    <tr class="table-filters-row">
-                                        <th>
-                                            <input type="text" class="form-control" aria-label="Filter by Sample ID" />
-                                        </th>
-                                        <th>
-                                            <input type="text" class="form-control" aria-label="Filter by Common Name" />
-                                        </th>
-                                        <th>
-                                            <input type="text" class="form-control" aria-label="Filter by Scientific Name" />
-                                        </th>
-                                        <th>
-                                            <input type="text" class="form-control" aria-label="Filter by Sample Attributes" />
-                                        </th>
-                                        <th>
-                                            <input type="text" class="form-control" aria-label="Filter by Taxonomic ID" />
-                                        </th>
-                                        <th>
-                                            <input type="text" class="form-control" aria-label="Filter by Genbank Name" />
-                                        </th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <?php $sample_models = $sampleDataProvider->getData();
-
-                                    foreach ($sample_models as $sample) { ?>
-                                        <tr>
-                                            <td><?= $sample['linkName'] ?></td>
-                                            <td><?= $sample['common_name'] ?></td>
-                                            <td><?= $sample['scientific_name'] ?></td>
-                                            <td><?= $sample['displayAttr'] ?></td>
-                                            <td><?= $sample['taxonomy_link'] ?></td>
-                                            <td><?= $sample['genbank_name'] ?></td>
-                                        </tr>
-                                    <?php } ?>
-
-                                </tbody>
-                            </table>
-                            <div class="table-footer">
-                                <?php
-                                if ($samplesPerPage <> $totalNbSamples) {
-                                  ?>
-                                  <div class="pagination-wrapper">
-                                  <?
-                                    $this->widget('SiteLinkPager', array(
-                                        'id' => 'samples-pager',
-                                        'pages' => $sampleDataProvider->getPagination(),
-                                    ));
-                                ?>
-                                <div class="page-selector">
-                                  <button class="btn background-btn-o" id="samplesPageButton" onclick="goToSamplesPage()">Go to page</button>
-                                  <input type="number" id="samplesPageInput" class="page_box" onkeypress="detectEnterKeyPress(event)" min="1" max="<?= $sampleDataProvider->getPagination()->getPageCount() ?>" aria-label="Enter page number">
-                                  <span class="page-selector-label"> of <?php echo $sampleDataProvider->getPagination()->getPageCount() ?></span>
-                                </div>
-                                </div>
-                                <?php
-                              }
-                              ?>
-                                <div class="pull-right">
-                                    <div class="summary">Displaying <?php echo $samplesPerPage ?> samples of <?php echo $totalNbSamples ?></div>
-                                </div>
-                                </div>
-
-                        </div>
-                    <?php
-                      }
+                            $this->renderPartial('_sample_panel', array(
+                                'sampleDataProvider' => $sampleDataProvider,
+                                'model' => $model,
+                                'columns' => $columns
+                            ));
+                        }
                     }
                     ?>
                     <?php
@@ -479,7 +393,7 @@ $sampleDataProvider = $samples->getDataProvider();
                                 ?>
                                 <div class="page-selector">
                                   <button class="btn background-btn-o" id="filesPageButton" onclick="goToFilesPage()">Go to page</button>
-                                  <input type="number" id="filesPageInput" class="page_box" onkeypress="detectEnterKeyPress(event)" min="1" max="<?= $fileDataProvider->getPagination()->getPageCount() ?>" aria-label="Enter page number">
+                                  <input type="number" id="filesPageInput" class="page_box" onkeypress="handleEnterKeyPress(event)" min="1" max="<?= $fileDataProvider->getPagination()->getPageCount() ?>" aria-label="Enter page number">
                                   <span class="page-selector-label"> of <?php echo $fileDataProvider->getPagination()->getPageCount() ?></span>
                                 </div>
                                 </div>
@@ -699,54 +613,7 @@ $sampleDataProvider = $samples->getDataProvider();
                     }
                 }
 
-                $('#samples_table').DataTable({
-                    "initComplete": function () {
-                        $("#samples_table").wrap("<div class='dataset-datatables-wrapper'></div>");
-
-                        function handleFilter() {
-                            console.log('Enter key pressed on filter input');
-                        }
-
-                        // Add event listeners for filter inputs
-                        $('.table-filters-row input').on('keypress', function(e) {
-                            if (e.which === 13 || e.keyCode === 13) {
-                                handleFilter();
-                            }
-                        });
-
-                        $('.table-filters-row input').on('blur', function() {
-                            handleFilter();
-                        });
-                    },
-                    "paging": false,
-                    "ordering": true,
-                    orderCellsTop: true,
-                    "info": false,
-                    "searching": false,
-                    "lengthChange": false,
-                    "pageLength": <?= $sampleDataProvider->getPagination()->getPageSize() ?>,
-                    "pagingType": "simple_numbers",
-                    "columns": [{
-                            "visible": <?= in_array('name', $columns) ? 'true' : 'false' ?>
-                        },
-                        {
-                            "visible": <?= in_array('common_name', $columns) ? 'true' : 'false' ?>
-                        },
-                        {
-                            "visible": <?= in_array('scientific_name', $columns) ? 'true' : 'false' ?>
-                        },
-                        {
-                            "visible": <?= in_array('attribute', $columns) ? 'true' : 'false' ?>
-                        },
-                        {
-                            "visible": <?= in_array('taxonomic_id', $columns) ? 'true' : 'false' ?>
-                        },
-                        {
-                            "visible": <?= in_array('genbank_name', $columns) ? 'true' : 'false' ?>
-                        },
-                    ]
-                });
-
+        // order file size column by bytes not by string
         $.fn.dataTable.ext.type.order['file-size-pre'] = function(data) {
             const units = {
                 'B': 1,
@@ -942,35 +809,15 @@ $sampleDataProvider = $samples->getDataProvider();
         });
     </script>
     <script>
-      function handleInitFilesPage() {
-          let currentPageNumber = 1;
-
-          const match = window.location.pathname.match(/Files_page\/(\d+)/);
-          if (match && match[1]) {
-              currentPageNumber = parseInt(match[1], 10);
-          }
-
-          $('#pageNumber').val(currentPageNumber);
-      }
-      function handleInitSamplesPage() {
-          let currentPageNumber = 1;
-
-          const match = window.location.pathname.match(/Samples_page\/(\d+)/);
-          if (match && match[1]) {
-              currentPageNumber = parseInt(match[1], 10);
-          }
-
-          $('#pageNumber').val(currentPageNumber);
-      }
       function handleInitPagination() {
-          let currentPageNumber = 1;
+        let currentPageNumber = 1;
 
-          const match = window.location.pathname.match(/Files_page\/(\d+)/);
-          if (match && match[1]) {
-              currentPageNumber = parseInt(match[1], 10);
-          }
+        const match = window.location.pathname.match(/Files_page\/(\d+)/);
+        if (match && match[1]) {
+            currentPageNumber = parseInt(match[1], 10);
+        }
 
-          $('#pageNumber').val(currentPageNumber);
+        $('#pageNumber').val(currentPageNumber);
       }
 
       function isNumber(value) {
@@ -998,42 +845,41 @@ $sampleDataProvider = $samples->getDataProvider();
         }
       }
 
-      function goToFilesPage() {
-        const pageID = <?php echo $model->identifier ?>;
-        //To validate page number
-        const max = <?php echo $fileDataProvider->getPagination()->getPageCount() ?>;
-        const min = 1;
-        let targetPageNumber = document.getElementById("filesPageInput").value;
-        const userInput = parseInt(targetPageNumber);
-        const targetUrlArray = ["", "dataset", "view", "id", pageID];
+            /**
+       * @param {Object} params
+       * @param {number} params.maxPage - The maximum page number
+       * @param {number} params.targetPageNumber - The page number to navigate to
+       * @param {string} params.pathPart - The part of the path to append to the URL
+       */
+      function goToPage(params) {
+        const { maxPage, targetPageNumber, pathPart } = params
 
-        targetUrlArray.push('Files_page', computePageNumber(userInput, min, max));
-        window.location = window.location.origin + targetUrlArray.join("/");
-      }
-
-      function goToSamplesPage() {
-        const pageID = <?php echo $model->identifier ?>;
-        //To validate page number
-        const max = <?php echo $sampleDataProvider->getPagination()->getPageCount() ?>;
-        const min = 1;
-        let targetPageNumber = document.getElementById("samplesPageInput").value;
-        const userInput = parseInt(targetPageNumber);
-        const targetUrlArray = ["", "dataset", "view", "id", pageID];
-
-        targetUrlArray.push('Samples_page', computePageNumber(userInput, min, max));
-        window.location = window.location.origin + targetUrlArray.join("/");
-      }
-
-      function detectEnterKeyPress(event) {
-        const validIds = ["filesPageInput", "samplesPageInput"];
-        const id = event.target.id;
-
-        if (!validIds.includes(id)) {
-          return
+        if (!maxPage || !targetPageNumber || !pathPart) {
+            console.error("goToPage: Missing required parameters");
+            return;
         }
 
+        const minPage = 1;
+        const pageId = <?php echo $model->identifier ?>;
+        const userInput = parseInt(targetPageNumber);
+        const targetUrlArray = ["", "dataset", "view", "id", pageId];
+
+        targetUrlArray.push(pathPart, computePageNumber(userInput, minPage, maxPage));
+        window.location = window.location.origin + targetUrlArray.join("/");
+      }
+
+      function goToFilesPage() {
+        const params = {
+            maxPage: <?php echo $fileDataProvider->getPagination()->getPageCount() ?>,
+            targetPageNumber: document.getElementById('filesPageInput').value,
+            pathPart: 'Files_page'
+        }
+        goToPage(params);
+      }
+
+      function handleEnterKeyPress(event) {
         if (event.which === 13 || event.keyCode === 13 || event.key === "Enter") {
-          id === "filesPageInput" ? goToFilesPage() : goToSamplesPage();
+            goToFilesPage()
         }
       }
 

--- a/protected/views/dataset/view.php
+++ b/protected/views/dataset/view.php
@@ -320,7 +320,15 @@ $sampleDataProvider = $samples->getDataProvider();
                             <p class="pull-left">
                               Click on a table column to sort the results.
                             </p>
-                            <a id="samples_table_settings" class="btn btn-default pull-right" data-toggle="modal" data-target="#samples_settings" href="#"><span class="glyphicon glyphicon-adjust"></span>Table Settings</a>
+                            <div class="btns-row btns-row-end">
+                                <button id="clear_samples_filters" class="btn btn-default" type="button">
+                                    <span class="glyphicon glyphicon-remove"></span> Clear All Filters
+                                </button>
+                                <a id="samples_table_settings" class="btn btn-default" data-toggle="modal" data-target="#samples_settings" href="#">
+                                    <span class="glyphicon glyphicon-adjust"></span>Table Settings
+                                </a>
+                            </div>
+                            <div class="clearfix"></div>
                             <table id="samples_table" class="table table-striped table-bordered" style="width:100%">
                                 <thead>
                                     <tr class="table-headers-row">


### PR DESCRIPTION
# Pull request for issue: #1156

- this PR adds column filters to the dataset samples table
- refactor: samples panel has been moved to a separate table for better modularity
- hefty backend work required to filter samples

## How to test?

TODO

## How have functionalities been implemented?

- Refactor samples panel into separate partial
- Small refactor of pagination script to adapt to new partial
- add new row to table with filter inputs
- "AND" filter logic
- add dynamic filtering via script:
  - clean filters via button click
  - submit filters to controller on blur and on enter
  - on page refresh any filters are cleared (reset), this behavior can be changed*
- to handle filter submission:
  - a new url is created, with a url param for each active filter
  - browser is refreshed with new url with filter params
  - controller intercepts request and retrieves filter params from URL
  - controller submits active filters to dataset assembly
  - next step would be to use a SQL query to filter datasets in the appropriate place, this is not yet done
  - the controller sends response to the client
  - the filter input values are set from the url, the client cleans up the url params via script

* if we want to keep active filter state on user triggered page refresh, probably the most reasonable is to use URL query params. An alternative would be using pathname, but if multiple filters are allowed, it might become cumbersome, and it will also generate a huge number of URLs that might be indexed by google and dilute SEO, if not properly setup. URL query params sounds like the most reasonable

## Any issues with implementation?

A significant amount of backend work required to make this work

## Any changes to automated tests?

TODO