### PR TITLE
Reorder homepage sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #199: Reorder home page sections
 - Feat #199: Add dataset feed to homepage
 - Feat #208: Homepage news items section rework
 - Feat #2189: Make public pages responsive

--- a/protected/views/site/index.php
+++ b/protected/views/site/index.php
@@ -13,6 +13,18 @@
             </div>
         </div>
     </section>
+    <?php if (count($feed_datasets) > 0) { ?>
+        <section class="dataset-feed-section">
+            <?php
+            $this->renderPartial('datasets_carousel', array('datasets' => $feed_datasets));
+            ?>
+        </section>
+    <?php } ?>
+    <? if (count($news) > 0) { ?>
+      <section class="news-section">
+        <?php $this->renderPartial('news', array('news' => $news)); ?>
+      </section>
+    <? } ?>
     <section class="mb-20">
         <div class="container">
             <div class="row">
@@ -202,18 +214,6 @@
             </div>
         </div>
     </section>
-    <? if (count($news) > 0) { ?>
-      <section class="news-section">
-        <?php $this->renderPartial('news', array('news' => $news)); ?>
-      </section>
-    <? } ?>
-    <?php if (count($feed_datasets) > 0) { ?>
-        <section class="dataset-feed-section">
-            <?php
-            $this->renderPartial('datasets_carousel', array('datasets' => $feed_datasets));
-            ?>
-        </section>
-    <?php } ?>
     <section>
         <h2 class="sr-only">Data Overview Metrics</h2>
         <div class="container">


### PR DESCRIPTION
# Pull request for issue: #199

As per this comment: https://github.com/gigascience/gigadb-website/issues/199#issuecomment-2965850691

This PR orders the sections of the home page

![image](https://github.com/user-attachments/assets/b1ef4951-3dab-485c-bc2a-6c1f3af5606e)


## How to test?

Navigate to the home page and confirm the order. Add news items from the admin page if needed: http://gigadb.gigasciencejournal.com/news/admin

## How have functionalities been implemented?

Simple reordering of the sections in the home page
