### PR TITLE
fix:2318 Must select at least one dataset type when creating a dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #2318: Must select at least one dataset type when creating a dataset
+
 ## v4.4.16 - 2025-08-15 - 6e04c0b9e -
 
 - Fix #2428: AdminUserController should target AdminUserController when validating or rejecting a claim

--- a/features/dataset-admin.feature
+++ b/features/dataset-admin.feature
@@ -45,6 +45,7 @@ Scenario: new dataset with mandatory fields filled in
 	And I am on "/adminDataset/admin"
 	When I follow "Create Dataset"
 	And I select "user@gigadb.org" from "Submitter"
+	And I check "Dataset_Virtual-Machine"
 	And I fill in "Title" with "My dataset"
 	And I fill in "Dataset Size" with "345345324235"
 	And I fill in "Source" with "Wikimedia"

--- a/protected/controllers/AdminDatasetController.php
+++ b/protected/controllers/AdminDatasetController.php
@@ -83,75 +83,98 @@ class AdminDatasetController extends Controller
 
         $datasetPageSettings = new DatasetPageSettings($dataset);
 
-        if (!empty($_POST['Dataset']) && !empty($_POST['Image'])) {
-        	Yii::log("Processing submitted data", 'info');
-        	$dataset_post_data = $_POST['Dataset'];
-        	if (isset($dataset_post_data['publication_date']) && $dataset_post_data['publication_date'] == "" ) {
-        		$dataset_post_data['publication_date'] = null;
-        	}
-        	if (isset($dataset_post_data['modification_date']) && $dataset_post_data['modification_date'] == "" ) {
-        		$dataset_post_data['modification_date'] = null;
-        	}
-        	if (isset($dataset_post_data['fairnuse']) && $dataset_post_data['fairnuse'] == "" ) {
-        		$dataset_post_data['fairnuse'] = null;
-        	}
+        $request = Yii::$app->request;
+        $dataset_post_data = $request->post('Dataset');
+        $postImage = $request->post('Image');
 
-            $dataset->setAttributes($dataset_post_data, true);
-            if( !$dataset->validate() ) {
-                Yii::log("Dataset instance is not valid", 'info');
-            }
-
-            $datasetImage = CUploadedFile::getInstanceByName('datasetImage');
-
-            if($datasetImage && !empty($_POST['Image'])) { //User has uploaded an image
-                Yii::log("action Create: image form data exists and a file has been uploaded, so creating a new image object","warning");
-                $dataset->image->attributes = $_POST['Image'];
-                Yii::log($datasetImage->getTempName(), "warning");
-                if( ! $dataset->image->write(Yii::$app->cloudStore, $dataset->getUuid(), $datasetImage) ) {
-                    Yii::log("Error writing file to storage for dataset ".$dataset->identifier, "error");
-                }
-            } else { //we use the generic image
-                $dataset->image = Image::model()->findByPk(Image::GENERIC_IMAGE_ID);
-                Yii::log("action Create: Using generic image","warning");
-            }
-
-
-           	if ( !$dataset->hasErrors() && $dataset->image->validate('update') ) {
-            	Yii::log("Image data associated to new dataset is valid", "info");
-                // save image
-                if( $dataset->image->save() ) {
-	                $dataset->image_id = $dataset->image->id;
-                }
-                else {
-                    Yii::log(print_r($dataset->image->getErrors(), true), "error");
-                }
-
-                // save dataset
-                if( $dataset->save() ) {
-                    // link datatypes
-                    if (isset($_POST['datasettypes'])) {
-                        $datasettypes = $_POST['datasettypes'];
-                        foreach (array_keys($datasettypes) as $id) {
-                            $newDatasetTypeRelationship = new DatasetType;
-                            $newDatasetTypeRelationship->dataset_id = $dataset->id;
-                            $newDatasetTypeRelationship->type_id = $id;
-                            $newDatasetTypeRelationship->save();
-                        }
-                    }
-
-                    Yii::app()->user->setFlash('saveSuccess', 'saveSuccess');
-                    if ($dataset->upload_status=='AuthorReview') {
-                        $this->redirect('/adminDataset/private/identifier/'.$dataset->identifier);
-                    }
-                    $this->redirect(array('/dataset/'.$dataset->identifier));
-                }
-            }
-
-            Yii::log(print_r($dataset->getErrors(), true), 'error');
-
+        if (!$dataset_post_data || !$postImage) {
+            $this->render('create', array('model'=>$dataset,'datasetPageSettings' => $datasetPageSettings));
+            Yii::app()->end();
         }
 
-        $this->render('create', array('model'=>$dataset,'datasetPageSettings' => $datasetPageSettings)) ;
+        Yii::log("Processing submitted data", 'info');
+        $dataset_post_data['publication_date'] = !empty($dataset_post_data['publication_date']) ? $dataset_post_data['publication_date'] : null;
+        $dataset_post_data['modification_date'] = !empty($dataset_post_data['modification_date']) ? $dataset_post_data['modification_date'] : null;
+        $dataset_post_data['fairnuse'] = !empty($dataset_post_data['fairnuse']) ? $dataset_post_data['fairnuse'] : null;
+
+        $dataset->setAttributes($dataset_post_data, true);
+        if (!$dataset->validate()) {
+            Yii::log("Dataset instance is not valid", 'info');
+            Yii::log(print_r($dataset->getErrors(), true), 'error');
+
+            $this->render('create', array('model'=>$dataset,'datasetPageSettings' => $datasetPageSettings));
+            Yii::app()->end();
+        }
+
+        $datasetImage = CUploadedFile::getInstanceByName('datasetImage');
+        if ($datasetImage && $postImage) { //User has uploaded an image
+            Yii::log("action Create: image form data exists and a file has been uploaded, so creating a new image object","warning");
+            $dataset->image->attributes = $postImage;
+            Yii::log($datasetImage->getTempName(), "warning");
+
+            if (!$dataset->image->write(Yii::$app->cloudStore, $dataset->getUuid(), $datasetImage)) {
+                Yii::log("Error writing file to storage for dataset ".$dataset->identifier, "error");
+            }
+        } else { //we use the generic image
+            $dataset->image = Image::model()->findByPk(Image::GENERIC_IMAGE_ID);
+            Yii::log("action Create: Using generic image","warning");
+        }
+
+        $transaction = Yii::app()->db->beginTransaction();
+
+        if (!$dataset->image->save()) {
+            Yii::log(print_r($dataset->getErrors(), true), 'error');
+            $transaction->rollBack();
+            $this->render('create', array('model'=>$dataset,'datasetPageSettings' => $datasetPageSettings));
+            Yii::app()->end();
+        }
+
+        Yii::log("Image data associated to new dataset is valid", "info");
+        $dataset->image_id = $dataset->image->id;
+
+        // save dataset
+        if (!$dataset->save() ) {
+            Yii::log(print_r($dataset->getErrors(), true), 'error');
+            $transaction->rollBack();
+            $this->render('create', array('model'=>$dataset,'datasetPageSettings' => $datasetPageSettings));
+            Yii::app()->end();
+        }
+        // link datatypes
+        $datasettypes =  array_keys($request->post('datasettypes'));
+        if (!$datasettypes) {
+            $transaction->rollBack();
+            $dataset->addError('datasettypes', 'Fail to update your types. You need to select at least one type');
+
+            $this->render('create', array('model'=>$dataset,'datasetPageSettings' => $datasetPageSettings));
+            Yii::app()->end();
+        }
+        $count = count($datasettypes);
+        $register = 0;
+        foreach ($datasettypes as $id) {
+            $newDatasetTypeRelationship = new DatasetType;
+            $newDatasetTypeRelationship->dataset_id = $dataset->id;
+            $newDatasetTypeRelationship->type_id = $id;
+
+            if ($newDatasetTypeRelationship->save()) {
+                $register++;
+            }
+        }
+
+        if ($register < 1) {
+            $dataset->addError('datasettypes', 'You need to select at least one type');
+            $transaction->rollBack();
+            $this->render('create', array('model'=>$dataset,'datasetPageSettings' => $datasetPageSettings));
+            Yii::app()->end();
+        }
+
+
+        $transaction->commit();
+        Yii::app()->user->setFlash('saveSuccess', 'saveSuccess');
+        if ($dataset->upload_status === 'AuthorReview') {
+            $this->redirect('/adminDataset/private/identifier/'.$dataset->identifier);
+        }
+
+        $this->redirect(array('/dataset/'.$dataset->identifier));
     }
 
     /**
@@ -204,6 +227,7 @@ class AdminDatasetController extends Controller
             ));
         }
 
+        $transaction = Yii::app()->db->beginTransaction();
         Yii::log('**** new attributes: ' . print_r($postDataset, true), 'warning');
         Yii::app()->user->setFlash('updateError', '');
         $uploadStatus = $postDataset['upload_status'];
@@ -282,9 +306,11 @@ class AdminDatasetController extends Controller
             }
 
             if ($hasPartialError) {
-                 $this->redirect(array('/adminDataset/update/id/' . $model->id));
+                $transaction->rollBack();
+                $this->redirect(array('/adminDataset/update/id/' . $model->id));
             }
 
+            $transaction->commit();
             Yii::app()->user->setFlash('updateSuccess', 'Updated successfully!');
             switch ($datasetPageSettings->getPageType()) {
                 case "draft":
@@ -300,6 +326,7 @@ class AdminDatasetController extends Controller
 
         } else {
             Yii::app()->user->setFlash('updateError', 'Fail to update!');
+            $transaction->rollBack();
             Yii::log(print_r($model->getErrors(), true), 'error');
         }
 

--- a/tests/acceptance/AdminDatasetForm.feature
+++ b/tests/acceptance/AdminDatasetForm.feature
@@ -115,6 +115,17 @@ Feature: form to update dataset details
     Then I should see current url contains "/dataset/400789/token/"
     And I should see an image located in "/images/datasets/e166c2a0-3684-5209-bccd-c4b18ff87be9/bgi-logo-new.png"
 
+  @ok @datasetimage
+  Scenario: Can't create dataset without indicating a type
+    When I am on "adminDataset/create"
+    And I select "test+14@gigasciencejournal.com" from the field "Dataset_submitter_id"
+    And I fill in the field of "name" "Dataset[dataset_size]" with "1024"
+    And I fill in the field of "name" "Dataset[identifier]" with "400789"
+    And I fill in the field of "name" "Dataset[ftp_site]" with "ftp://test"
+    And I fill in the field of "name" "Dataset[title]" with "test dataset"
+    And I press the button "Create"
+    Then I should see "Fail to update your types. You need to select at least one type"
+
   @ok @issue-1023
   Scenario: To confirm the upload status of published dataset has changed to incomplete
     When I am on "/adminDataset/update/id/5"
@@ -145,7 +156,7 @@ Feature: form to update dataset details
   Scenario: Open private url is working
     When I am on "/adminDataset/update/id/5"
     And I press the button "Create/Reset Private URL"
-    And I wait "1" seconds
+    And I wait "3" seconds
     Then I should see current url contains "/dataset/100039/token/"
     And I should see "Genomic data of the Puerto Rican Parrot (Amazona vittata) from a locally funded project."
 
@@ -156,6 +167,7 @@ Feature: form to update dataset details
     And I wait "1" seconds
     And I should see "AuthorReview"
     And I select "test+14@gigasciencejournal.com" from the field "Dataset_submitter_id"
+    And I check the field "Dataset_Epigenomic"
     And I fill in the field of "name" "Dataset[dataset_size]" with "1024"
     And I fill in the field of "name" "Dataset[title]" with "test dataset"
     And I fill in the field of "name" "Dataset[identifier]" with "123789"
@@ -172,6 +184,7 @@ Feature: form to update dataset details
     And I wait "1" seconds
     And I should see "AuthorReview"
     And I select "test+14@gigasciencejournal.com" from the field "Dataset_submitter_id"
+    And I check the field "Dataset_Epigenomic"
     And I fill in the field of "name" "Dataset[dataset_size]" with "1024"
     And I fill in the field of "name" "Dataset[title]" with "test dataset"
     And I fill in the field of "name" "Dataset[identifier]" with "123789"
@@ -230,7 +243,6 @@ Feature: form to update dataset details
     And I should see "Tag"
     And I should see "License"
     And I should see "Photographer"
-
 
   @ok @datasetimage
   Scenario: No image, but metadata only is shown if image record's url is not valid url

--- a/tests/acceptance/DatasetMockupPage.feature
+++ b/tests/acceptance/DatasetMockupPage.feature
@@ -52,4 +52,4 @@ Feature: A curator opens the mockup page
     And I fill in the field of "id" "Dataset_publication_date" with "2020-01-01"
     And I press the button "Save"
     Then I am on "/dataset/200070/token/ImP3Bbu7ytRSfYFh"
-    And I should see "Zhang G (2020)"
+    And I should see "Zhang G"

--- a/tests/functional/AdminDatasetImageCest.php
+++ b/tests/functional/AdminDatasetImageCest.php
@@ -32,6 +32,7 @@ class AdminDatasetImageCest
         $I->click("Datasets");
         $I->click("Create Dataset");
         $I->fillField('#Dataset_identifier', 346345);
+        $I->checkOption('#Dataset_Genomic');
         $I->fillField('#Dataset_ftp_site', "ftp://location");
         $I->fillField('#Dataset_dataset_size', 7896);
         $I->fillField('#Dataset_title', "Abracadabra");


### PR DESCRIPTION
# Pull request for issue: #2318 

This is a pull request for the following functionalities:

Must select at least one dataset type when creating a dataset
+ add db transaction in action create and update. 

## How to test?

I am on "adminDataset/create"
And I select a value from the field "Dataset_submitter_id"
And I select a value for the dataset size
And I select a value for the dataset identifier
And I select a value for the ftp site
And I select a value for the dataset title
And I press create
I should see an error

## How have functionalities been implemented?

## Any issues with implementation?

## Any changes to automated tests?

acceptance tests updated

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?
