### PR TITLE
Update the layout of the Advisory board page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #2350: Update the layout of the Advisory board page
+
 ## v4.4.14 - 2025-06-24 - 4159a6086
 
 - Feat #1641: Check if the DOI has been minted when the upload status is set to 'Published'

--- a/less/pages/advisory.less
+++ b/less/pages/advisory.less
@@ -3,6 +3,8 @@
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
+  max-width: 700px;
+  margin-inline: auto;
 }
 @media (max-width: @screen-md-max) {
   .advisory-img-row {

--- a/protected/views/site/advisory.php
+++ b/protected/views/site/advisory.php
@@ -22,27 +22,27 @@ $this->pageTitle = 'GigaDB - Advisory Board';
         </div>
         <section>
             <div class="row advisory-img-row">
-                <div class="col-xs-6 col-sm-4 col-lg-2 advisory-img-block">
+                <div class="col-xs-6 col-sm-4 advisory-img-block">
                     <img alt="Dr Paul Flicek" src="/images/profile/Paul.png" class="img-responsive">
                     <p><a href="http://www.ebi.ac.uk/about/people/paul-flicek">Dr Paul Flicek</a></p>
                 </div>
-                <div class="col-xs-6 col-sm-4 col-lg-2 advisory-img-block">
+                <div class="col-xs-6 col-sm-4 advisory-img-block">
                     <img alt="Prof Carole Goble" src="/images/profile/Carole.png" class="img-responsive">
                     <p><a href="http://www.manchester.ac.uk/research/Carole.goble/">Prof Carole Goble</a></p>
                 </div>
-                <div class="col-xs-6 col-sm-4 col-lg-2 advisory-img-block">
+                <div class="col-xs-6 col-sm-4 advisory-img-block">
                     <img alt="Dr Paul Horton" src="/images/profile/Paul.H.png" class="img-responsive">
                     <p><a href="http://www.cbrc.jp/eng/intro/index.eng.html">Dr Paul Horton</a></p>
                 </div>
-                <div class="col-xs-6 col-sm-4 col-lg-2 advisory-img-block">
+                <div class="col-xs-6 col-sm-4 advisory-img-block">
                     <img alt="Dr B F Francis Ouellette" src="/images/profile/Francis.png" class="img-responsive">
                     <p><a href="http://oicr.on.ca/person/researcher/francis-ouellette">Dr B F Francis Ouellette</a></p>
                 </div>
-                <div class="col-xs-6 col-sm-4 col-lg-2 advisory-img-block">
+                <div class="col-xs-6 col-sm-4 advisory-img-block">
                     <img alt="Dr Xin Zhou" src="/images/profile//ZhouXin.png" class="img-responsive">
                     <p><a href="https://www.linkedin.com/profile/view?id=157662709&trk=nav_responsive_tab_profile_pic">Dr Xin Zhou</a></p>
                 </div>
-                <div class="col-xs-6 col-sm-4 col-lg-2 advisory-img-block">
+                <div class="col-xs-6 col-sm-4 advisory-img-block">
                     <img alt="Jesse Xiao" src="/images/profile/jessexiao.jpg" class="img-responsive">
                     <p><a href="https://www.linkedin.com/in/jessexiao">Jesse (Sezhe) Xiao</a></p>
                 </div>

--- a/protected/views/site/advisory.php
+++ b/protected/views/site/advisory.php
@@ -22,27 +22,27 @@ $this->pageTitle = 'GigaDB - Advisory Board';
         </div>
         <section>
             <div class="row advisory-img-row">
-                <div class="col-lg-2 col-md-3 col-sm-3 col-xs-6 advisory-img-block">
+                <div class="col-xs-6 col-sm-4 col-lg-2 advisory-img-block">
                     <img alt="Dr Paul Flicek" src="/images/profile/Paul.png" class="img-responsive">
                     <p><a href="http://www.ebi.ac.uk/about/people/paul-flicek">Dr Paul Flicek</a></p>
                 </div>
-                <div class="col-lg-2 col-md-3 col-sm-3 col-xs-6 advisory-img-block">
+                <div class="col-xs-6 col-sm-4 col-lg-2 advisory-img-block">
                     <img alt="Prof Carole Goble" src="/images/profile/Carole.png" class="img-responsive">
                     <p><a href="http://www.manchester.ac.uk/research/Carole.goble/">Prof Carole Goble</a></p>
                 </div>
-                <div class="col-lg-2 col-md-3 col-sm-3 col-xs-6 advisory-img-block">
+                <div class="col-xs-6 col-sm-4 col-lg-2 advisory-img-block">
                     <img alt="Dr Paul Horton" src="/images/profile/Paul.H.png" class="img-responsive">
                     <p><a href="http://www.cbrc.jp/eng/intro/index.eng.html">Dr Paul Horton</a></p>
                 </div>
-                <div class="col-lg-2 col-md-3 col-sm-3 col-xs-6 advisory-img-block">
+                <div class="col-xs-6 col-sm-4 col-lg-2 advisory-img-block">
                     <img alt="Dr B F Francis Ouellette" src="/images/profile/Francis.png" class="img-responsive">
                     <p><a href="http://oicr.on.ca/person/researcher/francis-ouellette">Dr B F Francis Ouellette</a></p>
                 </div>
-                <div class="col-lg-2 col-md-3 col-sm-3 col-xs-6 advisory-img-block">
+                <div class="col-xs-6 col-sm-4 col-lg-2 advisory-img-block">
                     <img alt="Dr Xin Zhou" src="/images/profile//ZhouXin.png" class="img-responsive">
                     <p><a href="https://www.linkedin.com/profile/view?id=157662709&trk=nav_responsive_tab_profile_pic">Dr Xin Zhou</a></p>
                 </div>
-                <div class="col-lg-2 col-md-3 col-sm-3 col-xs-6 advisory-img-block">
+                <div class="col-xs-6 col-sm-4 col-lg-2 advisory-img-block">
                     <img alt="Jesse Xiao" src="/images/profile/jessexiao.jpg" class="img-responsive">
                     <p><a href="https://www.linkedin.com/in/jessexiao">Jesse (Sezhe) Xiao</a></p>
                 </div>


### PR DESCRIPTION
# Pull request for issue: #2350

Adjusted layout so that the items per row stay always the same regardless of screen size and also gave a max width to the image container so that it does not look "too large"

Mobile
![image](https://github.com/user-attachments/assets/4fe03172-4bf7-474f-9211-eb76aa13a21f)

Tablet
![image](https://github.com/user-attachments/assets/edbb3a00-de4f-481f-bb42-80b800c46374)

Desktop
![image](https://github.com/user-attachments/assets/c3ca919a-cc07-4890-962a-ad37f85e7f6e)


## How to test?

- rebuild styles, e.g. `docker-compose run --rm less`
- navigate to http://gigadb.gigasciencejournal.com/site/advisory
- change browser width and check that the page always looks as expected
