### PR TITLE
Simplify and compact curation log table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Feat #2331: Simplify and compact dataset curation log table
+
 ## v4.4.14 - 2025-06-24 - 4159a6086
 
 - Feat #1641: Check if the DOI has been minted when the upload status is set to 'Published'

--- a/less/modules/tables.less
+++ b/less/modules/tables.less
@@ -10,6 +10,10 @@ table.table td {
 table.table td {
   color: @color-darker-gray;
 }
+// use if table background color is not white
+table.table--black-text td {
+  color: @color-warm-black;
+}
 table.table a {
   text-decoration: none;
   color: @gigadb-green-on-lighter-gray;
@@ -282,5 +286,19 @@ table.dataset-view-table > tbody > tr {
     .summary {
       text-align: center;
     }
+  }
+}
+
+table.table-compact {
+  border-collapse: collapse;
+  > thead > tr > th,
+  > tbody > tr > td,
+  > tfoot > tr > td {
+    padding: 4px 6px;
+    line-height: 1.2;
+  }
+
+  > thead > tr > th {
+    font-weight: normal;
   }
 }

--- a/protected/js/bootstrap-tooltip-init.js
+++ b/protected/js/bootstrap-tooltip-init.js
@@ -1,3 +1,6 @@
 $(document).ready(function () {
-  $('[data-toggle="tooltip"]').tooltip();
+  $('[data-toggle="tooltip"]').tooltip({
+    html: true,
+    container: 'body'
+  });
 })

--- a/protected/models/CurationLog.php
+++ b/protected/models/CurationLog.php
@@ -194,4 +194,16 @@ class CurationLog extends CActiveRecord
             'criteria' => $criteria,
         ));
     }
+
+    public function getTooltip(): string
+    {
+        $fmt = Yii::app()->format;
+
+        $action        = CHtml::encode($this->action);
+        $createdBy     = CHtml::encode($this->created_by);
+        $modifiedBy    = CHtml::encode($this->last_modified_by ?? '-');
+        $modifiedDate  = CHtml::encode($this->last_modified_date ?? '-');
+
+        return "Created by: {$createdBy}<br/>Modified by: {$modifiedBy}<br/>Modified date: {$modifiedDate}";
+    }
 }

--- a/protected/models/CurationLog.php
+++ b/protected/models/CurationLog.php
@@ -197,9 +197,6 @@ class CurationLog extends CActiveRecord
 
     public function getTooltip(): string
     {
-        $fmt = Yii::app()->format;
-
-        $action        = CHtml::encode($this->action);
         $createdBy     = CHtml::encode($this->created_by);
         $modifiedBy    = CHtml::encode($this->last_modified_by ?? '-');
         $modifiedDate  = CHtml::encode($this->last_modified_date ?? '-');

--- a/protected/views/adminDataset/curationLog.php
+++ b/protected/views/adminDataset/curationLog.php
@@ -11,25 +11,38 @@ $this->widget(
     [
         'id'            => 'dataset-grid',
         'dataProvider'  => $model,
-        'itemsCssClass' => 'table table-bordered',
+        'itemsCssClass' => 'table table-bordered table-compact table--black-text',
+        'rowHtmlOptionsExpression' => "array('data-toggle'=>'tooltip', 'title'=>\$data->getTooltip())",
         'enableSorting'  => false,
         'columns'       => [
-            'creation_date',
-            'created_by',
-            'action',
+            [
+                'name' => 'creation_date',
+                'htmlOptions' => ['width' => '140'],
+            ],
             [
                     'name' => 'comments',
                     'type' =>  'text',
                     'value' => function($data) {
-                        if (preg_match('/^<\?xml/', $data->comments)) {
-                            return LogCurationFormatter::getDisplayXmlAttr($data->id, $data->comments);
+                        $commentOutput = $data->comments;
+
+                        if (preg_match('/^<\?xml/', $commentOutput)) {
+                            $commentOutput = LogCurationFormatter::getDisplayXmlAttr($data->id, $commentOutput);
                         }
 
-                        return $data->comments;
+                        $actionText = $data->action;
+                        $hasComment = strlen(trim(strip_tags($commentOutput))) > 0;
+
+                        if ($hasComment && $actionText) {
+                            return $actionText . ': ' . $commentOutput;
+                        }
+
+                        if (!$hasComment) {
+                            return $actionText;
+                        }
+
+                        return $commentOutput;
                     }
             ],
-            'last_modified_date',
-            'last_modified_by',
             [
                 'class'   => 'CButtonColumn',
                 'header' => "Actions",
@@ -72,6 +85,8 @@ $this->widget(
     ]
 );
 ?>
+<script>
+</script>
 <div id='modal' class='modal fade' role='dialog'>
     <div class='modal-dialog modal-lg'>
         <div class='modal-content'>

--- a/protected/views/adminDataset/curationLog.php
+++ b/protected/views/adminDataset/curationLog.php
@@ -85,8 +85,6 @@ $this->widget(
     ]
 );
 ?>
-<script>
-</script>
 <div id='modal' class='modal fade' role='dialog'>
     <div class='modal-dialog modal-lg'>
         <div class='modal-content'>

--- a/protected/views/adminDataset/curationLog.php
+++ b/protected/views/adminDataset/curationLog.php
@@ -29,7 +29,7 @@ $this->widget(
                             $commentOutput = LogCurationFormatter::getDisplayXmlAttr($data->id, $commentOutput);
                         }
 
-                        $actionText = $data->action;
+                        $actionText = $data->action ?? '';
                         $hasComment = strlen(trim(strip_tags($commentOutput))) > 0;
 
                         if ($hasComment && $actionText) {

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -451,4 +451,12 @@ class AcceptanceTester extends \Codeception\Actor
     {
         $this->dontSeeOptionIsSelected("#dataset-form select[id='$id']", $value);
     }
+
+    /**
+     * @Then I should see :text in the source
+     */
+    public function iShouldSeeInTheSource($text)
+    {
+        $this->seeInSource($text);
+    }
 }

--- a/tests/acceptance/AdminDatasetCurationLog.feature
+++ b/tests/acceptance/AdminDatasetCurationLog.feature
@@ -31,7 +31,7 @@ Feature: curation log entry under the dataset form
     And I should see "Failed to send DataCite XML"
     And I should see "<?xml"
 
-  @ok
+  @ok @issue-2331
   Scenario: Minting Doi and adding curation log entry with created_by filled in with by the connected user's name
     When I am on "/adminDataset/update/id/8"
     And I press the button "Mint DOI"
@@ -39,4 +39,4 @@ Feature: curation log entry under the dataset form
     And I should see "This DOI exists in DataCite already, so it has now been updated with the current values from GigaDB."
     Then I am on "/adminDataset/update/id/8"
     And I wait "3" seconds
-    And I should see "Joe Bloggs"
+    And I should see "Created by: Joe Bloggs" in the source


### PR DESCRIPTION
# Pull request for issue: #2331

Updated curator log table in dataset forms
![image](https://github.com/user-attachments/assets/17b5f771-d8b1-498c-bb3a-6cbed8d1df6b)
![image](https://github.com/user-attachments/assets/f47811c7-ba2c-4eca-a86b-b54a2db65b84)


* removed all columns except date / comments / actions
* 'action' prepended to 'comment' column
* hovering the log shows a tooltip with the content of the removed columns
* minimized spacing for compact layout, ignoring aesthetics
* slightly darken the text to enhance readability

## How to test?

* navigate to http://gigadb.gigasciencejournal.com/adminDataset/update/id/5
* click on 'mint doi'
* observe the newly generated curation logs at the bottom of the page
* create a new log
* visualize the new log in the form
* hover with the mouse over the logs to check that a tooltip with 'created by', 'modified by, 'modified date' are displayed
* `docker-compose run --rm codecept run --no-redirect -g issue-2331 acceptance -vv` should pass

## How have functionalities been implemented?

* see comments in PR diff

## Any issues with implementation?

--

## Any changes to automated tests?

Updated a breaking acceptance test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new table styling options for compact layout and improved text visibility on non-white backgrounds.
  * Tooltips now display detailed curation log information, including creator, last modifier, and modification date, with enhanced HTML formatting.

* **Enhancements**
  * Improved tooltip functionality to support HTML content and consistent placement.
  * Refined curation log display with clearer column formatting and more informative comments.
  * Updated acceptance tests to check for more precise UI text.

* **Tests**
  * Added a new test step for verifying specific text in the page source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->