### PR TITLE
Prevent overflowing unbroken words in curation log table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #2262: Prevent overflowing unbroken words in curation log table
+
 ## v4.4.8 - 2025-04-08 - 01de0477b -
 
 - Fix #2033: Create a mockup for all upload statuses except published

--- a/less/modules/tables.less
+++ b/less/modules/tables.less
@@ -248,3 +248,13 @@ table.dataset-view-table > tbody > tr {
     margin-top: 5px;
   }
 }
+
+// prevent table overflowing cells with very long words without breaks (e.g. long URLs)
+table.table-fixed {
+  table-layout: fixed;
+  width: 100%;
+  border-collapse: collapse;
+  th, td {
+    overflow-wrap: break-word;
+  }
+}

--- a/protected/views/adminDataset/curationLog.php
+++ b/protected/views/adminDataset/curationLog.php
@@ -27,7 +27,7 @@ $this->widget(
 
                         return $data->comments;
                     },
-                    'headerHtmlOptions' => array('style' => 'width: 300px'),
+                    'headerHtmlOptions' => array('style' => 'width: 30%'),
             ],
             'last_modified_date',
             'last_modified_by',

--- a/protected/views/adminDataset/curationLog.php
+++ b/protected/views/adminDataset/curationLog.php
@@ -11,7 +11,7 @@ $this->widget(
     [
         'id'            => 'dataset-grid',
         'dataProvider'  => $model,
-        'itemsCssClass' => 'table table-bordered',
+        'itemsCssClass' => 'table table-bordered table-fixed',
         'enableSorting'  => false,
         'columns'       => [
             'creation_date',
@@ -26,7 +26,8 @@ $this->widget(
                         }
 
                         return $data->comments;
-                    }
+                    },
+                    'headerHtmlOptions' => array('style' => 'width: 300px'),
             ],
             'last_modified_date',
             'last_modified_by',


### PR DESCRIPTION
# Pull request for issue: #2262

If the curation logs in the admin dataset edit page have very long text without breaks (e.g. long URLs), these words are now forced to wrap to prevent table overflow

![image](https://github.com/user-attachments/assets/d179e90c-fbc4-4202-92de-dbdc33b3217a)


## How to test?

- (rebuild the less styles)
- http://gigadb.gigasciencejournal.com/adminDataset/update/id/5
- add a curation log with a very long word without spaces
- the table layout should look fine

## How have functionalities been implemented?

- A new utility class has been added to the tables.less file that can be used with any tables that present this issue
- Our table cells stretch depending on their content, this utility prevents that, essentially setting the table cell width ignoring its content. That means if this utility is applied to a table, column widths would need to be explicitly set, if needed as each column no longer adapts its width to its content
- for that reason I also added a specific width % to the comment column, to make it wider than other columns

## Any issues with implementation?

--

## Any changes to automated tests?

--

