### PR TITLE
Fix checkbox focus styling in login form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #2381: Fix checkbox focus styling in login form
+
 ## v4.4.14 - 2025-06-24 - 4159a6086
 
 - Feat #1641: Check if the DOI has been minted when the upload status is set to 'Published'

--- a/less/modules/forms.less
+++ b/less/modules/forms.less
@@ -241,9 +241,12 @@ input[type="checkbox"] {
   align-items: center;
   width: 100%;
   margin-bottom: 10px;
+  height: 36px;
   input[type="checkbox"].form-control {
     margin: 0 0 0 90px;
     padding-top: 0px;
+    width: auto;
+    height: auto;
   }
   label.control-label {
     margin-left: 25px;
@@ -258,6 +261,7 @@ input[type="checkbox"] {
     display: flex;
     align-items: center;
     gap: 20px;
+    height: auto;
     input[type="checkbox"].form-control {
       margin: 0;
       width: auto;


### PR DESCRIPTION
# Pull request for issue: #2381

Fix checkbox focus style

desktop
![image](https://github.com/user-attachments/assets/a190664c-2e00-469d-9baa-21cf033dd492)
mobile
![image](https://github.com/user-attachments/assets/cea0f589-ffa7-4590-b8d0-7cfbe14d87e2)


## How to test?

* make sure to rebuild styles after checking out to branch `docker-compose run --rm less`
* go to http://gigadb.gigasciencejournal.com/site/login
* use keyboard to focus on checkbox, focus state should look like in image
* change window size to mobile size, focus state and form should look fine

## How have functionalities been implemented?

Tweaked styles of checkbox focus state

## Any issues with implementation?

--

## Any changes to automated tests?

--
