### PR TITLE
fix 2282: resend email from welcome page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #2282: Resend email from welcome page
+
 ## v4.4.10 - 2025-05-16 - 07a8f63b2 - 
 
 - Fix #2294: Add dedicated username variable for authenticating to email service

--- a/protected/controllers/UserController.php
+++ b/protected/controllers/UserController.php
@@ -358,6 +358,24 @@ class UserController extends Controller {
         $this->render('passwordChanged') ;
     }
 
+    public function actionSendActivationEmail(int $id) {
+        $user = User::model()->findByPk($id);
+
+        if (!$user) {
+            throw new CHttpException(404,'User not found');
+        }
+
+        $isSuccessful = $this->sendActivationEmail($user);
+
+        if($isSuccessful) {
+            Yii::app()->user->setFlash('success', 'A confirmation email has been resent!');
+        } else {
+            Yii::app()->user->setFlash('danger', 'Unable to send confirmation email!');
+        }
+
+        return $this->redirect(array('welcome', 'id'=>$user->id));
+    }
+
     # Send account activation email
     private function sendActivationEmail($user) {
         $recipient = $user->email;
@@ -365,11 +383,15 @@ class UserController extends Controller {
         $url = $this->createAbsoluteUrl('user/confirm', array('key' => $user->id));
         $body = $this->renderPartial('emailWelcome',array('url'=>$url),true);
         try {
-            Yii::app()->mailService->sendHTMLEmail(Yii::app()->params['adminEmail'], $recipient, $subject, $body);
+            $isSent = Yii::app()->mailService->sendHTMLEmail(Yii::app()->params['adminEmail'], $recipient, $subject, $body);
+            Yii::log("Sent account activation email to $recipient, $subject");
+
+            return $isSent;
+
         } catch (Swift_TransportException $ste) {
             Yii::log("Problem sending account activation email - " . $ste->getMessage(), "error");
+            return false;
         }
-        Yii::log("Sent account activation email to $recipient, $subject");
     }
 
     public function actionEmailWelcome() {

--- a/protected/views/user/welcome.php
+++ b/protected/views/user/welcome.php
@@ -1,7 +1,13 @@
 <? $this->pageTitle = Yii::app()->name . ' - Welcome' ?>
 
-<h2><?=Yii::t('app' , 'Welcome!')?></h2>
-<div class="clear"></div>
-<p><?=Yii::t('app' , 'Thank you for registering with GigaDB. An account activation email will be sent to your email address shortly. To complete your account\'s activation, please click on the activation link in the account activation email.')?><br/>
-<?= Yii::t('app' , 'If you don\'t receive the email within a few minutes, please check your spam filters, or')?> <?= CHtml::link(Yii::t('app' ,"resend the email"), array("user/sendActivationEmail", 'id'=>$user->id)) ?>.</p>
+<div class="container">
+    <h2><?=Yii::t('app' , 'Welcome!')?></h2>
+    <div class="clear"></div>
 
+    <?php foreach (Yii::app()->user->getFlashes() as $key => $message) {
+            echo '<div class="alert alert-' . $key . ' flash-' . $key .'">' . $message . "</div>\n";
+        }
+    ?>
+    <p><?=Yii::t('app' , 'Thank you for registering with GigaDB. An account activation email will be sent to your email address shortly. To complete your account\'s activation, please click on the activation link in the account activation email.')?><br/>
+    <?= Yii::t('app' , 'If you don\'t receive the email within a few minutes, please check your spam filters, or')?> <?= CHtml::link(Yii::t('app' ,"resend the email"), array("user/sendActivationEmail", 'id'=>$user->id)) ?>.</p>
+</div>

--- a/tests/acceptance/NewUser.feature
+++ b/tests/acceptance/NewUser.feature
@@ -76,3 +76,22 @@ Feature: NewUser
     And I press the button "Register"
     Then I should see "Captcha is incorrect!"
     And I should see a text field "User_email"
+
+    @ok
+  Scenario: Resend email for activation
+    Given I am on "/user/create"
+    And there is no user with email "martianmanhunter@mailinator.com"
+    When I fill in the field of "id" "User_email" with "martianmanhunter@mailinator.com"
+    And I fill in the field of "id" "User_first_name" with "J'onn"
+    And I fill in the field of "id" "User_last_name" with "J'onzz"
+    And I fill in the field of "id" "User_password" with "Azertyu1@"
+    And I fill in the field of "id" "User_password_repeat" with "Azertyu1@"
+    And I fill in the field of "id" "User_affiliation" with "GigaScience"
+    And I select "NCBI" from the field "User_preferred_link"
+    And I check the field "User_terms"
+    And I fill in the field of "id" "User_verifyCode" with "shazam"
+    And I press the button "Register"
+    Then I should see "Welcome!"
+    And I press the button "resend the email"
+    Then I should see "A confirmation email has been resent!"
+


### PR DESCRIPTION
# Pull request for issue: #2282 

This is a pull request for the following functionalities:

fix the issue with the 'resend email' link:

Go to http://gigadb.gigasciencejournal.com/user/welcome/id/{id}
Click on resend the email link
see a flash message

## How to test?

Go to http://gigadb.gigasciencejournal.com/user/welcome/id/{id}
Click on resend the email link
see a flash message

## How have functionalities been implemented?

## Any issues with implementation?

## Any changes to automated tests?

acceptance test added

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?
