### PR TITLE
Remove robots meta tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #2415: Remove redundant meta tag robots acceptance tests
 - Feat #2231: Add BlueSky social icon to header and footer
 - Fix: Add GIGADB_PORT to secrets example file
 - Feat #481: Add hyperlink to Gensc.org in FAQ page

--- a/tests/acceptance/DatasetMetadataLinkPreview.feature
+++ b/tests/acceptance/DatasetMetadataLinkPreview.feature
@@ -30,9 +30,3 @@ Feature: Add the metadata schema on dataset page to allow other web sites to mak
       | twitter:url | https://doi.org/10.5524/100006 |
       | twitter:image | https://assets.gigadb-cdn.net/live/images/datasets/images/data/cropped/100006_Pygoscelis_adeliae.jpg |
       | twitter:description | The Adelie penguin (Pygoscelis adeliae) is an iconic penguin of moderate stature and a tuxedo of black and white feathers.  The penguins are only found in the Antarctic region and surrounding islands.  Being very sensitive to climate change, and due to changes in their behavior based on minor shifts in climate, they are often used as a barometer of the Antarctic.With its status as one of the adorable and cuddly flightless birds of Antarctica, they serve as an example for conservation, and as a result they are now categorised at low risk for endangerment.  The sequence of the penguin can be of use in understanding the genetic underpinnings of its evolutionary traits and adaptation to its extreme environment; its unique system of feathers; its prowess as a diver; and its sensitivity to climate change.  We hope that this genome data will further our understanding of one of the most remarkable creatures to waddle the planet Earth. We sequenced the genome of an adult male from Inexpressible Island, Ross Sea, Antartica (provided by David Lambert) to a depth of approximately 60X with short reads from a series of libraries with various insert sizes (200bp- 20kb). The assembled scaffolds of high quality sequences total 1.23 Gb, with the contig and scaffold N50 values of 19 kb and 5 mb respectively. We identified 15,270 protein-coding genes with a mean length of  21.3 kb. |
-
-  @ok
-  Scenario: Search engines cannot index nor follow in non live environment
-    When I am on "/dataset/100016"
-    Then I should see "HTML" meta-tags
-      | robots | noindex, nofollow |


### PR DESCRIPTION
# Pull request for issue: #2415

This is a pull request for the following functionalities:

- Remove extra acceptance scenario to unblock v4.4.15 release 

## How to test?

Describe how the new functionalities can be tested by PR reviewers

### In dev
```
% cd gigadb-website
% ./up.sh
% ./test/acceptance_runner
```

### In CI/CD

1. Make sure you have followed `docs/SETUP_PROVISIONING.md` , `docs/SETUP_CI_CD_PIPELINE.md.
2. Push this PR to gitlab and trigger the pipeline, the acceptance test should passing.

## How have functionalities been implemented?

This scenario is failing in CI/CD:

```
  @ok
  Scenario: Search engines cannot index nor follow in non live environment
    When I am on "/dataset/100016"
    Then I should see "HTML" meta-tags
      | robots | noindex, nofollow |
```

After discussion, checking robots tag is better implemented in PR #2238 as a functional test, so this PR just simply remove that scenario


## Any issues with implementation?

None.

## Any changes to automated tests?

None.

## Any changes to documentation?

None.

## Any technical debt repayment?

None.

## Any improvements to CI/CD pipeline?

None.
