### PR TITLE
docs: update GigaDB search help page content for filtering results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-## v4.4.13 - 2025-06-13 - 26083397b - 
+- Feat #2328: Update GigaDB search help page "Filtering result" content
+
+## v4.4.13 - 2025-06-13 - 26083397b -
 
 - Feat #199: Reorder home page sections
 - Feat #199: Add dataset feed to homepage

--- a/protected/views/site/help.php
+++ b/protected/views/site/help.php
@@ -70,22 +70,7 @@ $this->pageTitle = 'GigaDB - Help';
                         <h2 class="page-subtitle" id="filteringResultTitle">Filtering result</h2>
                         <p class="mb-20">On the left of the search results you have the option to further refine the results by using the filters. By default all filters are disabled, allowing you to see all search results for your keyword. If you want to hide some results based on some criteria, choose the filter for your criteria, and select the options that match what you want to see.</p>
                         <h3 class="tabpanel-subtitle">Filter options for Datasets:</h3>
-                        <ol>
-                            <li>Dataset Type (<a href="#datasettypes" onclick="DatasetFunction()">Dataset Type</a> controlled vocabulary eg 'Genomic', 'Proteomic')</li>
-                            <li>Project (eg 'Genome 10K', '1000 Genomes'</li>
-                            <li>External Link Types (Controlled vocabulary: 'Genome Browser' or 'Additional Data')</li>
-                            <li>Publication Date (From and To. Format: dd-mm-yyyy)</li>
-                        </ol>
-                        <h3 class="tabpanel-subtitle">Filter options for Samples:</h3>
-                        <ol>
-                            <li>Common Name (Internally controlled eg 'Human', 'Mouse')</li>
-                        </ol>
-                        <h3 class="tabpanel-subtitle">Filter options for Files:</h3>
-                        <ol>
-                            <li>File Type (<a href="#filetypes" onclick="DatasetFunction()">File Type</a> controlled vocabulary eg 'Alignments', 'Genome sequence', 'SNPs')</li>
-                            <li>File Format (<a href="#fileformats" onclick="DatasetFunction()">File format</a> controlled vocabulary eg 'BIGWIG', 'FASTQ', 'VCF')</li>
-                            <li>File Size (From and To: Format KB, MB, GB, TB)</li>
-                        </ol>
+                        <p>We anticipate adding additional facets to filter the search results in a future release. Please contact us with any specific examples that you would find useful. At present one can filter the results to display only datasets that have matches at the "Dataset" level, "Sample" level or "File" level by clicking the relevant radial button in the menu to the left of the results, followed by the "Apply Filter" button.</p>
                     </section>
                 </div>
                 <div role="tabpanel" class="tab-pane" id="guidelines" aria-labelledby="liguideline">


### PR DESCRIPTION
# Pull request for issue: #2328

Simple text change on the help page. See original ticket for details

![image](https://github.com/user-attachments/assets/782db5d7-ac4b-4419-b380-c5ef3c273dcf)


## How to test?

http://gigadb.gigasciencejournal.com/site/help
verify you see text change

