### PR TITLE
fix:2270: allow transitions to submitted and DataPending from any upload status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #2270: Allow transitions to 'Submitted' and 'DataPending' from any upload status.
 - Fix #1955: Edit user without being forced to enter a password + add a password regex
 
 ## v4.4.8 - 2025-04-08 - 01de0477b -

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -207,26 +207,9 @@ class AdminDatasetController extends Controller
         Yii::log('**** new attributes: ' . print_r($postDataset, true), 'warning');
         $uploadStatus = $postDataset['upload_status'];
         $previousUploadStatus = $model->upload_status;
-        $isStatusAvailable = true;
 
         // setting DatasetUpload, the busisness object for File uploading
         $datasetUpload = $this->getDatasetUpload($model->identifier);
-
-        if ($uploadStatus && $uploadStatus !== $previousUploadStatus) {
-            $isStatusAvailable = $this->checkAndSetTransition($datasetUpload, $model, $uploadStatus);
-        }
-
-        if (!$isStatusAvailable) {
-            Yii::app()->user->setFlash('updateError', 'Fail to update status!');
-            Yii::log(sprintf('Failed to change status to %s', $uploadStatus), 'error');
-
-            return $this->render('update', array(
-                'model' => $model,
-                'datasetPageSettings' => $datasetPageSettings,
-                'curationlog'=> $dataProvider,
-                'dataset_id'=> $id,
-            ));
-        }
 
         //curator
         $curatorId = $postDataset['curator_id'];
@@ -583,15 +566,19 @@ class AdminDatasetController extends Controller
         switch ($model->upload_status) {
             case 'Submitted':
                 $contentToSend = $datasetUpload->renderNotificationEmailBody('Submitted');
-                $statusIsSet = $datasetUpload->sendNotificationEmailBody($contentToSend, $model->upload_status);
+                $statusIsSet = true;
+                if (Yii::app()->featureFlag->isEnabled('fuw')) {
+                    $statusIsSet = $datasetUpload->sendNotificationEmailBody($contentToSend, $model->upload_status);
+                }
 
                 break;
             case 'DataPending':
                 $contentToSend = ($emailBody = Yii::$app->request->post('Dataset')['emailBody']) ?
                     $this->processTemplateString($emailBody, ['identifier' => $model->identifier]) : $datasetUpload->renderNotificationEmailBody('DataPending');
-
-                $statusIsSet = $datasetUpload->sendNotificationEmailBody($contentToSend, $model->upload_status, $model->submitter->email);
-
+                $statusIsSet = true;
+                if (Yii::app()->featureFlag->isEnabled('fuw')) {
+                    $statusIsSet = $datasetUpload->sendNotificationEmailBody($contentToSend, $model->upload_status, $model->submitter->email);
+                }
                 break;
             default:
                 $statusIsSet = true;

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -435,4 +435,20 @@ class AcceptanceTester extends \Codeception\Actor
     {
         $this->see($text, ['css' => "$table tr:nth-child($row) td:nth-child($column)"]);
     }
+
+    /**
+     * @Then I can see the option :value selected for :id
+     */
+    public function iCanSeeTheOptionSelectedFor($value, $id)
+    {
+        $this->seeOptionIsSelected("#dataset-form select[id='$id']", $value);
+    }
+
+    /**
+     * @Then I cannot see the option :value selected for :id
+     */
+    public function iCannotSeeTheOptionSelectedFor($value, $id)
+    {
+        $this->dontSeeOptionIsSelected("#dataset-form select[id='$id']", $value);
+    }
 }

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -548,3 +548,23 @@ Feature: form to update dataset details
     And I am on "/adminDataset/update/id/8"
     Then I should see "Dataset_Workflow" checkbox is checked
     Then I should see "Dataset_Genomic" checkbox is unchecked
+
+  @ok
+  Scenario: Check upload status can be set to submitted from any previous upload status
+    Given I am on "/adminDataset/update/id/5"
+    And I cannot see the option "Submitted" selected for "Dataset_upload_status"
+    When I select "Submitted" from the field "Dataset_upload_status"
+    And I press the button "Save"
+    And I am on "/adminDataset/update/id/5"
+    Then I can see the option "Submitted" selected for "Dataset_upload_status"
+
+  @ok
+  Scenario: Check upload status can be set to DataPending from any previous upload status
+    Given I am on "/adminDataset/update/id/5"
+    And I cannot see the option "DataPending" selected for "Dataset_upload_status"
+    When I select "DataPending" from the field "Dataset_upload_status"
+    And I press the button "Save"
+    And I wait "3" seconds
+    And I press the button "Save and send email"
+    And I am on "/adminDataset/update/id/5"
+    Then I can see the option "DataPending" selected for "Dataset_upload_status"


### PR DESCRIPTION
# Pull request for issue: #2270

This is a pull request for the following functionalities:

    Given I am on "/adminDataset/update/id/5"
    When I select "DataPending" or "Submitted" from any upload status field
    And I press the button "Save"
    I shouldn't see an error

## How to test?

 Given I am on "/adminDataset/update/id/5"
    When I select "DataPending" or "Submitted" from any upload status field
    And I press the button "Save"
    I shouldn't see an error

## How have functionalities been implemented?

## Any issues with implementation?

## Any changes to automated tests?

acceptance test added

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?
