### PR TITLE
Add Supplemental File Guidelines page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #2330: Add Supplemental File Guidelines page
+
 ## v4.4.14 - 2025-06-24 - 4159a6086
 
 - Feat #1641: Check if the DOI has been minted when the upload status is set to 'Published'

--- a/less/modules/definition-lists.less
+++ b/less/modules/definition-lists.less
@@ -1,4 +1,4 @@
-dl {
+dl.inline-list {
   font-size: 13px;
   .dl-item-wrapper {
     display: flex;
@@ -6,14 +6,40 @@ dl {
     gap: 4px;
   }
   dt {
-    color: @dark-gray-on-white;
+    color: @color-warm-black;
     font-weight: bold;
     &::after {
       content: " - ";
       font-weight: normal;
     }
   }
+  &.separator-none {
+    dt::after {
+      content: none;
+    }
+  }
   dd {
-    color: @dark-gray-on-white;
+    color: @color-warm-black;
+    margin-bottom: 10px;
+  }
+}
+
+
+dl.definition-list {
+  dt {
+    font-weight: 600;
+    font-size: 1.05em;
+    color: @color-warm-black;
+    margin-top: 1.5em;
+  }
+
+  dd {
+    margin: 0.5em 0 0 0;
+    padding-left: 0.7em;
+    border-left: 3px solid @color-medium-gray;
+
+    &:last-of-type {
+      margin-bottom: 1.5em;
+    }
   }
 }

--- a/less/modules/definition-lists.less
+++ b/less/modules/definition-lists.less
@@ -13,11 +13,6 @@ dl.inline-list {
       font-weight: normal;
     }
   }
-  &.separator-none {
-    dt::after {
-      content: none;
-    }
-  }
   dd {
     color: @color-warm-black;
     margin-bottom: 10px;

--- a/playwright/paths.js
+++ b/playwright/paths.js
@@ -30,6 +30,7 @@ const PUBLIC_PATHS = [
   },
   '/site/help',
   '/site/guide',
+  '/site/supplementalfileguidelines',
   '/site/guidegenomic',
   '/site/guideimaging',
   '/site/guidemetabolomic',

--- a/protected/components/GuideNavigation.php
+++ b/protected/components/GuideNavigation.php
@@ -23,7 +23,7 @@ class GuideNavigation extends CWidget
     public function run()
     {
         $isActiveGeneral = $this->isActive('site', 'guide');
-
+        $isActiveSupplementalFileGuide = $this->isActive('site', 'supplementalFileGuide');
         $datasetLinks = [
             'Genomic Dataset Checklist' => 'guidegenomic',
             'Imaging Dataset Checklist' => 'guideimaging',
@@ -37,7 +37,8 @@ class GuideNavigation extends CWidget
 
         Yii::app()->controller->renderPartial('//guide/_guideNavigationView', [
             'menuHtml' => $menuHtml,
-            'isActiveGeneral' => $isActiveGeneral
+            'isActiveGeneral' => $isActiveGeneral,
+            'isActiveSupplementalFileGuide' => $isActiveSupplementalFileGuide
         ]);
     }
 }

--- a/protected/controllers/SiteController.php
+++ b/protected/controllers/SiteController.php
@@ -36,7 +36,7 @@ class SiteController extends Controller {
 	public function accessRules() {
         return array(
             array('allow',  // allow all users
-                'actions'=>array('index','error','contact','mapbrowse','team','about','advisory','faq','term','help','privacy', 'login', 'loginAffiliate', 'logout', 'revoke', 'feed', 'Guide', 'Guidegenomic', 'Guideimaging', 'Guidemetabolomic', 'Guideepigenomic', 'Guidemetagenomic', 'Guidesoftware'),
+                'actions'=>array('index','error','contact','mapbrowse','team','about','advisory','faq','term','help','privacy', 'login', 'loginAffiliate', 'logout', 'revoke', 'feed', 'Guide', 'SupplementalFileGuide', 'Guidegenomic', 'Guideimaging', 'Guidemetabolomic', 'Guideepigenomic', 'Guidemetagenomic', 'Guidesoftware'),
                 'users'=>array('*'),
                 'ips'=>array('*'),
             ),
@@ -243,6 +243,9 @@ class SiteController extends Controller {
 
     public function actionGuide() {
         $this->render('guide');
+    }
+    public function actionSupplementalFileGuide() {
+        $this->render('supplementafileguide');
     }
     public function actionGuidegenomic() {
         $this->render('guidegenomic');

--- a/protected/views/guide/_guideNavigationView.php
+++ b/protected/views/guide/_guideNavigationView.php
@@ -1,9 +1,18 @@
+<?php
+
+$isActiveDatasetChecklists = !$isActiveGeneral && !$isActiveSupplementalFileGuide;
+
+?>
+
 <nav aria-label="Submission Guidelines" class="guide-nav" id="guideNav">
     <ul class="nav nav-tabs nav-border-tabs">
         <li class="<?= $isActiveGeneral ? 'active' : '' ?>">
             <a href="/site/guide">General Submission Guidelines</a>
         </li>
-        <li class="dropdown<?= !$isActiveGeneral ? ' active' : '' ?>" id="dataset-dropdown">
+        <li class="<?= $isActiveSupplementalFileGuide ? 'active' : '' ?>">
+            <a href="/site/supplementalFileGuide">Supplemental File Guidelines</a>
+        </li>
+        <li class="dropdown<?= $isActiveDatasetChecklists ? ' active' : '' ?>" id="dataset-dropdown">
             <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false" type="button">
                 Datasets Checklists&nbsp;
                 <i class="fa fa-angle-down" aria-hidden="true"></i>

--- a/protected/views/site/faq.php
+++ b/protected/views/site/faq.php
@@ -496,7 +496,7 @@ $this->pageTitle = 'GigaDB - FAQ';
                     <div id="panel33" aria-labelledby="heading33" class="panel-collapse collapse">
                         <div class="panel-body">
                             <p>There are various reason why certain data values may need to not be included in the sample metadata, but you still want it to be compliant with particular Minimum Information standards such the GSC MIxS. To maintain compliance when there are missing values within the mandatory fields please use the following terms only:</p>
-                            <dl>
+                            <dl class="inline-list">
                                 <div class="dl-item-wrapper">
                                     <dt>Term</dt>
                                     <dd>Definition</dd>

--- a/protected/views/site/guide.php
+++ b/protected/views/site/guide.php
@@ -24,8 +24,23 @@ $this->pageTitle = 'GigaDB - Submission Guidelines';
                     <div class="tab-pane active">
                         <h2 class="page-subtitle h4">General Submission Guidelines </h2>
                         <div class="subsection">
-                            <p>GigaDB is a <a target="_blank" href="https://www.cngb.org/aboutUs.html?i18nlang=en_US">China National GeneBank</a> supported repository used to host data and tools associated with articles in <i>GigaScience</i>. As part of your manuscript submission and in line with the <a target="_blank" href="https://academic.oup.com/gigascience/pages/editorial_policies_and_reporting_standards">Reporting Standards</a> and <a target="_blank" href="http://doi.org/10.25504/fairsharing.prdtva">FAIRsharing guidelines for data deposition and formatting for papers submitted to <i>GigaScience</i></a> we will provide an associated GigaDB dataset to host the data and files required for transparency and reproducibility. GigaDB is an open-access database. As such, all data submitted to GigaDB must be fully consented for public release (for more information about our data policies, please see our <a href="/site/term">Terms of use</a> page).
+                            <p>GigaDB is a repository used to host data and tools associated with articles in <i>GigaScience</i>. As part of your manuscript submission and in line with the <a target="_blank" href="https://academic.oup.com/gigascience/pages/editorial_policies_and_reporting_standards">Reporting Standards</a> and <a target="_blank" href="http://doi.org/10.25504/fairsharing.prdtva">FAIRsharing guidelines for data deposition and formatting for papers submitted to <i>GigaScience</i></a> we will provide an associated GigaDB dataset to host the data and files required for transparency and reproducibility. GigaDB is an open-access database. As such, all data submitted to GigaDB must be fully consented for public release (for more information about our data policies, please see our <a href="/site/term">Terms of use</a> page).
                             </p>
+                        </div>
+
+                        <h2 class="page-subtitle h4">The GigaScience philosophy on supplemental files</h2>
+                        <div class="subsection">
+
+                            <p><i>GigaScience Press</i> treat supplemental files a little differently to other publishers. In <i>GigaScience journal</i>, supplemental files do still exist in the same way as other more traditional journals, but our GigaDB curation team will check those for data content. If we find the content to be data (rather than narrative) then we will move those data objects into GigaDB (converting them to machine readable formats) to enable them to be discovered, integrated and re-used as required by other researchers. With our other journal <i>GigaByte</i>, we have taken things a step further, by not accepting traditional "supplemental files" at all. Instead authors need to consider whether the information in a supplemental file is:</p>
+
+                            <ol type="A">
+                                <li>Important narrative, in which case it should be incorporated into the manuscript text.</li>
+                                <li>Data, in which case it can be submitted to GigaDB (or other open repositories) and cited from the manuscript.</li>
+                                <li>Superfluous to requirements and removed.</li>
+                            </ol>
+
+                            <p>To help with this we have prepared a list of things commonly found in supplemental files and how we would recommend they be represented: <a href="/site/supplementalFileGuide">Supplemental File Guidelines</a>.</p>
+
                         </div>
 
                         <h2 class="page-subtitle h4">Workflow</h2>
@@ -118,7 +133,7 @@ $this->pageTitle = 'GigaDB - Submission Guidelines';
                                             <span aria-hidden="true">y</span><span class="sr-only">yes</span>
                                         </td>
                                         <td>
-                                            Manuscript title prefixed with “Supporting data for”
+                                            Manuscript title prefixed with "Supporting data for"
                                         </td>
                                     </tr>
                                     <tr>

--- a/protected/views/site/help.php
+++ b/protected/views/site/help.php
@@ -38,7 +38,7 @@ $this->pageTitle = 'GigaDB - Help';
                         <h2 class="page-subtitle" id="searchResultTitle">Search result</h2>
                         <p>The search results are grouped by <span class="text-italic">GigaDB</span> Datasets (G), Samples (S) and Files (F).</p>
 
-                        <dl class="help-search-result">
+                        <dl class="inline-list help-search-result">
                             <div class="help-search-result-item">
                                 <dt>
                                     <div class="text-icon text-icon-sm text-icon-blue" aria-hidden="true">G</div>
@@ -121,7 +121,7 @@ $this->pageTitle = 'GigaDB - Help';
                 <div role="tabpanel" class="tab-pane" id="vocabulary" aria-labelledby="livocabulary">
                     <section aria-labelledby="datasettypes" class="m-0">
                         <h2 class="page-subtitle" id="datasettypes">Dataset types</h2>
-                        <dl class="help-description-list">
+                        <dl class="inline-list help-description-list">
                             <div class="help-definition-container">
                                 <dt>Genomic</dt>
                                 <dd>Includes all genetic and genomic data eg sequence, assemblies, alignments, genotypes, variation and annotation. Minimal requirements: DNA sequence data eg next-gen raw reads (fastq files) OR assembled DNA sequences (fasta files).</dd>
@@ -212,7 +212,7 @@ $this->pageTitle = 'GigaDB - Help';
                     <section aria-labelledby="filetypes" class="m-0">
                         <h2 class="page-subtitle" id="filetypes">File types</h2>
                         <p>File types and examples of associated file extensions:</p>
-                        <dl class="help-description-list">
+                        <dl class="inline-list help-description-list">
                             <div class="help-definition-container">
                                 <dt>Alignments</dt>
                                 <dd>.bam, .chain, .maf, .net, .sam</dd>
@@ -314,7 +314,7 @@ $this->pageTitle = 'GigaDB - Help';
 
                         <!-- FILE FORMATS DL -->
 
-                        <dl class="help-description-list">
+                        <dl class="inline-list help-description-list">
                             <div class="help-definition-container">
                                 <dt id="agp">AGP <span class="dt-sidenote">(.agp)</span></dt>
                                 <dd>
@@ -664,7 +664,7 @@ Bmb006173_1_IPR000909 GO:0007165 GO:0004629 GO:0007242&lt;</pre>
 
                     <section aria-labelledby="uploadStatusTitle" class="m-0">
                         <h2 class="page-subtitle" id="uploadStatusTitle">Upload status</h2>
-                        <dl class="help-description-list">
+                        <dl class="inline-list help-description-list">
                             <div class="help-definition-container">
                                 <dt>Publish</dt>
                                 <dd>this dataset is fully consented for immediate release upon <span class="text-italic">Giga</span>DB approval</dd>
@@ -685,7 +685,7 @@ Bmb006173_1_IPR000909 GO:0007165 GO:0004629 GO:0007242&lt;</pre>
                         <p>The DOI relationship vocabulary is taken from the <a href="http://schema.datacite.org/meta/kernel-2.2/doc/DataCite-MetadataKernel_v2.2.pdf" target="_blank" aria-label="DataCite Pdf file">DataCite</a> 'relationType' schema property (ID=12.2).</p>
                         <p>Definition: Description of the relationship of the resource being registered (A) and the related resource (B).</p>
 
-                        <dl class="help-description-list">
+                        <dl class="inline-list help-description-list">
                             <div class="help-definition-container">
                                 <dt>IsSupplementTo</dt>
                                 <dd>indicates that A is a supplement to B</dd>
@@ -728,7 +728,7 @@ Bmb006173_1_IPR000909 GO:0007165 GO:0004629 GO:0007242&lt;</pre>
 
                         <p>For attributes (sample, dataset or files) that have some or all values missing please use the following controlled value terms to describe the exact reason for the missing value.</p>
 
-                        <dl class="help-description-list">
+                        <dl class="inline-list help-description-list">
                             <div class="help-definition-container">
                                 <dt>not applicable</dt>
                                 <dd>information is inappropriate to report, often this attribute can be removed entirely.</dd>
@@ -777,7 +777,7 @@ Bmb006173_1_IPR000909 GO:0007165 GO:0004629 GO:0007242&lt;</pre>
                         <p>To search for datasets without the ID's, use the term <span>search?keyword=</span></p>
                         <p>To search by specific attributes use <span>search?&lt;attribute_name&gt;=</span></p>
                         <p>Available <strong>attribute_name</strong> to search include:</p>
-                        <dl class="help-description-list">
+                        <dl class="inline-list help-description-list">
                             <div class="help-definition-container">
                                 <dt><strong>taxno</strong></dt>
                                 <dd>Taxonomic ID (NCBI)</dd>

--- a/protected/views/site/supplementafileguide.php
+++ b/protected/views/site/supplementafileguide.php
@@ -3,11 +3,13 @@ $this->pageTitle = 'GigaDB - Supplemental File Guidelines'; ?>
 
 <div class="content mb-30">
   <div class="container">
-    <?php
-        $this->widget('TitleBreadcrumb', ['pageTitle' => 'GigaDB -
-    Supplemental File Guidelines', 'breadcrumbItems' => [['label' => 'Home',
-        'href'                                                            => '/'], ['isActive' => true, 'label' => 'Supplemental File
-    Guidelines', ]]]); ?>
+    <?php $this->widget('TitleBreadcrumb', [
+            'pageTitle' => 'GigaDB - Supplemental File Guidelines',
+            'breadcrumbItems' => [
+                ['label' => 'Home', 'href' => '/'],
+                ['isActive' => true, 'label' => 'Supplemental File Guidelines']
+            ]
+        ]); ?>
     <section>
       <?php
       $this->widget('GuideNavigation'); ?>

--- a/protected/views/site/supplementafileguide.php
+++ b/protected/views/site/supplementafileguide.php
@@ -1,0 +1,199 @@
+<?php
+$this->pageTitle = 'GigaDB - Supplemental File Guidelines'; ?>
+
+<div class="content mb-30">
+  <div class="container">
+    <?php
+        $this->widget('TitleBreadcrumb', ['pageTitle' => 'GigaDB -
+    Supplemental File Guidelines', 'breadcrumbItems' => [['label' => 'Home',
+        'href'                                                            => '/'], ['isActive' => true, 'label' => 'Supplemental File
+    Guidelines', ]]]); ?>
+    <section>
+      <?php
+      $this->widget('GuideNavigation'); ?>
+
+      <section>
+        <div class="tab-content">
+          <div class="tab-pane active">
+            <h2 class="page-subtitle h4">Supplemental File Guidelines</h2>
+
+            <div class="subsection">
+              <p>Below is a list of things commonly found in supplemental files and how we would recommend they be represented.</p>
+
+              <dl class="definition-list">
+                <dt>Raw data files</dt>
+                <dd>
+                  <p>
+                    These should be submitted to recognized community
+                    repositories if available, otherwise they should be
+                    submitted to GigaDB as part of the associated dataset.
+                  </p>
+                </dd>
+
+                <dt>Additional methods</dt>
+                <dd>
+                  <p>
+                    These should be translated into an online methods tool such
+                    as protocols.io and cited in the main manuscript.
+                  </p>
+                </dd>
+
+                <dt>Additional details of analysis</dt>
+                <dd>
+                  <p>
+                    These should be translated into an online methods tool such
+                    as protocols.io and cited in the main manuscript.
+                  </p>
+                </dd>
+
+                <dt>Scripts and/or bespoke analysis code</dt>
+                <dd>
+                  <p>
+                    If appropriate these could be uploaded to a code repository
+                    such as GitHub and cited in the manuscript, otherwise they
+                    should be submitted to GigaDB as part of the associated
+                    dataset.
+                  </p>
+                </dd>
+
+                <dt>Tables of analysis results</dt>
+                <dd>
+                  <p>
+                    These should be converted to a machine readable format and
+                    uploaded to GigaDB as part of the associated dataset.
+                  </p>
+                </dd>
+
+                <dt>Summary Tables of analysis results</dt>
+                <dd>
+                  <p>
+                    You should consider the utility of these carefully, if they
+                    are required as part of the narrative of your manuscript
+                    they should be included in the manuscript. We would not
+                    expect to see these as data files in GigaDB, since they can
+                    be re-created from the actual data files.
+                  </p>
+                </dd>
+
+                <dt>Lists of things</dt>
+                <dd>
+                  <p>
+                    You should consider the utility of these carefully, if they
+                    are required as part of the narrative of your manuscript
+                    they should be included in the manuscript. If they are large
+                    lists of results or input data/accessions they should be
+                    converted to a machine readable format and uploaded to
+                    GigaDB as part of the associated dataset.
+                  </p>
+                </dd>
+
+                <dt>Lists of PCR primers</dt>
+                <dd>
+                  <p>
+                    These should be included in the relevant experimental
+                    methods and submitted to online methods tool such as
+                    protocols.io and cited in the main manuscript.
+                  </p>
+                </dd>
+
+                <dt>Lists of BLAST hits</dt>
+                <dd>
+                  <p>
+                    The full results files should be uploaded to GigaDB as
+                    machine readable data files as part of the associated
+                    dataset. If a summary of results is required you should
+                    consider the utility of these carefully, if they are
+                    essential as part of the narrative of your manuscript they
+                    should be included in the manuscript, no summary file should
+                    be included in the associated dataset.
+                  </p>
+                </dd>
+
+                <dt>Diagrams of the experiment</dt>
+                <dd>
+                  <p>
+                    You should consider the utility of these carefully, if they
+                    are required as part of the narrative of your manuscript
+                    they should be included in the manuscript. We would not
+                    expect to see these as data files in GigaDB, since they are
+                    not data that can be reused in any way. If a workflow is
+                    required, it should be translated into a machine readable
+                    workflow (e.g. in Common Workflow Language, CWL) and
+                    uploaded to GigaDB as part of the associated dataset.
+                  </p>
+                </dd>
+
+                <dt>Images of gels</dt>
+                <dd>
+                  <p>
+                    The original images (un-manipulated and un-annotated) should
+                    be uploaded to GigaDB as part of the associated dataset. We
+                    would not normally expect to see "manuscript-ready" versions
+                    of a figure of the manipulated images in GigaDB, if you
+                    believe they are required as part of the narrative then they
+                    should be included in the main manuscript.
+                  </p>
+                </dd>
+
+                <dt>
+                  Images (e.g of subjects/samples, microscopy slides, etc.)
+                </dt>
+                <dd>
+                  <p>
+                    The original images (un-manipulated and un-annotated) should
+                    be uploaded to GigaDB as part of the associated dataset. We
+                    would not normally expect to see a "manuscript-ready"
+                    versions of a figure of the manipulated images in GigaDB,
+                    however we understand that there maybe some scenarios where
+                    the authors may wish to provide composite images such as
+                    multiple staining events overlaid, these should be included
+                    in GigaDB together with the original separate channel
+                    images.
+                  </p>
+                </dd>
+
+                <dt>Further discussion of results</dt>
+                <dd>
+                  <p>
+                    You should consider the utility of these carefully, if they
+                    are required as part of the narrative of your manuscript
+                    they should be included in the manuscript. We would not
+                    expect to see these as data files in GigaDB, since they are
+                    not "data" that can be reused in any way.
+                  </p>
+                </dd>
+
+                <dt>
+                  Visualizations of data<sup id="fn-ref-1"
+                    ><a href="#fn-1" aria-label="See footnote 1">1</a></sup
+                  >
+                </dt>
+                <dd>
+                  <p>
+                    You should consider the utility of these carefully, if they
+                    are required as part of the narrative of your manuscript
+                    they should be included in the manuscript. We would not
+                    expect to see these as data files in GigaDB, since they are
+                    not "data" that can be reused in any way. However, we would
+                    expect to see the data files that are being visualized
+                    (unless they are already hosted in external stable
+                    repositories such as INSDC).
+                  </p>
+                </dd>
+              </dl>
+
+              <p class="footnote" id="fn-1">
+                <sup>1</sup> Visualization of data includes (but is not limited
+                to) things like Gene orientation diagrams, Circos plots, graphs,
+                networks, heatmaps, geographical maps showing locations,
+                phylogenetic trees, HiC contact maps, Venn diagrams, alignment
+                maps, karyotype diagrams, etc...
+                <a href="#fn-ref-1" aria-label="Back to reference">↩︎</a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </section>
+  </div>
+</div>

--- a/tests/acceptance/StaticContentNavigation.feature
+++ b/tests/acceptance/StaticContentNavigation.feature
@@ -170,7 +170,7 @@ Feature: A user visit gigadb website
     When I press the button "About"
     Then I should see a link "Jobs" to "https://jobs.gigasciencejournal.com/"
 
-  @issue-2330
+  @ok @issue-2330
   Scenario: Link to Supplemental File Guidelines page is found in the guide page
     When I am on "/site/guide"
     Then I should see a link "Supplemental File Guidelines" to "/site/supplementalFileGuide"

--- a/tests/acceptance/StaticContentNavigation.feature
+++ b/tests/acceptance/StaticContentNavigation.feature
@@ -169,3 +169,8 @@ Feature: A user visit gigadb website
     When I am on "/dataset/100006"
     When I press the button "About"
     Then I should see a link "Jobs" to "https://jobs.gigasciencejournal.com/"
+
+  @issue-2330
+  Scenario: Link to Supplemental File Guidelines page is found in the guide page
+    When I am on "/site/guide"
+    Then I should see a link "Supplemental File Guidelines" to "/site/supplementalFileGuide"


### PR DESCRIPTION
# Pull request for issue: #2330

* Added new page http://gigadb.gigasciencejournal.com/site/supplementalFileGuide with the content provided in the issue
* This new page is linked to from the tabs list in the guides page

## How to test?

* navigate to http://gigadb.gigasciencejournal.com/site/guide
* verify new tab is present
![image](https://github.com/user-attachments/assets/769ec519-9e03-4c46-abcc-29ce84f1056e)
* verify new content is present
![image](https://github.com/user-attachments/assets/27292d39-30a9-41a4-8b25-18f8eb0b0e34)
* verify new page is reachable from either the tab "Supplemental File Guidelines" or from the in-page link, ie
![image](https://github.com/user-attachments/assets/02cbce55-bb7b-4f19-a402-e1a09842507d)
![image](https://github.com/user-attachments/assets/651d0729-56dc-42bf-953e-728ad13653a8)
* navigate to http://gigadb.gigasciencejournal.com/site/supplementalFileGuide
* active tab should match the current page
* the content should look like in the screenshot below
![image](https://github.com/user-attachments/assets/d2475d81-d670-43dc-a6b4-c5f4dc8865ff)
* the following test should pass:

```sh
docker-compose run --rm codecept run --no-redirect -g issue-2330 acceptance -vv
```

## How have functionalities been implemented?

* I choose to add a new page with the requested content rather than adding it to the existing guide page, it seemed like the best option to avoid making the guide page content very long-- it is already somewhat long
* the issue mentions the possibility of using a collapsible widget to avoid showing all content at once, I think a new page is a more straighforward option that avoids complicating the layout
* I have added the link to the new page as a new tab in the guide navigation, so the protected/components/GuideNavigation.php component is extended to include this new link
* some of the new content has been added to the protected/views/site/guide.php page, alternatively it could be added to the new page altogether, and leave the guide page untouched (just with the new tab present in the navigation)
* the new page makes use of a definition list (dl) to show the content. I was not satisfied by how the existing dl look like so I created a new style which I think is more readable and less crowded
* Minor refactor on existing dl styles, putting them behind a class name so they are not applied by default

## Any issues with implementation?

--

## Any changes to automated tests?

Added one acceptance test to expect the presence of a link to the new page

## Any changes to documentation?

--

## Any technical debt repayment?

--

## Any improvements to CI/CD pipeline?

--


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a "Supplemental File Guidelines" page with detailed recommendations for supplemental file submissions.
  * Added a navigation tab and accessible link to the new guidelines page from the guide section.
* **Improvements**
  * Updated guide content to clarify GigaScience’s approach to supplemental files.
  * Enhanced definition list styling for improved readability across help and FAQ pages.
* **Bug Fixes**
  * Minor typographic correction in the guide’s metadata table.
* **Tests**
  * Added acceptance test to verify navigation to the new guidelines page.
* **Documentation**
  * Updated changelog to document the new feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->