### PR TITLE
Fix server error page message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-## v4.4.12 - 2025-05-27 - da60e55e3 - 
+- Fix #2351: Fix server error page message
+
+## v4.4.12 - 2025-05-27 - da60e55e3 -
 
 - Feat #1341: Show maintenance error on 500 errors
 - Feat #1892: Update onboarding pages layout

--- a/protected/views/site/error.php
+++ b/protected/views/site/error.php
@@ -2,12 +2,12 @@
   <?php
   $isServerError = $code == 500;
   $this->widget('TitleBreadcrumb', [
-    'pageTitle' => $isServerError ? 'Maintenance' : 'Error ' . $code,
+    'pageTitle' => $isServerError ? 'Server Error' : 'Error ' . $code,
   ]);
   ?>
   <?php if ($isServerError): ?>
     <div class="error">
-      <p>The site is under maintenance. Please come back later or contact <a href="mailto:database@gigasciencejournal.com">database@gigasciencejournal.com</a> for support</p>
+      <p>A server error has occurred. Please come back later or contact <a href="mailto:database@gigasciencejournal.com">database@gigasciencejournal.com</a> for support</p>
       <div class="mt-10">
         <a href="/">
           Go to the home page


### PR DESCRIPTION
# Pull request for issue: #2351

Udated message displayed on the error page

![image](https://github.com/user-attachments/assets/840b831f-ad27-47b9-a1d7-8c74905a6c0d)


## How to test?

You can throw a 500 error from any controller

eg. grep $this->render('about'); then add the following before the render call

throw new CHttpException(500,'Mock Internal Server Error');

And navigate to http://gigadb.gigasciencejournal.com/site/about to confirm
