### PR TITLE
fix:2417: rewrite the image error message + set image tag length to 250 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix #2417: Set image tag length to 250 characters
+- Fix #2417: Rewrite the image error message
+
 ## v4.4.16 - 2025-08-15 - 6e04c0b9e -
 
 - Fix #2428: AdminUserController should target AdminUserController when validating or rejecting a claim

--- a/protected/models/Dataset.php
+++ b/protected/models/Dataset.php
@@ -768,8 +768,14 @@ class Dataset extends CActiveRecord
         }
 
         if ($this->image->id !== Image::GENERIC_IMAGE_ID && !$this->image->save()) {
-            Yii::app()->user->setFlash('updateError', 'Fail to update image!');
-            Yii::log(print_r($this->getErrors(), true), 'error');
+            $messages = [];
+            foreach ($this->image->getErrors() as $attr => $values) {
+                foreach ($values as $value) {
+                    $messages[] = $value;
+                }
+            }
+            Yii::app()->user->setFlash('updateError', implode('<br />', $messages));
+            Yii::log(implode('<br />', $messages), 'error');
 
             return false;
         }

--- a/protected/models/Image.php
+++ b/protected/models/Image.php
@@ -57,7 +57,7 @@ class Image extends CActiveRecord
         // will receive user inputs.
         return array(
             array('license, photographer, source', 'required'),
-            array('tag', 'length', 'max'=>120),
+            array('tag', 'length', 'max'=>250),
             array('url, source', 'length', 'max'=>256),
             array('photographer', 'length', 'max'=>128),
             // The following rule is used by search().

--- a/tests/unit/ImageTest.php
+++ b/tests/unit/ImageTest.php
@@ -19,6 +19,44 @@ class ImageTest extends \Codeception\Test\Unit
     {
     }
 
+    public function testTagValidationFails()
+    {
+        $image = new Image();
+        $image->license = 'required';
+        $image->photographer = 'required';
+        $image->source = 'required';
+        $image->tag = 'JqLwMsZbNxVcTaRfGhYpOjUkIeDqAzWsXcErTfVbNyUiOpLmKhJgFdSeDcRfTgHyJuKiLoPmNzQwErTyUiOpAsDfGhJkLzXcVbNmQwErTyUiOpLpKjHgFdSaZxCvBnMqWeRtYuIoPaSdFgHjKlZxCvBnMqWeRtYuIpOlKjHgFdSaZxCvBnMqWeRtYuIpOlKjHgFdSaZxCvBnMqWeRtYuIpOlKjHgFdSaZxCvBnMqWeRtYuIpOlKjHgFdSaZxCvBnMqWeRtYuIpOlKjHgFdSaZxCvBnMqWeRtYuIpOlKjHgFdSaZxCvBnMqWeRtYuIpOlKjHgFd';
+
+        $this->assertFalse($image->validate());
+
+        $messages = [];
+        foreach ($image->getErrors() as $attr => $values) {
+            foreach ($values as $value) {
+                $messages[] = $value;
+            }
+        }
+        $this->assertEquals('Tag is too long (maximum is 250 characters).', implode(',', $messages));
+    }
+
+    public function testTagValidationSucceed()
+    {
+        $image = new Image();
+        $image->license = 'required';
+        $image->photographer = 'required';
+        $image->source = 'required';
+        $image->tag = 'JqLwMsZbNxVcTaRfGhYpOjUkIeDq';
+
+        $this->assertTrue($image->validate());
+
+        $messages = [];
+        foreach ($image->getErrors() as $attr => $values) {
+            foreach ($values as $value) {
+                $messages[] = $value;
+            }
+        }
+        $this->assertNotEquals('Tag is too long (maximum is 250 characters).', implode(',', $messages));
+    }
+
     /**
      * Test writing image content to storage managed by Flysystem (happy path)
      * @return void


### PR DESCRIPTION
# Pull request for issue: #2417 

rewrite the image error message + set image tag length to 250 characters

## How to test?

Go to https://gigadb.org/adminDataset/update/id/{id}
enter your tag: the limit is set to 250 characters

## How have functionalities been implemented?

## Any issues with implementation?

## Any changes to automated tests?

unit tests added

## Any changes to documentation?

## Any technical debt repayment?

## Any improvements to CI/CD pipeline?
