### PR TITLE
Content change in Genomic Guideline page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #2349: Content change in Genomic Guideline page
+
 ## v4.4.14 - 2025-06-24 - 4159a6086
 
 - Feat #1641: Check if the DOI has been minted when the upload status is set to 'Published'

--- a/protected/views/site/guidegenomic.php
+++ b/protected/views/site/guidegenomic.php
@@ -117,7 +117,7 @@ $this->pageTitle = 'GigaDB - Genomic Dataset checklists';
                                 </tr>
                                 <tr>
                                     <td>
-                                        BUSCO result output files from the latest version of BUSCO; Please provide the 3 files under the "run_lineage_name" folder as shown in the documentation: <a href="https://busco.ezlab.org/busco_userguide.html#outputs">https://busco.ezlab.org/busco_userguide.html#outputs</a>, namely: short_summary.*.txt ,  full_table.tsv , and missing_busco_list.tsv
+                                        BUSCO result output files from the latest version of BUSCO; Please provide the 3 files under the "run_lineage_name" folder as shown in the <a href="https://busco.ezlab.org/busco_userguide.html#outputs">BUSCO User Guide</a>, namely: short_summary.*.txt ,  full_table.tsv , and missing_busco_list.tsv
                                     </td>
                                     <td>
                                         text
@@ -218,8 +218,8 @@ $this->pageTitle = 'GigaDB - Genomic Dataset checklists';
                         </div>
                         <br>
                         <br>
-                        <p>For genomic and transcriptomic datasets we would expect to see sample metadata that complies with the <a target="_blank" href="http://gensc.org/">Genomic Standards Consortium</a> MIxS checklists, the most common features of which are summarised below.</p>
-                        <p>For transcriptomic datasets we we would expect users to follow the well established <a target="_blank" href="https://doi.org/10.1038/ng1201-365">MIAME</a> (Minimum Information About a Microarray Experiment) and <a target="_blank" href="http://fged.org/projects/minseqe/">MINSEQE</a> (Minimum Information About a Next-generation Sequencing Experiment) guidelines outlining the minimum information that should be included when describing a microarray or sequencing studies.</p>
+                        <p>For genomic and transcriptomic datasets we would expect to see sample metadata that complies with the <a href="http://gensc.org/">Genomic Standards Consortium</a> MIxS checklists, the most common features of which are summarised below.</p>
+                        <p>For transcriptomic datasets we we would expect users to follow the well established <a href="https://doi.org/10.1038/ng1201-365"><abbr>MIAME</abbr></a> (Minimum Information About a Microarray Experiment) and <a href="https://www.fged.org/projects/minseqe/"><abbr>MINSEQE</abbr></a> (Minimum Information About a Next-generation Sequencing Experiment) guidelines outlining the minimum information that should be included when describing a microarray or sequencing studies.</p>
                         <p>The complete list of pre-defined sample attributes are available in the <a href="/">GigaDB home page</a>, and it is possible to include bespoke attributes by communication with us.</p>
                         <br>
                         <br>


### PR DESCRIPTION
# Pull request for issue: #2349

Update two links in the page http://gigadb.gigasciencejournal.com/site/guidegenomic

More meaningful label of BUSCO link
![image](https://github.com/user-attachments/assets/57256333-ba5b-498f-ba1f-20a5c2d4acd4)

Update the MINSEQE link
![image](https://github.com/user-attachments/assets/51a0ab68-4352-494a-9058-98f51888953d)


## How to test?

Both above links should be presented as in the screenshot and work (open in new tab, show existing page)

## How have functionalities been implemented?

- Simple html update
- Issue asks to use "documentation" as label for the BUSCO link, I made the label even more specific, which is a good SEO practice
- Note that JS changes all external links to have `target="_blank" rel="noopener noreferrer"` so explicitly adding ths is not necessary (protected/views/shared/_handle_external_links.php)
- I wrapped some abbreviations in the `abbr` element
