### PR TITLE
Create a simplified dataset view

### DIFF
--- a/gigadb/app/services/URLsService.php
+++ b/gigadb/app/services/URLsService.php
@@ -101,6 +101,21 @@ final class URLsService extends Component
      */
     public static function editUrlQueryParams(array $addOrModifyParams = [], array $removeParams = []): string
     {
+        foreach ($addOrModifyParams as $key => $value) {
+            if (!is_string($key) || preg_match('/[^\w.-]/', $key)) {
+                throw new \InvalidArgumentException('Invalid character in parameter key. Only word characters, dots, and hyphens are allowed.');
+            }
+            if (!is_scalar($value) && !is_null($value)) {
+                throw new \InvalidArgumentException('Invalid value type. Only scalar values or null are allowed.');
+            }
+        }
+
+        foreach ($removeParams as $param) {
+            if (!is_string($param) || preg_match('/[^\w.-]/', $param)) {
+                throw new \InvalidArgumentException('Invalid character in parameter to remove. Only word characters, dots, and hyphens are allowed.');
+            }
+        }
+
         $uri   = Yii::app()->request->getRequestUri();
         $parts = parse_url($uri);
 

--- a/gigadb/app/services/URLsService.php
+++ b/gigadb/app/services/URLsService.php
@@ -90,4 +90,43 @@ final class URLsService extends Component
 
         return $badUrls;
     }
+
+   /**
+     * Manages query parameters for the current URL based on the current route and $_GET params.
+     * It allows for adding, modifying, and removing parameters in a single call.
+     *
+     * @param array $addOrModifyParams Associative array of parameters to add or overwrite (e.g., ['key' => 'value']).
+     * @param array $removeParams A simple array of parameter keys to remove from the URL (e.g., ['key1', 'key2']).
+     * @return string The newly generated URL.
+     */
+    public static function editUrlQueryParams(array $addOrModifyParams = [], array $removeParams = []): string
+    {
+        $uri   = Yii::app()->request->getRequestUri();
+        $parts = parse_url($uri);
+
+        $queryParams = [];
+        if (isset($parts['query']) && $parts['query'] !== '') {
+            parse_str($parts['query'], $queryParams);
+        }
+
+        foreach ($removeParams as $param) {
+            unset($queryParams[$param]);
+        }
+
+        foreach ($addOrModifyParams as $key => $value) {
+            $queryParams[$key] = $value;
+        }
+
+        $newQuery = http_build_query($queryParams);
+
+        $newUri = ($parts['path'] ?? '');
+        if ($newQuery !== '') {
+            $newUri .= '?' . $newQuery;
+        }
+        if (isset($parts['fragment'])) {
+            $newUri .= '#' . $parts['fragment'];
+        }
+
+        return $newUri;
+    }
 }

--- a/less/index.less
+++ b/less/index.less
@@ -75,3 +75,5 @@
 @import "modules/carousel-slider.less";
 @import "modules/news-section.less";
 @import "modules/dataset-feed-section.less";
+@import "layout/print.less";
+@import "pages/dataset-print.less";

--- a/less/layout/print.less
+++ b/less/layout/print.less
@@ -29,6 +29,11 @@ body.print {
   .badge {
     all: unset;
   }
+
+  // hide hypothes.is widget
+  hypothesis-sidebar {
+    display: none!important;
+  }
 }
 
 

--- a/less/layout/print.less
+++ b/less/layout/print.less
@@ -1,0 +1,31 @@
+// print styles not specific to a module or page
+body.print {
+  div {
+    display: block;
+  }
+  header, footer, nav, aside, video, iframe, .mobile-navigation, .skip-to-main-link {
+    display: none!important;
+  }
+
+  [role="dialog"], [role="tooltip"], [role="tablist"] {
+    display: none!important;
+  }
+  [role="tabpanel"] {
+    display: block!important;
+    &:before {
+      content: attr(id);
+    }
+  }
+
+  .left-border-title {
+    all: unset;
+  }
+
+  .left-border-title-lg {
+    all: unset;
+  }
+
+  .badge {
+    all: unset;
+  }
+}

--- a/less/layout/print.less
+++ b/less/layout/print.less
@@ -1,5 +1,9 @@
 // print styles not specific to a module or page
 body.print {
+  .print-hidden {
+    display: none!important;
+  }
+
   div {
     display: block;
   }
@@ -12,9 +16,6 @@ body.print {
   }
   [role="tabpanel"] {
     display: block!important;
-    &:before {
-      content: attr(id);
-    }
   }
 
   .left-border-title {
@@ -27,5 +28,12 @@ body.print {
 
   .badge {
     all: unset;
+  }
+}
+
+
+body:not(.print) {
+  .print-only {
+    display: none!important;
   }
 }

--- a/less/pages/dataset-print.less
+++ b/less/pages/dataset-print.less
@@ -21,7 +21,7 @@ body.print .dataset-view-container {
     text-decoration: underline;
   }
 
-  a[href]:after {
+  a[href]:not(.print__collapse-href):after {
     content: " (" attr(href) ")";
     font-size: 90%;
   }
@@ -194,7 +194,7 @@ body.print .dataset-view-container {
     }
   }
 
-  .table-footer {
+  .table-footer .pagination-wrapper {
     display: none;
   }
 }

--- a/less/pages/dataset-print.less
+++ b/less/pages/dataset-print.less
@@ -1,0 +1,171 @@
+body.print .dataset-view-container {
+  *,
+  *::before,
+  *::after {
+    background: transparent !important;
+    color: initial !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+    border-color: initial !important;
+    text-decoration: initial !important;
+  }
+
+  font-size: 12pt;
+  line-height: 1.4;
+
+  a,
+  a:visited {
+    text-decoration: underline;
+  }
+
+  a[href]:after {
+    content: " (" attr(href) ")";
+    font-size: 90%;
+  }
+
+  a[href^="#"]:after,
+  a[href^="javascript:"]:after {
+    content: "";
+  }
+
+  h1 { font-size: 24pt; }
+  h2 { font-size: 18pt; }
+  h3 { font-size: 14pt; }
+
+  .dataset-color-background-block {
+    padding: 0;
+  }
+  .result-sub-links {
+    text-wrap: wrap;
+  }
+  .media-body {
+    width: auto;
+  }
+
+  #dropdown-div {
+    float: none;
+    margin: 0;
+
+    .drop-citation-btn {
+      display: none !important;
+    }
+
+    .dropdown-box,
+    ul {
+      position: static;
+      border: none;
+      list-style: disc inside;
+      padding: 0;
+      margin: 0 0 0 20px;
+    }
+
+    li {
+      a,
+      a:hover {
+        background: none !important;
+        color: initial !important;
+        padding: 0;
+      }
+    }
+  }
+  .citation-popup:before {
+    content: attr(data-content)": ";
+  }
+  .dataset-des-images {
+    display: none!important;
+  }
+  .content-popup {
+    display: none!important;
+  }
+
+  .sort-message {
+    display: none!important;
+  }
+
+  #samples_table_settings, #files_table_settings {
+    display: none!important;
+  }
+
+  #\33 dmodels {
+    display: none!important;
+  }
+
+  #\33 dsketchfab {
+    display: none!important;
+  }
+
+  [role="tabpanel"]#protocolsio,
+  [role="tabpanel"]#jbrowse,
+  [role="tabpanel"]#codeocean {
+    display: none!important;
+  }
+
+  table.table {
+    border: none;
+    border-top: 3px double @color-true-black;
+    border-bottom: 3px double @color-true-black;
+    padding: 5px 0;
+    thead {
+      display: none;
+    }
+
+    tbody {
+      display: block;
+      border: none;
+
+      tr {
+        display: flex;
+        flex-direction: column;
+        flex-wrap: wrap;
+        border: none;
+        padding: 5px 0;
+        &:not(:last-child) {
+          border-bottom: 1px solid @color-true-black;
+        }
+
+        th,
+        td {
+          flex: 1 1 100%;
+          padding: 0;
+          border: none;
+        }
+
+        [class*="js-short-"] {
+          display: none;
+        }
+        [class*="js-long-"] {
+          display: block!important;
+        }
+        [class*="js-long-"] + button {
+          display: none;
+        }
+
+        .button-column {
+          display: none;
+        }
+
+        > *:first-child {
+          flex: 0 0 40%;
+          font-weight: bold;
+          text-align: left;
+        }
+
+        > *:not(:first-child) {
+          flex: 1 0 60%;
+          text-align: left;
+          word-break: break-word;
+        }
+
+        &::after {
+          content: "";
+          display: block;
+          width: 100%;
+        }
+      }
+    }
+  }
+}
+
+body.print .sibling-dataset-links {
+  display: none;
+}

--- a/less/pages/dataset-print.less
+++ b/less/pages/dataset-print.less
@@ -3,11 +3,10 @@ body.print .dataset-view-container {
   *::before,
   *::after {
     background: transparent !important;
-    color: initial !important;
+    color: @color-true-black !important;
     box-shadow: none !important;
     text-shadow: none !important;
     border-color: initial !important;
-    text-decoration: initial !important;
   }
 
   font-size: 12pt;
@@ -15,6 +14,10 @@ body.print .dataset-view-container {
 
   a,
   a:visited {
+    text-decoration: underline;
+  }
+
+  a:hover {
     text-decoration: underline;
   }
 
@@ -37,6 +40,9 @@ body.print .dataset-view-container {
   }
   .result-sub-links {
     text-wrap: wrap;
+  }
+  .media-left {
+    display: none;
   }
   .media-body {
     width: auto;
@@ -114,11 +120,11 @@ body.print .dataset-view-container {
       border: none;
 
       tr {
-        display: flex;
-        flex-direction: column;
-        flex-wrap: wrap;
         border: none;
         padding: 5px 0;
+        margin-bottom: 1em;
+        display: block;
+        border-bottom: 1px solid @color-light-gray;
         &:not(:last-child) {
           border-bottom: 1px solid @color-true-black;
         }
@@ -126,8 +132,16 @@ body.print .dataset-view-container {
         th,
         td {
           flex: 1 1 100%;
-          padding: 0;
           border: none;
+          display: block;
+          padding: 2px 0;
+
+          &::before {
+            content: attr(data-header) ": ";
+            font-weight: 700;
+            display: inline-block;
+            width: 200px;
+          }
         }
 
         [class*="js-short-"] {

--- a/less/pages/dataset-print.less
+++ b/less/pages/dataset-print.less
@@ -31,9 +31,17 @@ body.print .dataset-view-container {
     content: "";
   }
 
+  :is(h1, h2, h3, h4, h5, h6, p, .subsection) {
+    margin-bottom: 1em;
+  }
+
   h1 { font-size: 24pt; }
   h2 { font-size: 18pt; }
   h3 { font-size: 14pt; }
+
+  img {
+    display: none;
+  }
 
   .dataset-color-background-block {
     padding: 0;
@@ -46,6 +54,12 @@ body.print .dataset-view-container {
   }
   .media-body {
     width: auto;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    align-items: flex-start;
+    justify-content: flex-start;
+    gap: 0.5em;
   }
 
   #dropdown-div {
@@ -118,15 +132,15 @@ body.print .dataset-view-container {
     tbody {
       display: block;
       border: none;
+      margin-top: 1em;
 
       tr {
         border: none;
-        padding: 5px 0;
-        margin-bottom: 1em;
+        padding-bottom: 1em;
         display: block;
-        border-bottom: 1px solid @color-light-gray;
         &:not(:last-child) {
           border-bottom: 1px solid @color-true-black;
+          margin-bottom: 1em;
         }
 
         th,
@@ -138,9 +152,10 @@ body.print .dataset-view-container {
 
           &::before {
             content: attr(data-header) ": ";
-            font-weight: 700;
             display: inline-block;
-            width: 200px;
+            font-weight: 400;
+            width: 135px;
+            font-size: 10pt;
           }
         }
 
@@ -177,6 +192,10 @@ body.print .dataset-view-container {
         }
       }
     }
+  }
+
+  .table-footer {
+    display: none;
   }
 }
 

--- a/less/pages/dataset.less
+++ b/less/pages/dataset.less
@@ -1,167 +1,192 @@
 /* dataset */
-.dataset-view-container {
-  margin-top: 40px;
-}
-.dataset-media {
-  margin-bottom: 20px;
-}
-.media-left {
-  padding-right: 20px;
-}
-.media-object {
-  max-width: none;
-  width: 300px;
-  height: auto;
-}
-p.dataset-release-date-text {
-  margin-bottom: 10px;
-  padding-left: 13px;
-}
-.dataset-color-background-block {
-  padding: 5px 10px 30px 10px;
-}
-.dataset .subsection {
-  margin-bottom: 20px;
-}
-.dataset .background-btn {
-  height: 44px;
-}
-.doi-badge .badge:last-child {
-  font-size: 13px;
-  font-weight: normal;
-  color: @color-true-white;
-  background-color: @color-gigadb-green;
-  padding: 5px 10px;
-  border-radius: 0px 4px 4px 0px;
-  text-decoration: none;
-}
-.doi-badge .badge:first-child {
-  background-color: @color-darker-gray;
-  font-size: 13px;
-  font-weight: normal;
-  padding: 5px 10px;
-  border-radius: 4px 0px 0px 4px;
-}
-
-#dataset_slider {
-  h2 {
-    display: inline-block;
-    margin-right: 20px;
-  }
-  .carousel {
-    margin-bottom: 0;
-  }
-  .carousel-inner {
-    width: auto;
-  }
-  .data-block {
-    width: 172px;
-    float: left;
-    margin: 10px 0 10px 20px;
-    img {
-      width: auto;
-      margin: 0 auto 10px auto;
-      display: block;
-      max-width: 172px;
-      min-height: 172px;
-      height: 172;
+body:not(.print) {
+  .dataset-view-container {
+    margin-top: 40px;
+    position: relative;
+    .print-button-container {
+      position: absolute;
+      top: 0;
+      right: 0;
+    }
+    @media (max-width: @screen-md-max) {
+      .print-button-container {
+        position: relative;
+        display: flex;
+        justify-content: flex-end;
+      }
+    }
+    @media (max-width: @screen-xs-max) {
+      .print-button-container {
+        margin-right: 22px;
+      }
     }
   }
-  .carousel-control.right {
-    right: 0px;
-    top: -18px;
+  .dataset-media {
+    margin-bottom: 20px;
   }
-  .carousel-control.left {
-    right: 25px;
-    top: -18px;
-    left: auto;
+  @media (max-width: @screen-md-max) {
+    .dataset-media {
+      margin-top: 0;
+    }
   }
-  .carousel-control.right,
-  .carousel-control.left {
+  .media-left {
+    padding-right: 20px;
+  }
+  .media-object {
+    max-width: none;
+    width: 300px;
+    height: auto;
+  }
+  p.dataset-release-date-text {
+    margin-bottom: 10px;
+    padding-left: 13px;
+  }
+  .dataset-color-background-block {
+    padding: 5px 10px 30px 10px;
+  }
+  .dataset .subsection {
+    margin-bottom: 20px;
+  }
+  .dataset .background-btn {
+    height: 44px;
+  }
+  .doi-badge .badge:last-child {
+    font-size: 13px;
+    font-weight: normal;
+    color: @color-true-white;
+    background-color: @color-gigadb-green;
+    padding: 5px 10px;
+    border-radius: 0px 4px 4px 0px;
+    text-decoration: none;
+  }
+  .doi-badge .badge:first-child {
+    background-color: @color-darker-gray;
+    font-size: 13px;
+    font-weight: normal;
+    padding: 5px 10px;
+    border-radius: 4px 0px 0px 4px;
+  }
+
+  #dataset_slider {
+    h2 {
+      display: inline-block;
+      margin-right: 20px;
+    }
+    .carousel {
+      margin-bottom: 0;
+    }
+    .carousel-inner {
+      width: auto;
+    }
+    .data-block {
+      width: 172px;
+      float: left;
+      margin: 10px 0 10px 20px;
+      img {
+        width: auto;
+        margin: 0 auto 10px auto;
+        display: block;
+        max-width: 172px;
+        min-height: 172px;
+        height: 172;
+      }
+    }
+    .carousel-control.right {
+      right: 0px;
+      top: -18px;
+    }
+    .carousel-control.left {
+      right: 25px;
+      top: -18px;
+      left: auto;
+    }
+    .carousel-control.right,
+    .carousel-control.left {
+      font-size: 28px !important;
+      line-height: 18px;
+    }
+  }
+
+  #dataset_slider .carousel-control.left {
     font-size: 28px !important;
     line-height: 18px;
   }
-}
 
-#dataset_slider .carousel-control.left {
-  font-size: 28px !important;
-  line-height: 18px;
-}
+  .left-border-title-lg i {
+    font-size: 15px;
+  }
 
-.left-border-title-lg i {
-  font-size: 15px;
-}
+  #dataset-block-wrapper {
+    width: 100%;
+    margin: 0;
+  }
+  /* Provides horizontal scrolling in dataset table */
+  .dataset-datatables-wrapper {
+    overflow: auto;
+    width: 100%;
+    position: relative;
+  }
+  #badge-div {
+    margin-right: 10px;
+    float: left;
+  }
+  #dropdown-div {
+    margin: 0;
+    float: left;
+  }
+  .dropdown-box {
+    position: absolute;
+  }
+  .drop-citation-btn {
+    padding: 3px;
+    width: 110px;
+    color: @white-on-gigadb-green;
+    font-size: 13px;
+    font-weight: normal;
+    border: none;
+    cursor: pointer;
+    background-color: @color-gigadb-green;
+    border-radius: 4px 4px 4px 4px;
+    display: inline-block;
+    position: relative;
+    text-decoration: none;
+  }
+  #dropdown-div ul {
+    list-style: none;
+    position: relative;
+    float: none;
+    margin-top: 5px;
+    min-width: 100px;
+    border: 1px solid @color-gigadb-green;
+    border-radius: 4px 4px 4px 4px;
+    font-size: 13px;
+    cursor: pointer;
+  }
+  #dropdown-div li a:hover {
+    background-color: #f3faf6;
+  }
 
-#dataset-block-wrapper {
-  width: 100%;
-  margin: 0;
-}
-/* Provides horizontal scrolling in dataset table */
-.dataset-datatables-wrapper {
-  overflow: auto;
-  width: 100%;
-  position: relative;
-}
-#badge-div {
-  margin-right: 10px;
-  float: left;
-}
-#dropdown-div {
-  margin: 0;
-  float: left;
-}
-.dropdown-box {
-  position: absolute;
-}
-.drop-citation-btn {
-  padding: 3px;
-  width: 110px;
-  color: @white-on-gigadb-green;
-  font-size: 13px;
-  font-weight: normal;
-  border: none;
-  cursor: pointer;
-  background-color: @color-gigadb-green;
-  border-radius: 4px 4px 4px 4px;
-  display: inline-block;
-  position: relative;
-  text-decoration: none;
-}
-#dropdown-div ul {
-  list-style: none;
-  position: relative;
-  float: none;
-  margin-top: 5px;
-  min-width: 100px;
-  border: 1px solid @color-gigadb-green;
-  border-radius: 4px 4px 4px 4px;
-  font-size: 13px;
-  cursor: pointer;
-}
-#dropdown-div li a:hover {
-  background-color: #f3faf6;
-}
-
-.citation-list {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  color: @dark-gray-on-white;
-  line-height: 1.3;
-}
-
-@media (max-width: @screen-xs-max) {
-  .dataset-media {
+  .citation-list {
     display: flex;
     flex-direction: column;
-    align-items: center;
-    gap: 15px;
-    .dataset-media-left {
-      padding-right: 0;
-    }
-    .dataset-media-body {
-      width: initial;
-      display: block;
+    gap: 12px;
+    color: @dark-gray-on-white;
+    line-height: 1.3;
+  }
+
+  @media (max-width: @screen-xs-max) {
+    .dataset-media {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 15px;
+      .dataset-media-left {
+        padding-right: 0;
+      }
+      .dataset-media-body {
+        width: initial;
+        display: block;
+      }
     }
   }
 }

--- a/protected/components/DatasetPageAssembly.php
+++ b/protected/components/DatasetPageAssembly.php
@@ -321,6 +321,16 @@ class DatasetPageAssembly extends yii\base\Component
         }
 
         $pager = new FilesPagination();
+
+        // handle print view
+        $isPrint  = Yii::app()->request->getParam('print') === 'true';
+        $showFull = Yii::app()->request->getParam('full') === 'true';
+        if ($isPrint && !$showFull) {
+            $pageSize = 100;
+        } elseif ($isPrint && $showFull) {
+            $pageSize = 10_000; // assumes 10k is well beyond the number of files any dataset has
+        }
+
         $pager->setPageSize($pageSize);
         $this->_files = new FormattedDatasetFiles(
             $pager,
@@ -365,6 +375,16 @@ class DatasetPageAssembly extends yii\base\Component
         }
 
         $pager = new FilesPagination();
+
+        // handle print view
+        $isPrint  = Yii::app()->request->getParam('print') === 'true';
+        $showFull = Yii::app()->request->getParam('full') === 'true';
+        if ($isPrint && !$showFull) {
+            $pageSize = 100;
+        } elseif ($isPrint && $showFull) {
+            $pageSize = 10_000; // assumes 10k is well beyond the number of samples any dataset has
+        }
+
         $pager->setPageSize($pageSize);
         $this->_samples = new FormattedDatasetSamples(
             $pager,

--- a/protected/views/dataset/view.php
+++ b/protected/views/dataset/view.php
@@ -1,3 +1,7 @@
+<?php
+use GigaDB\services\URLsService;
+?>
+
 <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css" />
 
 <?php
@@ -6,6 +10,8 @@ $this->pageTitle = "GigaDB Dataset - DOI 10.5524/" . $model->identifier . " - " 
 
 $fileDataProvider = $files->getDataProvider();
 $sampleDataProvider = $samples->getDataProvider();
+$totalNbFiles = $fileDataProvider->getTotalItemCount();
+$totalNbSamples = $sampleDataProvider->getTotalItemCount();
 
 ?>
 
@@ -324,9 +330,35 @@ $sampleDataProvider = $samples->getDataProvider();
 
                 <div class="tab-content dataset-tab-content">
                 <?php
+                    $isPrint  = Yii::app()->request->getParam('print') === 'true';
+                    $showFull = Yii::app()->request->getParam('full') === 'true';
+
+                    if ($totalNbFiles > 100 || $totalNbSamples > 100) {
+                        if ($isPrint && !$showFull) {
+                            $showAllUrl = URLsService::editUrlQueryParams(['full' => 'true']);
+                            echo CHtml::tag(
+                                'p',
+                                ['class' => 'print-only'],
+                                CHtml::link(
+                                    'Show all ' . ($totalNbFiles + $totalNbSamples) . ' results',
+                                    $showAllUrl,
+                                    ['class' => 'print__collapse-href']
+                                ) .
+                                ' (they might take a while to load, depending on the number of results)'
+                            );
+                        } else {
+                            $showLessUrl = URLsService::editUrlQueryParams([], ['full']);
+                            echo CHtml::tag(
+                                'p',
+                                ['class' => 'print-only'],
+                                CHtml::link('Show less results', $showLessUrl, ['class' => 'print__collapse-href'])
+                            );
+                        }
+                    }
+                ?>
+                <?php
                     if ($sampleDataProvider->getTotalItemCount() > 0) {
                         $samplesPerPage = $sampleDataProvider->getItemCount();
-                        $totalNbSamples = $sampleDataProvider->getTotalItemCount();
 
                         if (count($model->samples) > 0) {
                     ?>
@@ -397,7 +429,6 @@ $sampleDataProvider = $samples->getDataProvider();
                     <?php
                     if ($fileDataProvider->getTotalItemCount() > 0) {
                         $filesPerPage = $fileDataProvider->getItemCount();
-                        $totalNbFiles = $fileDataProvider->getTotalItemCount();
 
                         if (count($model->samples) > 0) {
                     ?>

--- a/protected/views/dataset/view.php
+++ b/protected/views/dataset/view.php
@@ -21,6 +21,9 @@ $sampleDataProvider = $samples->getDataProvider();
 <div class="content">
     <div class="container dataset-view-container">
         <div class="subsection">
+            <div class="print-button-container">
+                <?php $this->renderPartial('application.views.shared._printToggle'); ?>
+            </div>
             <div class="media dataset-media">
                 <div class="media-left dataset-media-left">
                     <?php if ($model->image) {
@@ -329,7 +332,7 @@ $sampleDataProvider = $samples->getDataProvider();
                     ?>
                         <div role="tabpanel" class="tab-pane active" id="sample">
 
-                            <p class="pull-left">
+                            <p class="pull-left sort-message">
                               Click on a table column to sort the results.
                             </p>
                             <a id="samples_table_settings" class="btn btn-default pull-right" data-toggle="modal" data-target="#samples_settings" href="#"><span class="glyphicon glyphicon-adjust"></span>Table Settings</a>
@@ -401,7 +404,7 @@ $sampleDataProvider = $samples->getDataProvider();
                             <?php } else { ?>
                                 <div role="tabpanel" class="tab-pane active" id="files">
                                 <?php   } ?>
-                                <p class="pull-left">
+                                <p class="pull-left sort-message">
                                   Click on a table column to sort the results.
                                 </p>
                                 <a id="files_table_settings" class="btn btn-default pull-right" data-toggle="modal" data-target="#files_settings" href="#"><span class="glyphicon glyphicon-adjust"></span>Table Settings</a>
@@ -584,7 +587,7 @@ $sampleDataProvider = $samples->getDataProvider();
 
     <div class="clear"></div>
 
-    <div class="fixed-btn-container">
+    <div class="fixed-btn-container sibling-dataset-links">
         <a href="/dataset/<?php echo $previous_doi ?>" class="fixed-btn-left" title="Previous dataset" aria-label="Previous dataset"><span class="fa fa-angle-left"></span></a>
         <a href="/dataset/<?php echo $next_doi ?>" title="Next dataset" class="fixed-btn-right" aria-label="Next dataset"><span class="fa fa-angle-right"></span></a>
     </div>

--- a/protected/views/dataset/view.php
+++ b/protected/views/dataset/view.php
@@ -336,6 +336,7 @@ $sampleDataProvider = $samples->getDataProvider();
                               Click on a table column to sort the results.
                             </p>
                             <a id="samples_table_settings" class="btn btn-default pull-right" data-toggle="modal" data-target="#samples_settings" href="#"><span class="glyphicon glyphicon-adjust"></span>Table Settings</a>
+                            <div class="print-only">Samples</div>
                             <table id="samples_table" class="table table-striped table-bordered" style="width:100%">
                                 <thead>
                                     <tr>
@@ -352,12 +353,12 @@ $sampleDataProvider = $samples->getDataProvider();
 
                                     foreach ($sample_models as $sample) { ?>
                                         <tr>
-                                            <td><?= $sample['linkName'] ?></td>
-                                            <td><?= $sample['common_name'] ?></td>
-                                            <td><?= $sample['scientific_name'] ?></td>
-                                            <td><?= $sample['displayAttr'] ?></td>
-                                            <td><?= $sample['taxonomy_link'] ?></td>
-                                            <td><?= $sample['genbank_name'] ?></td>
+                                            <td data-header="Sample ID"><?= $sample['linkName'] ?></td>
+                                            <td data-header="Common Name"><?= $sample['common_name'] ?></td>
+                                            <td data-header="Scientific Name"><?= $sample['scientific_name'] ?></td>
+                                            <td data-header="Sample Attributes"><?= $sample['displayAttr'] ?></td>
+                                            <td data-header="Taxonomic ID"><?= $sample['taxonomy_link'] ?></td>
+                                            <td data-header="Genbank Name"><?= $sample['genbank_name'] ?></td>
                                         </tr>
                                     <?php } ?>
 
@@ -410,6 +411,7 @@ $sampleDataProvider = $samples->getDataProvider();
                                 <a id="files_table_settings" class="btn btn-default pull-right" data-toggle="modal" data-target="#files_settings" href="#"><span class="glyphicon glyphicon-adjust"></span>Table Settings</a>
                                 <br>
                                 <br>
+                                <div class="print-only">Files</div>
                                 <table id="files_table" class="table table-striped table-bordered dataset-files-table" style="width:100%">
                                     <thead>
                                         <tr>
@@ -429,20 +431,20 @@ $sampleDataProvider = $samples->getDataProvider();
                                         foreach ($file_models as $file) {
                                         ?>
                                             <tr>
-                                                <td class="text-break-word"><?= $file['nameHtml'] ?></td>
-                                                <td><?= $file['description'] ?></td>
-                                                <td><?php
+                                                <td class="text-break-word" data-header="File Name"><?= $file['nameHtml'] ?></td>
+                                                <td data-header="Description"><?= $file['description'] ?></td>
+                                                <td class="print-hidden"><?php
                                                     //TODO: huge performance issue with large numbers of fileDatasetKeywordsTest.php:49, manifesting when disabling cache
                                                     //                                        $file_samples = $files->formatDatasetFilesSamples(3, $file['id']) ;
                                                     //                                        echo $file_samples[0]['visible'];
                                                     //                                        echo $file_samples[0]['hidden'];
                                                     //                                        echo $file_samples[0]['more_link'];
                                                     ?></td>
-                                                <td><?= $file['type'] ?></td>
-                                                <td><?= $file['format'] ?></td>
-                                                <td><?= $file['sizeUnit'] ?></td>
-                                                <td><?= $file['date_stamp'] ?></td>
-                                                <td><?= $file['attrDesc'] ?></td>
+                                                <td data-header="Data Type"><?= $file['type'] ?></td>
+                                                <td data-header="File Format"><?= $file['format'] ?></td>
+                                                <td data-header="Size"><?= $file['sizeUnit'] ?></td>
+                                                <td data-header="Release Date"><?= $file['date_stamp'] ?></td>
+                                                <td data-header="File Attributes"><?= $file['attrDesc'] ?></td>
                                                 <td class="button-column">
                                                     <div class="icon-wrapper">
                                                         <a class="js-download-count fa fa-download fa-lg icon icon-download" href="<?= $file['location'] ?>" aria-label="Download <?= $file["name"] ?>"></a>
@@ -485,7 +487,7 @@ $sampleDataProvider = $samples->getDataProvider();
                             ?>
 
                                 <div role="tabpanel" class="tab-pane" id="funding">
-
+                                    <div class="print-only">Funding</div>
                                     <div class="dataset-datatables-wrapper">
                                         <table class="table table-bordered text-center">
                                             <thead>
@@ -500,10 +502,10 @@ $sampleDataProvider = $samples->getDataProvider();
 
                                                 <?php foreach ($funding as $funder) { ?>
                                                     <tr>
-                                                        <td><?= $funder['funder_name'] ?></td>
-                                                        <td><?= $funder['awardee'] ?></td>
-                                                        <td><?= $funder['grant_award'] ?></td>
-                                                        <td><?= $funder['comments'] ?></td>
+                                                        <td data-header="Funding body"><?= $funder['funder_name'] ?></td>
+                                                        <td data-header="Awardee"><?= $funder['awardee'] ?></td>
+                                                        <td data-header="Award ID"><?= $funder['grant_award'] ?></td>
+                                                        <td data-header="Comments"><?= $funder['comments'] ?></td>
                                                     </tr>
                                                 <?php } ?>
                                             </tbody>
@@ -556,7 +558,7 @@ $sampleDataProvider = $samples->getDataProvider();
                             ?>
 
                             <div role="tabpanel" class="tab-pane" id="history">
-
+                                <div class="print-only">History</div>
                                 <div class="dataset-datatables-wrapper">
                                     <table class="table table-bordered text-center">
                                         <thead>
@@ -568,8 +570,8 @@ $sampleDataProvider = $samples->getDataProvider();
                                         <tbody>
                                             <?php foreach ($mainSection->getHistory() as $log) { ?>
                                                 <tr>
-                                                    <td><?= date('F j, Y', strtotime($log['created_at'])) ?></td>
-                                                    <td><?= $log['message'] ?></td>
+                                                    <td data-header="Date"><?= date('F j, Y', strtotime($log['created_at'])) ?></td>
+                                                    <td data-header="Action"><?= $log['message'] ?></td>
                                                 </tr>
                                             <?php } ?>
                                         </tbody>

--- a/protected/views/layouts/main.php
+++ b/protected/views/layouts/main.php
@@ -38,7 +38,7 @@
   <?php $this->renderPartial('//shared/_matomo') ?>
 </head>
 
-<body>
+<body class="<?= isset($_GET['print']) && $_GET['print'] === 'true' ? 'print' : '' ?>">
   <?php
   $this->renderPartial('//shared/_header');
   ?>

--- a/protected/views/shared/_printToggle.php
+++ b/protected/views/shared/_printToggle.php
@@ -1,3 +1,23 @@
+<?php
+/**
+ * Partial: Print View Toggle
+ *
+ * Renders a button that lets the user switch between the regular “web” view
+ * and a printer-friendly version of the current page. The script embedded in
+ * this partial inspects the current URL for the query parameter
+ * `print=true`, toggles a `print` class on the <body> element, and updates the
+ * button’s label accordingly. Pressing the button flips the state, modifies
+ * the URL via `history.replaceState`, and reapplies the class without
+ * reloading the page.
+ *
+ * Usage (Yii 1.1):
+ *     <?php $this->renderPartial('shared/_printToggle'); ?>
+ *
+ * Requirements:
+ *   - jQuery 3 must be loaded before this partial executes.
+ *   - Pages should provide CSS rules that target `body.print`.
+ */
+?>
 <button class="btn btn-link print-view-link" aria-label="Switch to print view">
     <span class="label-text">Print view</span>
 </button>

--- a/protected/views/shared/_printToggle.php
+++ b/protected/views/shared/_printToggle.php
@@ -1,0 +1,29 @@
+<button class="btn btn-link print-view-link" aria-label="Switch to print view">
+    <span class="label-text">Print view</span>
+</button>
+<script>
+    $(document).ready(function () {
+        const url = new URL(window.location);
+        const $btn = $('.print-view-link');
+        const $label = $btn.find('.label-text');
+
+        const update = (toPrint) => {
+            $('body').toggleClass('print', toPrint);
+            $label.text(toPrint ? 'Web view' : 'Print view');
+        };
+
+        let isPrint = url.searchParams.get('print') === 'true';
+        update(isPrint);
+
+        $btn.on('click', () => {
+            isPrint = !isPrint;
+            if (isPrint) {
+                url.searchParams.set('print', 'true');
+            } else {
+                url.searchParams.delete('print');
+            }
+            history.replaceState(null, '', url);
+            update(isPrint);
+        });
+    });
+</script>

--- a/protected/views/shared/_printToggle.php
+++ b/protected/views/shared/_printToggle.php
@@ -17,18 +17,22 @@
  *   - Pages should provide CSS rules that target `body.print`.
  */
 ?>
-<button class="btn btn-link print-view-link" aria-label="Switch to print view">
-    <span class="label-text">Print view</span>
+<button class="btn btn-link js-print-view-link" aria-label="Switch to print view">
+    <span class="js-label-text">Print view</span>
+    <span class="sr-only js-sr-message" aria-live="polite"></span>
 </button>
 <script>
     $(document).ready(function () {
         const url = new URL(window.location);
-        const $btn = $('.print-view-link');
-        const $label = $btn.find('.label-text');
+        const $btn = $('.js-print-view-link');
+        const $label = $btn.find('.js-label-text');
+        const $srMessage = $btn.find('.js-sr-message');
 
         const update = (toPrint) => {
             $('body').toggleClass('print', toPrint);
-            $label.text(toPrint ? 'Web view' : 'Print view');
+            $label.text(`${toPrint ? 'web' : 'print'} view`);
+            $btn.attr('aria-label', `Switch to ${toPrint ? 'web' : 'print'} view`);
+            $srMessage.text(`Currently in ${toPrint ? 'print' : 'web'} view`);
         };
 
         let isPrint = url.searchParams.get('print') === 'true';

--- a/protected/views/shared/_printToggle.php
+++ b/protected/views/shared/_printToggle.php
@@ -14,7 +14,6 @@
  *     <?php $this->renderPartial('shared/_printToggle'); ?>
  *
  * Requirements:
- *   - jQuery 3 must be loaded before this partial executes.
  *   - Pages should provide CSS rules that target `body.print`.
  */
 ?>

--- a/protected/views/shared/_printToggle.php
+++ b/protected/views/shared/_printToggle.php
@@ -30,7 +30,7 @@
 
         const update = (toPrint) => {
             $('body').toggleClass('print', toPrint);
-            $label.text(`${toPrint ? 'web' : 'print'} view`);
+            $label.text(`${toPrint ? 'Web' : 'Print'} view`);
             $btn.attr('aria-label', `Switch to ${toPrint ? 'web' : 'print'} view`);
             $srMessage.text(`Currently in ${toPrint ? 'print' : 'web'} view`);
         };

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -451,4 +451,22 @@ class AcceptanceTester extends \Codeception\Actor
     {
         $this->dontSeeOptionIsSelected("#dataset-form select[id='$id']", $value);
     }
+
+    /**
+     * @Then I should see header and footer
+     */
+    public function iShouldSeeHeaderAndFooter()
+    {
+        $this->seeElement('header');
+        $this->seeElement('footer');
+    }
+
+    /**
+     * @Then I should not see header and footer
+     */
+    public function iShouldNotSeeHeaderAndFooter()
+    {
+        $this->dontSeeElement('header');
+        $this->dontSeeElement('footer');
+    }
 }

--- a/tests/acceptance/DatasetView.feature
+++ b/tests/acceptance/DatasetView.feature
@@ -275,7 +275,7 @@ Feature: a user visit the dataset page
     And I press the button "Print view"
     Then I should be on "/dataset/100006?print=true"
     And I should see "Web view"
-    And I should not see "Print view"
+    And I should see "Currently in print view"
     And I should not see header and footer
 
   @issue-152 @ok
@@ -283,7 +283,7 @@ Feature: a user visit the dataset page
     Given I have not signed in
     When I am on "/dataset/100006?print=true"
     Then I should see "Web view"
-    And I should not see "Print view"
+    And I should see "Currently in print view"
     And I should not see header and footer
 
   @issue-152 @ok
@@ -317,5 +317,5 @@ Feature: a user visit the dataset page
     And I press the button "Web view"
     Then I should be on "/dataset/100006"
     And I should see "Print view"
-    And I should not see "Web view"
+    And I should see "Currently in web view"
     And I should see header and footer

--- a/tests/acceptance/DatasetView.feature
+++ b/tests/acceptance/DatasetView.feature
@@ -267,3 +267,55 @@ Feature: a user visit the dataset page
     Given I have not signed in
     When I am on "/dataset/100142"
     Then I should see "Read the pre-print publication(s):"
+
+  @issue-152 @ok
+  Scenario: Show print view toggle button and switch to print view
+    Given I have not signed in
+    When I am on "/dataset/100006"
+    And I press the button "Print view"
+    Then I should be on "/dataset/100006?print=true"
+    And I should see "Web view"
+    And I should not see "Print view"
+    And I should not see header and footer
+
+  @issue-152 @ok
+  Scenario: Show print view without header or footer
+    Given I have not signed in
+    When I am on "/dataset/100006?print=true"
+    Then I should see "Web view"
+    And I should not see "Print view"
+    And I should not see header and footer
+
+  @issue-152 @ok
+  Scenario: Show full list of samples and files in print view
+    Given I have not signed in
+    When I am on "/dataset/100035?print=true"
+    And I follow "Show all 301 results"
+    And I wait "2" seconds
+    Then I should be on "/dataset/100035?print=true&full=true"
+    And I should see "Show less results"
+
+  @issue-152 @ok
+  Scenario: Hide full list of samples and files in print view
+    Given I have not signed in
+    When I am on "/dataset/100035?print=true&full=true"
+    And I follow "Show less results"
+    And I wait "2" seconds
+    Then I should be on "/dataset/100035?print=true"
+    And I should see "Show all 301 results"
+
+  @issue-152 @ok
+  Scenario: Show full list of samples and files from direct navigation
+    Given I have not signed in
+    When I am on "/dataset/100035?print=true&full=true"
+    Then I should see "Show less results"
+
+  @issue-152 @ok
+  Scenario: From print view return to web view
+    Given I have not signed in
+    When I am on "/dataset/100006?print=true"
+    And I press the button "Web view"
+    Then I should be on "/dataset/100006"
+    And I should see "Print view"
+    And I should not see "Web view"
+    And I should see header and footer


### PR DESCRIPTION
# Pull request for issue: #152

Next actionable: deploy this feature to a preview branch and share it with management for feedback on the appearance before reviewing and merging, as management might want to propose changes to the UI of the for print view, e.g. more compact content, more presence of gigadb brand,  etc

## Description

This pull request introduces a printer-friendly version of the dataset view page. The goal is to provide a clean, simplified layout optimized for printing by removing unnecessary UI elements like the header, footer, navigation, and other interactive components.

A "Print view" toggle button has been added to allow users to switch between the standard and print-optimized modes without a page reload. This improves usability and ensures the printed output is clean, readable, and focused on the essential dataset information.

the following screenshots summarize how this feature works from a user perspective

Normal view showing the location of the toggle view button:
<img width="1219" height="624" alt="Screenshot from 2025-07-18 10-56-24" src="https://github.com/user-attachments/assets/a3f6be2e-288c-4831-9a19-86bdfaa89f79" />

Print view, showing a `print=true` url query param and a simplified print ready view
<img width="1546" height="941" alt="Screenshot from 2025-07-18 10-57-55" src="https://github.com/user-attachments/assets/cf3acf6e-bf80-4b4d-ac53-421bb18b0760" />

Button (link) to toggle the full list of results. It is displayed on the condition: `$totalNbFiles > 100 || $totalNbSamples > 100`
<img width="1259" height="826" alt="Screenshot from 2025-07-18 11-04-11" src="https://github.com/user-attachments/assets/739a0f03-1666-4e6e-85fc-0298a4c0fc52" />

after the full list of results is on display. Controlled by URL query param `full=true`
<img width="978" height="523" alt="Screenshot from 2025-07-18 11-05-02" src="https://github.com/user-attachments/assets/a7525a0f-b3b6-46cb-ba46-6862583f9496" />



## Changes Made

### Backend
- **`URLsService.php`**: Added a `editUrlQueryParams()` method to dynamically manage URL query parameters, used for toggling the complete file/sample list in print view.
- **`DatasetPageAssembly.php`**: Updated to detect the print view via URL parameters and adjust pagination accordingly. It now displays up to 100 items by default in print view, with an option to show all results for larger datasets.
- **`dataset/view.php`**: Modified to include a print view toggle, add `data-header` attributes for improved table layouts in print, and conditionally render elements specific to the print view.
- **`layouts/main.php`**: Adjusted to add a `print` class to the `<body>` tag when the print view is active.

### Frontend
- **`_printToggle.php`**: Created a new shared partial that provides the "Print view" / "Web view" toggle button and the associated JavaScript to update the UI and URL.
- **`less/`**:
    - Added `layout/print.less` and `pages/dataset-print.less` to define the styles for the printer-friendly layout.
    - Updated `index.less` to import the new print styles.
    - Scoped existing styles in `pages/dataset.less` to `body:not(.print)` to prevent conflicts with the print view.

## How to Test

1. Navigate to any dataset page, e.g. http://gigadb.gigasciencejournal.com/dataset/100035
2. Click the "Print view" button located at the top right of the main content area.
3. **Verify**: The URL should update to include `?print=true`. The page layout should change to a simplified format, with the header, footer, and side navigation hidden.
4. **Verify**: The content, including metadata, files, and samples, should be restyled for clarity and readability.
5. Open the browser's print preview (Ctrl+P / Cmd+P).
6. **Verify**: The preview should display a clean, well-formatted document. The files and samples tables should be stacked vertically for better print output.
7. For datasets with more than 100 files or samples, confirm that a "Show all X results" link appears in print view. Clicking it should append `&full=true` to the URL and display all items.
8. Click the "Web view" button.
9. **Verify**: The page should revert to the standard interactive layout, and the `?print=true` parameter should be removed from the URL.
10. tests should pass: `docker-compose run --rm codecept run --no-redirect -g issue-152 acceptance -vv`

## Changes to tests

Numerous acceptance tests are added that fully cover this feature without being strict about the appearance and layout

`docker-compose run --rm codecept run --no-redirect -g issue-152 acceptance -vv`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a print-friendly view for dataset pages, accessible via a toggle button.
  * Users can switch between web and print views without reloading the page.
  * Print view simplifies layout, hides non-essential elements, and restructures tables for improved readability on paper.
  * Option to display all or limited results in print view for large datasets.

* **Style**
  * Introduced new stylesheets for print layouts and dataset print views.
  * Updated existing dataset page styles to support print and web view modes.

* **Bug Fixes**
  * Improved accessibility and clarity in tables by adding data-header attributes and print-specific labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->